### PR TITLE
レンダリングに関連する部分を切り離す

### DIFF
--- a/src/camera.ts
+++ b/src/camera.ts
@@ -1,7 +1,6 @@
 import p5 from "p5";
 import { renderIterationToPixel } from "./color";
 import {
-  shouldDrawCompletedArea,
   shouldDrawColorChanged,
   updateColor,
   getIterationTimes,
@@ -27,7 +26,7 @@ export const setupCamera = (p: p5, w: number, h: number) => {
 };
 
 export const nextBuffer = (p: p5): p5.Graphics => {
-  if (shouldDrawCompletedArea() || shouldDrawColorChanged()) {
+  if (shouldDrawColorChanged()) {
     updateColor();
 
     renderToMainBuffer(bufferRect);

--- a/src/camera.ts
+++ b/src/camera.ts
@@ -1,7 +1,7 @@
 import p5 from "p5";
 import { renderIterationToPixel } from "./color";
 import {
-  shouldDrawColorChanged,
+  colorChanged,
   updateColor,
   getIterationTimes,
   getPalette,
@@ -26,7 +26,7 @@ export const setupCamera = (p: p5, w: number, h: number) => {
 };
 
 export const nextBuffer = (p: p5): p5.Graphics => {
-  if (shouldDrawColorChanged()) {
+  if (colorChanged()) {
     updateColor();
 
     renderToMainBuffer(bufferRect);

--- a/src/camera.ts
+++ b/src/camera.ts
@@ -8,29 +8,33 @@ import {
   getPalette,
   getCurrentParams,
 } from "./mandelbrot";
+import { Rect } from "./rect";
 
 let mainBuffer: p5.Graphics;
 
 let width: number;
 let height: number;
 
+let bufferRect: Rect;
+
 export const setupCamera = (p: p5, w: number, h: number) => {
   mainBuffer = p.createGraphics(w, h);
   width = w;
   height = h;
+  bufferRect = { x: 0, y: 0, width: w, height: h };
 };
 
 export const nextBuffer = (p: p5): p5.Graphics => {
   if (shouldDrawCompletedArea() || shouldDrawColorChanged()) {
     updateColor();
 
-    renderToMainBuffer(p);
+    renderToMainBuffer(p, bufferRect);
   }
 
   return mainBuffer;
 };
 
-export const renderToMainBuffer = (p: p5) => {
+export const renderToMainBuffer = (p: p5, rect: Rect) => {
   const params = getCurrentParams();
 
   recolor(

--- a/src/camera.ts
+++ b/src/camera.ts
@@ -1,12 +1,6 @@
 import p5 from "p5";
 import { renderIterationToPixel } from "./color";
-import {
-  colorChanged,
-  updateColor,
-  getIterationTimes,
-  getPalette,
-  getCurrentParams,
-} from "./mandelbrot";
+import { getIterationTimes, getCurrentParams } from "./mandelbrot";
 import { Rect } from "./rect";
 
 let mainBuffer: p5.Graphics;
@@ -15,6 +9,31 @@ let width: number;
 let height: number;
 
 let bufferRect: Rect;
+let lastColorIdx = 0;
+let currentColorIdx = 0;
+let colorsArray: Uint8ClampedArray[];
+
+const colorChanged = () => {
+  return lastColorIdx !== currentColorIdx;
+};
+
+const updateColor = () => {
+  lastColorIdx = currentColorIdx;
+};
+
+export const setColorsArray = (colors: Uint8ClampedArray[]) => {
+  colorsArray = colors;
+};
+
+export const setColorIndex = (index: number) => {
+  if (colorsArray[index]) {
+    currentColorIdx = index;
+  } else {
+    currentColorIdx = 0;
+  }
+};
+
+export const getPalette = () => colorsArray[currentColorIdx];
 
 export const getCanvasWidth = () => width;
 

--- a/src/camera.ts
+++ b/src/camera.ts
@@ -1,5 +1,5 @@
 import p5 from "p5";
-import { recolor } from "./color";
+import { renderIterationToPixel } from "./color";
 import {
   shouldDrawCompletedArea,
   shouldDrawColorChanged,
@@ -17,6 +17,8 @@ let height: number;
 
 let bufferRect: Rect;
 
+export const getCanvasWidth = () => width;
+
 export const setupCamera = (p: p5, w: number, h: number) => {
   mainBuffer = p.createGraphics(w, h);
   width = w;
@@ -28,18 +30,17 @@ export const nextBuffer = (p: p5): p5.Graphics => {
   if (shouldDrawCompletedArea() || shouldDrawColorChanged()) {
     updateColor();
 
-    renderToMainBuffer(p, bufferRect);
+    renderToMainBuffer(bufferRect);
   }
 
   return mainBuffer;
 };
 
-export const renderToMainBuffer = (p: p5, rect: Rect) => {
+export const renderToMainBuffer = (rect: Rect) => {
   const params = getCurrentParams();
 
-  recolor(
-    width,
-    height,
+  renderIterationToPixel(
+    rect,
     mainBuffer,
     params.N,
     getIterationTimes(),

--- a/src/camera.ts
+++ b/src/camera.ts
@@ -1,0 +1,44 @@
+import p5 from "p5";
+import { recolor } from "./color";
+import {
+  shouldDrawCompletedArea,
+  shouldDrawColorChanged,
+  updateColor,
+  getIterationTimes,
+  getPalette,
+  getCurrentParams,
+} from "./mandelbrot";
+
+let mainBuffer: p5.Graphics;
+
+let width: number;
+let height: number;
+
+export const setupCamera = (p: p5, w: number, h: number) => {
+  mainBuffer = p.createGraphics(w, h);
+  width = w;
+  height = h;
+};
+
+export const nextBuffer = (p: p5): p5.Graphics => {
+  if (shouldDrawCompletedArea() || shouldDrawColorChanged()) {
+    updateColor();
+
+    renderToMainBuffer(p);
+  }
+
+  return mainBuffer;
+};
+
+export const renderToMainBuffer = (p: p5) => {
+  const params = getCurrentParams();
+
+  recolor(
+    width,
+    height,
+    mainBuffer,
+    params.N,
+    getIterationTimes(),
+    getPalette()
+  );
+};

--- a/src/color.ts
+++ b/src/color.ts
@@ -1,4 +1,6 @@
 import p5 from "p5";
+import { Rect } from "./rect";
+import { getCanvasWidth } from "./camera";
 
 type ColorMapper = {
   size: number;
@@ -74,7 +76,7 @@ export const buildColors = (p: p5) => {
 export const fillColor = (
   x: number,
   y: number,
-  width: number,
+  canvasWidth: number,
   pixels: Uint8ClampedArray,
   palette: Uint8ClampedArray,
   iteration: number,
@@ -84,7 +86,7 @@ export const fillColor = (
   for (let i = 0; i < density; i++) {
     for (let j = 0; j < density; j++) {
       const pixelIndex =
-        4 * ((y * density + j) * width * density + (x * density + i));
+        4 * ((y * density + j) * canvasWidth * density + (x * density + i));
 
       if (iteration !== maxIteration) {
         const paletteIdx = (iteration % (palette.length / 4)) * 4;
@@ -105,20 +107,20 @@ export const fillColor = (
 const calcLogicalIndex = (x: number, y: number, width: number): number =>
   x + y * width;
 
-export const recolor = (
-  width: number,
-  height: number,
+export const renderIterationToPixel = (
+  rect: Rect,
   buffer: p5.Graphics,
   maxIteration: number,
   iterationsResult: Uint32Array,
   palette: Uint8ClampedArray
 ) => {
-  buffer.background(0);
+  const width = getCanvasWidth();
+
   buffer.loadPixels();
   const density = buffer.pixelDensity();
 
-  for (let y = 0; y < height; y++) {
-    for (let x = 0; x < width; x++) {
+  for (let y = rect.y; y < rect.y + rect.height; y++) {
+    for (let x = rect.x; x < rect.x + rect.width; x++) {
       const logicalIndex = calcLogicalIndex(x, y, width);
       const n = iterationsResult[logicalIndex];
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,18 +14,21 @@ import {
   importParamsFromClipboard,
   resetIterationCount,
   resetRadius,
-  setColorIndex,
-  setColorsArray,
   setCurrentParams,
   setDeepIterationCount,
   setOffsetParams,
   paramsChanged,
-  colorChanged,
   zoom,
   startCalculation,
   initializeIterationBuffer,
 } from "./mandelbrot";
-import { nextBuffer, renderToMainBuffer, setupCamera } from "./camera";
+import {
+  nextBuffer,
+  renderToMainBuffer,
+  setColorIndex,
+  setColorsArray,
+  setupCamera,
+} from "./camera";
 import { Rect } from "./rect";
 
 resetWorkers();

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,6 +27,7 @@ import {
   initializeIterationBuffer,
 } from "./mandelbrot";
 import { nextBuffer, renderToMainBuffer, setupCamera } from "./camera";
+import { Rect } from "./rect";
 
 resetWorkers();
 
@@ -168,8 +169,8 @@ const sketch = (p: p5) => {
     )
       return;
 
-    startCalculation(() => {
-      renderToMainBuffer(p);
+    startCalculation((updatedRect: Rect) => {
+      renderToMainBuffer(p, updatedRect);
     });
   };
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -170,7 +170,7 @@ const sketch = (p: p5) => {
       return;
 
     startCalculation((updatedRect: Rect) => {
-      renderToMainBuffer(p, updatedRect);
+      renderToMainBuffer(updatedRect);
     });
   };
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -164,11 +164,11 @@ const sketch = (p: p5) => {
     p.image(result, 0, 0);
     drawInfo(p);
 
-    if (!paramsChanged()) return;
-
-    startCalculation((updatedRect: Rect) => {
-      renderToMainBuffer(updatedRect);
-    });
+    if (paramsChanged()) {
+      startCalculation((updatedRect: Rect) => {
+        renderToMainBuffer(updatedRect);
+      });
+    }
   };
 };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,7 +21,6 @@ import {
   setOffsetParams,
   shouldDrawWithoutRecolor,
   shouldDrawColorChanged,
-  shouldDrawCompletedArea,
   zoom,
   startCalculation,
   initializeIterationBuffer,
@@ -162,12 +161,7 @@ const sketch = (p: p5) => {
     p.image(result, 0, 0);
     drawInfo(p);
 
-    if (
-      shouldDrawCompletedArea() ||
-      shouldDrawColorChanged() ||
-      shouldDrawWithoutRecolor()
-    )
-      return;
+    if (shouldDrawColorChanged() || shouldDrawWithoutRecolor()) return;
 
     startCalculation((updatedRect: Rect) => {
       renderToMainBuffer(updatedRect);

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,8 +19,8 @@ import {
   setCurrentParams,
   setDeepIterationCount,
   setOffsetParams,
-  shouldDrawWithoutRecolor,
-  shouldDrawColorChanged,
+  paramsChanged,
+  colorChanged,
   zoom,
   startCalculation,
   initializeIterationBuffer,
@@ -161,7 +161,7 @@ const sketch = (p: p5) => {
     p.image(result, 0, 0);
     drawInfo(p);
 
-    if (shouldDrawColorChanged() || shouldDrawWithoutRecolor()) return;
+    if (!paramsChanged()) return;
 
     startCalculation((updatedRect: Rect) => {
       renderToMainBuffer(updatedRect);

--- a/src/main.ts
+++ b/src/main.ts
@@ -78,13 +78,13 @@ const isInside = (p: p5) =>
   0 <= p.mouseX && p.mouseX <= p.width && 0 <= p.mouseY && p.mouseY <= p.height;
 
 const sketch = (p: p5) => {
-  let buffer: p5.Graphics;
+  let mainBuffer: p5.Graphics;
 
   p.setup = () => {
     const { width, height } = getCanvasSize();
 
     p.createCanvas(width, height);
-    buffer = p.createGraphics(width, height);
+    mainBuffer = p.createGraphics(width, height);
 
     p.noStroke();
     p.colorMode(p.HSB, 360, 100, 100, 100);
@@ -168,20 +168,20 @@ const sketch = (p: p5) => {
       recolor(
         p.width,
         p.height,
-        buffer,
+        mainBuffer,
         params.N,
         getIterationTimes(),
         getPalette()
       );
 
       p.background(0);
-      p.image(buffer, 0, 0);
+      p.image(mainBuffer, 0, 0);
       drawInfo(p);
 
       return;
     } else if (shouldDrawWithoutRecolor()) {
       p.background(0);
-      p.image(buffer, 0, 0);
+      p.image(mainBuffer, 0, 0);
       drawInfo(p);
 
       return;
@@ -191,7 +191,7 @@ const sketch = (p: p5) => {
       recolor(
         p.width,
         p.height,
-        buffer,
+        mainBuffer,
         params.N,
         getIterationTimes(),
         getPalette()

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -25,9 +25,9 @@ let lastCalc: MandelbrotParams = {
   r: new BigNumber(0),
   N: 0,
   R: 0,
+  mode: "normal",
 };
 
-let needsReCalculation = false;
 let running = false;
 
 let iterationTimeBuffer: Uint32Array;
@@ -51,6 +51,7 @@ let currentParams: MandelbrotParams = {
   r: new BigNumber("0.00000363797880709171295166015625"),
   N: DEFAULT_N,
   R: 2,
+  mode: "normal",
 };
 
 let offsetParams: OffsetParams = {
@@ -119,9 +120,9 @@ export const setDeepIterationCount = () =>
 export const resetRadius = () => setCurrentParams({ r: new BigNumber("2.0") });
 
 export const changeMode = () => {
-  toggleWorkerType();
+  const mode = toggleWorkerType();
+  setCurrentParams({ mode });
   setOffsetParams({ x: 0, y: 0 });
-  needsReCalculation = true;
 };
 
 export const exportParamsToClipboard = () => {
@@ -179,16 +180,12 @@ export const zoom = (times: number) => {
   setOffsetParams({ x: 0, y: 0 });
 };
 
-export const shouldDrawColorChanged = () => {
-  return (
-    !needsReCalculation &&
-    isSameParams(lastCalc, currentParams) &&
-    lastColorIdx !== currentColorIdx
-  );
+export const colorChanged = () => {
+  return lastColorIdx !== currentColorIdx;
 };
 
-export const shouldDrawWithoutRecolor = () => {
-  return !needsReCalculation && isSameParams(lastCalc, currentParams);
+export const paramsChanged = () => {
+  return !isSameParams(lastCalc, currentParams);
 };
 
 export const updateColor = () => {
@@ -204,7 +201,6 @@ export const startCalculation = (
     terminateWorkers();
   }
 
-  needsReCalculation = false;
   running = true;
   completed = 0;
   progresses.fill(0);
@@ -325,7 +321,12 @@ export const startCalculation = (
 };
 
 const isSameParams = (a: MandelbrotParams, b: MandelbrotParams) =>
-  a.x === b.x && a.y === b.y && a.r === b.r && a.N === b.N && a.R === b.R;
+  a.x === b.x &&
+  a.y === b.y &&
+  a.r === b.r &&
+  a.N === b.N &&
+  a.R === b.R &&
+  a.mode === b.mode;
 
 const getOffsetRects = (): Rect[] => {
   const offsetX = offsetParams.x;

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -207,7 +207,9 @@ export const updateColor = () => {
   lastColorIdx = currentColorIdx;
 };
 
-export const startCalculation = (onComplete: () => void) => {
+export const startCalculation = (
+  bufferChanged: (updatedRect: Rect) => void
+) => {
   updateCurrentParams();
 
   if (running) {
@@ -285,9 +287,9 @@ export const startCalculation = (onComplete: () => void) => {
         progresses[idx] = 1.0;
         completed++;
 
-        if (isCompleted(completed)) {
-          onComplete();
+        bufferChanged(rect);
 
+        if (isCompleted(completed)) {
           running = false;
           const after = performance.now();
           lastTime = (after - before).toFixed();

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -33,10 +33,6 @@ let running = false;
 let iterationTimeBuffer: Uint32Array;
 let iterationTimeBufferTemp: Uint32Array;
 
-let lastColorIdx = 0;
-let currentColorIdx = 0;
-let colorsArray: Uint8ClampedArray[];
-
 let completed = 0;
 let lastTime = "0";
 
@@ -157,20 +153,6 @@ export const initializeIterationBuffer = () => {
   iterationTimeBufferTemp = new Uint32Array(height * width);
 };
 
-export const setColorsArray = (colors: Uint8ClampedArray[]) => {
-  colorsArray = colors;
-};
-
-export const setColorIndex = (index: number) => {
-  if (colorsArray[index]) {
-    currentColorIdx = index;
-  } else {
-    currentColorIdx = 0;
-  }
-};
-
-export const getPalette = () => colorsArray[currentColorIdx];
-
 export const zoom = (times: number) => {
   if (1 < times && currentParams.r.times(times).gte(5)) {
     return;
@@ -180,16 +162,8 @@ export const zoom = (times: number) => {
   setOffsetParams({ x: 0, y: 0 });
 };
 
-export const colorChanged = () => {
-  return lastColorIdx !== currentColorIdx;
-};
-
 export const paramsChanged = () => {
   return !isSameParams(lastCalc, currentParams);
-};
-
-export const updateColor = () => {
-  lastColorIdx = currentColorIdx;
 };
 
 export const startCalculation = (
@@ -315,7 +289,6 @@ export const startCalculation = (
       endY,
       startX,
       endX,
-      palette: getPalette(),
     });
   });
 };

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -150,7 +150,7 @@ export const importParamsFromClipboard = () => {
     });
 };
 
-export const initializeBuffer = () => {
+export const initializeIterationBuffer = () => {
   const { width, height } = getCanvasSize();
 
   iterationTimeBuffer = new Uint32Array(height * width);

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -38,7 +38,6 @@ let currentColorIdx = 0;
 let colorsArray: Uint8ClampedArray[];
 
 let completed = 0;
-let lastCompleted = 0;
 let lastTime = "0";
 
 let width = DEFAULT_WIDTH;
@@ -180,17 +179,6 @@ export const zoom = (times: number) => {
   setOffsetParams({ x: 0, y: 0 });
 };
 
-export const shouldDrawCompletedArea = () => {
-  const hasNewCompletedArea = lastCompleted !== completed;
-
-  return (
-    running &&
-    hasNewCompletedArea &&
-    !needsReCalculation &&
-    isSameParams(lastCalc, currentParams)
-  );
-};
-
 export const shouldDrawColorChanged = () => {
   return (
     !needsReCalculation &&
@@ -219,7 +207,6 @@ export const startCalculation = (
   needsReCalculation = false;
   running = true;
   completed = 0;
-  lastCompleted = -1;
   progresses.fill(0);
 
   const before = performance.now();

--- a/src/rect.ts
+++ b/src/rect.ts
@@ -1,3 +1,6 @@
+/**
+ * pixel単位の矩形
+ */
 export interface Rect {
   x: number;
   y: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,7 @@ export interface MandelbrotParams {
   r: BigNumber;
   N: number;
   R: number;
+  mode: MandelbrotWorkerType;
 }
 
 export interface WorkerParams {

--- a/src/workers.ts
+++ b/src/workers.ts
@@ -18,9 +18,10 @@ export const workerPaths: Record<MandelbrotWorkerType, new () => Worker> = {
 
 export const currentWorkerType = (): MandelbrotWorkerType => _currentWorkerType;
 
-export const toggleWorkerType = (): void => {
+export const toggleWorkerType = (): MandelbrotWorkerType => {
   _currentWorkerType = _currentWorkerType === "normal" ? "doublejs" : "normal";
   resetWorkers();
+  return _currentWorkerType;
 };
 
 export const getWorkerCount = (): number => _workerCount;


### PR DESCRIPTION
- 計算したiteration数を元にレンダリングするのはcameraに任せる
- mainやmandelbrotからレンダリング関係の処理を引き剥がす
- 描画のタイミングがばらけていたので計算が済んだところから適宜描画していくようにした
   - よくわからんフラグが消えた