### PR TITLE
Modalを開いているときはcanvasを操作できないようにした

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -31,7 +31,7 @@ import { Rect } from "./rect";
 import React from "react";
 import ReactDOMClient from "react-dom/client";
 import { AppRoot } from "./view/app-root";
-import { createStore, updateStore } from "./store/store";
+import { createStore, getStore, updateStore } from "./store/store";
 import { getIterationTimeAt } from "./aggregator";
 import { MantineProvider } from "@mantine/core";
 import BigNumber from "bignumber.js";
@@ -49,6 +49,7 @@ createStore({
   iteration: 0,
   mode: "normal",
   poi: [],
+  modalOpened: false,
 });
 
 // localStorageから復帰
@@ -106,6 +107,7 @@ const sketch = (p: p5) => {
 
   p.mouseClicked = () => {
     if (!isInside(p)) return;
+    if (getStore("modalOpened")) return;
 
     const { mouseX, mouseY } = calcVars(p.mouseX, p.mouseY, p.width, p.height);
 
@@ -118,6 +120,7 @@ const sketch = (p: p5) => {
 
   p.mouseWheel = (event: WheelEvent) => {
     if (!isInside(p)) return;
+    if (getStore("modalOpened")) return;
 
     // canvas内ではスクロールしないようにする
     event.preventDefault();
@@ -138,6 +141,8 @@ const sketch = (p: p5) => {
   };
 
   p.keyPressed = (event: KeyboardEvent | undefined) => {
+    if (getStore("modalOpened")) return;
+
     if (event) {
       let diff = 100;
       const params = getCurrentParams();

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -12,7 +12,7 @@ export const createStore = <T>(value: T): Store<T> => {
   return store;
 };
 
-const getStore = (key: string) => store[key];
+export const getStore = (key: string) => store[key];
 
 export const updateStore = (key: string, value: any) => {
   if (store[key] === value) return;

--- a/src/view/header/index.tsx
+++ b/src/view/header/index.tsx
@@ -1,10 +1,10 @@
 import { ActionIcon, Flex, Grid, Modal } from "@mantine/core";
-import { useDisclosure } from "@mantine/hooks";
 import { IconHelp } from "@tabler/icons-react";
+import { useModalState } from "../modal/use-modal-state";
 import { Instructions } from "./instructions";
 
 export const Header = () => {
-  const [opened, { open, close }] = useDisclosure(false);
+  const [opened, { open, close }] = useModalState();
 
   return (
     <>

--- a/src/view/modal/use-modal-state.tsx
+++ b/src/view/modal/use-modal-state.tsx
@@ -1,0 +1,15 @@
+import { useDisclosure } from "@mantine/hooks";
+import { updateStore } from "../../store/store";
+
+export const useModalState = (): ReturnType<typeof useDisclosure> => {
+  const [opened, callbacks] = useDisclosure(false, {
+    onOpen: () => {
+      updateStore("modalOpened", true);
+    },
+    onClose: () => {
+      updateStore("modalOpened", false);
+    },
+  });
+
+  return [opened, callbacks];
+};

--- a/src/view/right-sidebar/parameters.tsx
+++ b/src/view/right-sidebar/parameters.tsx
@@ -1,11 +1,8 @@
-import { Container, Group, Modal, Text, TextInput } from "@mantine/core";
-import { useStoreValue } from "../../store/store";
+import { Container, Group, Text } from "@mantine/core";
 import { GLITCHED_POINT_ITERATION } from "../../mandelbrot";
-import { useModalState } from "../modal/use-modal-state";
+import { useStoreValue } from "../../store/store";
 
 export const Parameters = () => {
-  const [opened, { open, close }] = useModalState();
-
   const centerX = useStoreValue("centerX");
   const centerY = useStoreValue("centerY");
   const mouseX = useStoreValue("mouseX");
@@ -23,9 +20,6 @@ export const Parameters = () => {
   // TODO: たぶんrの値見て表示の精度を決めるべき
   return (
     <>
-      <Modal opened={opened} onClose={close} centered withCloseButton={false}>
-        <TextInput data-autofocus label="Input new r value" />
-      </Modal>
       <Container w="100%">
         <Group position="apart">
           <Text>CenterX</Text>
@@ -45,7 +39,7 @@ export const Parameters = () => {
         </Group>
         <Group position="apart">
           <Text>r</Text>
-          <Text onClick={open}>{r.toPrecision(10)}</Text>
+          <Text>{r.toPrecision(10)}</Text>
         </Group>
         <Group position="apart">
           <Text>MAX Iteration</Text>

--- a/src/view/right-sidebar/parameters.tsx
+++ b/src/view/right-sidebar/parameters.tsx
@@ -1,4 +1,4 @@
-import { Container, Group, Table, Text } from "@mantine/core";
+import { Container, Group, Text } from "@mantine/core";
 import { useStoreValue } from "../../store/store";
 import { GLITCHED_POINT_ITERATION } from "../../mandelbrot";
 

--- a/src/view/right-sidebar/parameters.tsx
+++ b/src/view/right-sidebar/parameters.tsx
@@ -1,8 +1,11 @@
-import { Container, Group, Text } from "@mantine/core";
+import { Container, Group, Modal, Text, TextInput } from "@mantine/core";
 import { useStoreValue } from "../../store/store";
 import { GLITCHED_POINT_ITERATION } from "../../mandelbrot";
+import { useModalState } from "../modal/use-modal-state";
 
 export const Parameters = () => {
+  const [opened, { open, close }] = useModalState();
+
   const centerX = useStoreValue("centerX");
   const centerY = useStoreValue("centerY");
   const mouseX = useStoreValue("mouseX");
@@ -19,39 +22,44 @@ export const Parameters = () => {
 
   // TODO: たぶんrの値見て表示の精度を決めるべき
   return (
-    <Container w="100%">
-      <Group position="apart">
-        <Text>CenterX</Text>
-        <Text>{centerX.toPrecision(20)}</Text>
-      </Group>
-      <Group position="apart">
-        <Text>CenterY</Text>
-        <Text>{centerY.toPrecision(20)}</Text>
-      </Group>
-      <Group position="apart">
-        <Text>MouseX</Text>
-        <Text>{mouseX.minus(centerX).toPrecision(10)}</Text>
-      </Group>
-      <Group position="apart">
-        <Text>MouseY</Text>
-        <Text>{centerY.minus(mouseY).toPrecision(10)}</Text>
-      </Group>
-      <Group position="apart">
-        <Text>r</Text>
-        <Text>{r.toPrecision(10)}</Text>
-      </Group>
-      <Group position="apart">
-        <Text>MAX Iteration</Text>
-        <Text>{N}</Text>
-      </Group>
-      <Group position="apart">
-        <Text>Iteration at cursor</Text>
-        <Text>{iterationString}</Text>
-      </Group>
-      <Group position="apart">
-        <Text>Mode</Text>
-        <Text>{mode}</Text>
-      </Group>
-    </Container>
+    <>
+      <Modal opened={opened} onClose={close} centered withCloseButton={false}>
+        <TextInput data-autofocus label="Input new r value" />
+      </Modal>
+      <Container w="100%">
+        <Group position="apart">
+          <Text>CenterX</Text>
+          <Text>{centerX.toPrecision(20)}</Text>
+        </Group>
+        <Group position="apart">
+          <Text>CenterY</Text>
+          <Text>{centerY.toPrecision(20)}</Text>
+        </Group>
+        <Group position="apart">
+          <Text>MouseX</Text>
+          <Text>{mouseX.minus(centerX).toPrecision(10)}</Text>
+        </Group>
+        <Group position="apart">
+          <Text>MouseY</Text>
+          <Text>{centerY.minus(mouseY).toPrecision(10)}</Text>
+        </Group>
+        <Group position="apart">
+          <Text>r</Text>
+          <Text onClick={open}>{r.toPrecision(10)}</Text>
+        </Group>
+        <Group position="apart">
+          <Text>MAX Iteration</Text>
+          <Text>{N}</Text>
+        </Group>
+        <Group position="apart">
+          <Text>Iteration at cursor</Text>
+          <Text>{iterationString}</Text>
+        </Group>
+        <Group position="apart">
+          <Text>Mode</Text>
+          <Text>{mode}</Text>
+        </Group>
+      </Container>
+    </>
   );
 };


### PR DESCRIPTION
## やったこと
- `modalOpened` をstoreに追加し、その値を見てcanvasの操作を止めるようにした

## やらなかったこと
- rやNをモーダルで直接入力できるようにしようとしたが、意外と面倒でテンション上がらなかったのでやめた
- モーダル開いていないときも入力を全部 `event.preventDefault()` で奪っておりあまりよくない