### PR TITLE
ドラッグで中心点を変えられるように変更

### DIFF
--- a/src/camera.ts
+++ b/src/camera.ts
@@ -62,7 +62,7 @@ export const nextResultBuffer = (p: p5): p5.Graphics => {
   return resultBuffer;
 };
 
-export const clearResultBuffer = (p: p5) => {
+export const clearResultBuffer = () => {
   // @ts-ignore
   resultBuffer.clear();
 };
@@ -93,4 +93,5 @@ export const renderToResultBuffer = (rect: Rect) => {
 
 export const mergeToMainBuffer = () => {
   mainBuffer.image(resultBuffer, 0, 0);
+  clearResultBuffer();
 };

--- a/src/camera.ts
+++ b/src/camera.ts
@@ -6,6 +6,7 @@ import { renderIterationsToPixel } from "./rendering";
 import { Palette } from "./color";
 
 let mainBuffer: p5.Graphics;
+let resultBuffer: p5.Graphics;
 
 let width: number;
 let height: number;
@@ -41,6 +42,7 @@ export const getCanvasWidth = () => width;
 
 export const setupCamera = (p: p5, w: number, h: number) => {
   mainBuffer = p.createGraphics(w, h);
+  resultBuffer = p.createGraphics(w, h);
   width = w;
   height = h;
   bufferRect = { x: 0, y: 0, width: w, height: h };
@@ -56,6 +58,15 @@ export const nextBuffer = (p: p5): p5.Graphics => {
   return mainBuffer;
 };
 
+export const nextResultBuffer = (p: p5): p5.Graphics => {
+  return resultBuffer;
+};
+
+export const clearResultBuffer = (p: p5) => {
+  // @ts-ignore
+  resultBuffer.clear();
+};
+
 export const renderToMainBuffer = (rect: Rect) => {
   const params = getCurrentParams();
 
@@ -66,4 +77,20 @@ export const renderToMainBuffer = (rect: Rect) => {
     getIterationCache(),
     getPalette()
   );
+};
+
+export const renderToResultBuffer = (rect: Rect) => {
+  const params = getCurrentParams();
+
+  renderIterationsToPixel(
+    rect,
+    resultBuffer,
+    params.N,
+    getIterationCache(),
+    getPalette()
+  );
+};
+
+export const mergeToMainBuffer = () => {
+  mainBuffer.image(resultBuffer, 0, 0);
 };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -128,6 +128,8 @@ const sketch = (p: p5) => {
 
     p.noStroke();
     p.colorMode(p.HSB, 360, 100, 100, 100);
+
+    p.cursor(p.CROSS);
   };
 
   p.mousePressed = () => {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -169,7 +169,7 @@ const sketch = (p: p5) => {
     if (mouseClickStartedInside) {
       changeCursor(p, "grabbing");
       mouseDragged = true;
-      clearResultBuffer(p);
+      clearResultBuffer();
     }
   };
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -44,6 +44,7 @@ import { AppRoot } from "./view/app-root";
 import { currentWorkerType, resetWorkers, setWorkerCount } from "./workers";
 import { chromaJsPalettes } from "./color/color-chromajs";
 import { p5jsPalettes } from "./color/color-p5js";
+import { drawCrossHair } from "./rendering";
 
 resetWorkers();
 
@@ -151,7 +152,6 @@ const sketch = (p: p5) => {
     p.createCanvas(width, height);
     setupCamera(p, width, height);
 
-    p.noStroke();
     p.colorMode(p.HSB, 360, 100, 100, 100);
 
     p.cursor(p.CROSS);
@@ -307,6 +307,7 @@ const sketch = (p: p5) => {
     if (mouseDragged) {
       const { pixelDiffX, pixelDiffY } = getDraggingPixelDiff(p);
       p.image(mainBuffer, pixelDiffX, pixelDiffY);
+      drawCrossHair(p);
     } else if (mouseDraggedComplete) {
       const { mouseX, mouseY } = mouseReleasedOn;
       p.image(mainBuffer, mouseX, mouseY);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -256,7 +256,9 @@ const sketch = (p: p5) => {
       if (event.key === "o") exportParamsToClipboard();
       if (event.key === "i") importParamsFromClipboard();
       if (event.key === "ArrowDown") zoom(rate);
+      if (event.key === "s") zoom(rate);
       if (event.key === "ArrowUp") zoom(1.0 / rate);
+      if (event.key === "w") zoom(1.0 / rate);
       if (event.key === "ArrowRight") setCurrentParams({ N: params.N + diff });
       if (event.key === "ArrowLeft") setCurrentParams({ N: params.N - diff });
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -186,10 +186,10 @@ const sketch = (p: p5) => {
 
         const rate = getStore("zoomRate");
         // shiftキーを押しながらクリックすると縮小
-        if (!ev.shiftKey) {
-          zoom(1.0 / rate);
-        } else {
+        if (ev.shiftKey) {
           zoom(rate);
+        } else {
+          zoom(1.0 / rate);
         }
       }
     }
@@ -227,6 +227,7 @@ const sketch = (p: p5) => {
     if (event) {
       let diff = 100;
       const params = getCurrentParams();
+      const rate = getStore("zoomRate");
 
       if (event.shiftKey) {
         const N = params.N;
@@ -254,8 +255,8 @@ const sketch = (p: p5) => {
       if (event.key === "m") cycleMode();
       if (event.key === "o") exportParamsToClipboard();
       if (event.key === "i") importParamsFromClipboard();
-      if (event.key === "ArrowDown") zoom(2);
-      if (event.key === "ArrowUp") zoom(0.5);
+      if (event.key === "ArrowDown") zoom(rate);
+      if (event.key === "ArrowUp") zoom(1.0 / rate);
       if (event.key === "ArrowRight") setCurrentParams({ N: params.N + diff });
       if (event.key === "ArrowLeft") setCurrentParams({ N: params.N - diff });
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -209,6 +209,7 @@ const sketch = (p: p5) => {
 
     changeCursor(p, p.CROSS);
     mouseClickStartedInside = false;
+    mouseDragged = false;
   };
 
   p.mouseWheel = (event: WheelEvent) => {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -125,6 +125,15 @@ const changeCursor = (p: p5, cursor: string) => {
   }
 };
 
+const getDraggingPixelDiff = (p: p5) => {
+  const { mouseX: clickedMouseX, mouseY: clickedMouseY } = mouseClickedOn;
+
+  const pixelDiffX = -Math.floor(p.mouseX - clickedMouseX);
+  const pixelDiffY = -Math.floor(p.mouseY - clickedMouseY);
+
+  return { pixelDiffX, pixelDiffY };
+};
+
 const sketch = (p: p5) => {
   let mouseClickStartedInside = false;
 
@@ -169,14 +178,11 @@ const sketch = (p: p5) => {
 
       if (mouseDragged) {
         // ドラッグ終了時
-        const { mouseX: clickedMouseX, mouseY: clickedMouseY } = mouseClickedOn;
+        const { pixelDiffX, pixelDiffY } = getDraggingPixelDiff(p);
+        setOffsetParams({ x: pixelDiffX, y: pixelDiffY });
+
         const centerX = p.width / 2;
         const centerY = p.height / 2;
-
-        const pixelDiffX = -Math.floor(p.mouseX - clickedMouseX);
-        const pixelDiffY = -Math.floor(p.mouseY - clickedMouseY);
-
-        setOffsetParams({ x: pixelDiffX, y: pixelDiffY });
 
         const { mouseX, mouseY } = calcVars(
           centerX + pixelDiffX,
@@ -283,6 +289,15 @@ const sketch = (p: p5) => {
   p.draw = () => {
     const result = nextBuffer(p);
     p.background(0);
+
+    if (mouseDragged) {
+      const { pixelDiffX, pixelDiffY } = getDraggingPixelDiff(p);
+      p.image(result, -pixelDiffX, -pixelDiffY);
+      drawInfo(p);
+
+      return;
+    }
+
     p.image(result, 0, 0);
     drawInfo(p);
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -113,6 +113,7 @@ const drawInfo = (p: p5) => {
 
 let currentCursor: "cross" | "grab" = "cross";
 let mouseDragged = false;
+let mouseClickedOn = { mouseX: 0, mouseY: 0 };
 
 const isInside = (p: p5) =>
   0 <= p.mouseX && p.mouseX <= p.width && 0 <= p.mouseY && p.mouseY <= p.height;
@@ -145,6 +146,7 @@ const sketch = (p: p5) => {
   p.mousePressed = () => {
     if (isInside(p)) mouseClickStartedInside = true;
     mouseDragged = false;
+    mouseClickedOn = { mouseX: p.mouseX, mouseY: p.mouseY };
   };
 
   p.mouseDragged = () => {
@@ -165,23 +167,34 @@ const sketch = (p: p5) => {
       if (!isInside(p)) return;
       if (getStore("canvasLocked")) return;
 
-      const { mouseX, mouseY } = calcVars(
-        p.mouseX,
-        p.mouseY,
-        p.width,
-        p.height
-      );
-
       if (mouseDragged) {
         // ドラッグ終了時
-        // FIXME: 移動時の処理をそのまま残しているだけなので適切に直して
-        const pixelDiffX = Math.floor(p.mouseX - p.width / 2);
-        const pixelDiffY = Math.floor(p.mouseY - p.height / 2);
+        const { mouseX: clickedMouseX, mouseY: clickedMouseY } = mouseClickedOn;
+        const centerX = p.width / 2;
+        const centerY = p.height / 2;
+
+        const pixelDiffX = -Math.floor(p.mouseX - clickedMouseX);
+        const pixelDiffY = -Math.floor(p.mouseY - clickedMouseY);
 
         setOffsetParams({ x: pixelDiffX, y: pixelDiffY });
+
+        const { mouseX, mouseY } = calcVars(
+          centerX + pixelDiffX,
+          centerY + pixelDiffY,
+          p.width,
+          p.height
+        );
+
         setCurrentParams({ x: mouseX, y: mouseY });
       } else {
         // クリック時
+        const { mouseX, mouseY } = calcVars(
+          p.mouseX,
+          p.mouseY,
+          p.width,
+          p.height
+        );
+
         setCurrentParams({ x: mouseX, y: mouseY });
 
         const rate = getStore("zoomRate");

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -107,11 +107,16 @@ export const updateCurrentParams = () => {
 };
 
 export const setCurrentParams = (params: Partial<MandelbrotParams>) => {
-  const needModeChange = currentParams.mode !== params.mode;
+  const needModeChange =
+    params.mode != null && currentParams.mode !== params.mode;
+  const needResetOffset = params.r != null && !currentParams.r.eq(params.r);
 
   currentParams = { ...currentParams, ...params };
   if (needModeChange) {
     setWorkerType(currentParams.mode);
+    setOffsetParams({ x: 0, y: 0 });
+  }
+  if (needResetOffset) {
     setOffsetParams({ x: 0, y: 0 });
   }
 };

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -220,6 +220,8 @@ export const startCalculation = async (
     // 新しく計算しない部分を先に描画しておく
     onBufferChanged(iterationBufferTransferedRect, false);
 
+    // TODO: perturbation時はreference pointsの値を取っておけば移動がかなり高速化できる気がする
+
     calculationRects = divideRect(getOffsetRects(), getWorkerCount(), minSide);
   } else {
     // 移動していない場合は再利用するCacheがないので消す

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -171,7 +171,7 @@ export const paramsChanged = () => {
 };
 
 export const startCalculation = async (
-  onBufferChanged: (updatedRect: Rect) => void
+  onBufferChanged: (updatedRect: Rect, isCompleted: boolean) => void
 ) => {
   updateCurrentParams();
 
@@ -213,7 +213,7 @@ export const startCalculation = async (
     translateRectInIterationCache(offsetX, offsetY);
 
     // 新しく計算しない部分を先に描画しておく
-    onBufferChanged(iterationBufferTransferedRect);
+    onBufferChanged(iterationBufferTransferedRect, false);
 
     calculationRects = divideRect(getOffsetRects(), getWorkerCount(), minSide);
   } else {
@@ -265,10 +265,12 @@ export const startCalculation = async (
         progresses[idx] = 1.0;
         completed++;
 
-        // TODO: たぶん適度にdebounceしたほうがいい
-        onBufferChanged(rect);
+        const comp = isCompleted(completed);
 
-        if (isCompleted(completed)) {
+        // TODO: たぶん適度にdebounceしたほうがいい
+        onBufferChanged(rect, comp);
+
+        if (comp) {
           running = false;
           const after = performance.now();
           lastTime = (after - before).toFixed();

--- a/src/rendering.ts
+++ b/src/rendering.ts
@@ -86,3 +86,20 @@ export const renderIterationsToPixel = (
 
   graphics.updatePixels();
 };
+
+export const drawCrossHair = (p: p5) => {
+  const length = 10;
+
+  const centerX = Math.floor(p.width / 2);
+  const centerY = Math.floor(p.height / 2);
+
+  // FIXME: たぶんカラーパレットを見て目立つ色を選ぶべき
+
+  p.stroke(p.color(0, 0, 100));
+  p.line(centerX - length, centerY, centerX + length, centerY);
+  p.line(centerX, centerY - length, centerX, centerY + length);
+
+  p.stroke(p.color(0, 0, 0));
+  p.line(centerX - length / 2, centerY, centerX + length / 2, centerY);
+  p.line(centerX, centerY - length / 2, centerX, centerY + length / 2);
+};

--- a/src/view/header/instructions.tsx
+++ b/src/view/header/instructions.tsx
@@ -14,6 +14,9 @@ export const Instructions = () => {
         <Text>Change center & Zoom</Text>
 
         <Text>Click</Text>
+        <Text>Zoom clicked point</Text>
+
+        <Text>Drag</Text>
         <Text>Change center</Text>
       </SimpleGrid>
 


### PR DESCRIPTION
## 変更したこと
- ドラッグで中心位置を変えられるようにした
   - 構造に中心を合わせやすいようにドラッグ中はクロスヘアを表示
- これに伴いクリックで指定地点を拡大、ドラッグで位置移動に変えた
- 移動時に差分だけ計算する機能が動いてなかったのを修正

## 気付いたこと
- perturbation時はreference pointを保存しておけば同じ拡大率での移動めっちゃ早くなりそう
   - TODO: reference pointからどのくらい離れたら爆発するのか検知する方法

![image](https://github.com/k-chop/p5mandelbrot/assets/241973/463eb6d1-5f91-4e8b-896b-a975f62f6c59)