### PR TITLE
低解像度から徐々に描画できるようにした (perturbationのみ)

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -159,6 +159,8 @@ const sketch = (p: p5) => {
 
   p.mousePressed = () => {
     if (isInside(p)) {
+      mergeToMainBuffer();
+
       mouseClickStartedInside = true;
       mouseDragged = false;
       mouseClickedOn = { mouseX: p.mouseX, mouseY: p.mouseY };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -159,6 +159,8 @@ const sketch = (p: p5) => {
 
   p.mousePressed = () => {
     if (isInside(p)) {
+      if (getStore("canvasLocked")) return;
+
       mergeToMainBuffer();
 
       mouseClickStartedInside = true;
@@ -184,7 +186,6 @@ const sketch = (p: p5) => {
 
     // FIXME: ドラッグできるようになったとき、ドラッグ中に外に出るのは許容する必要がある
     if (isInside(p) && mouseClickStartedInside) {
-      if (!isInside(p)) return;
       if (getStore("canvasLocked")) return;
 
       if (mouseDragged) {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -169,8 +169,10 @@ const sketch = (p: p5) => {
     }
   };
 
-  p.mouseDragged = () => {
+  p.mouseDragged = (ev: MouseEvent) => {
     if (mouseClickStartedInside) {
+      ev.preventDefault();
+
       changeCursor(p, "grabbing");
       mouseDragged = true;
       clearResultBuffer();
@@ -184,9 +186,10 @@ const sketch = (p: p5) => {
     // canvas内でクリックして、canvas内で離した場合のみクリック時の処理を行う
     // これで外からcanvas内に流れてきた場合の誤クリックを防げる
 
-    // FIXME: ドラッグできるようになったとき、ドラッグ中に外に出るのは許容する必要がある
-    if (isInside(p) && mouseClickStartedInside) {
+    if (mouseClickStartedInside) {
       if (getStore("canvasLocked")) return;
+
+      ev.preventDefault();
 
       if (mouseDragged) {
         // ドラッグ終了時

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -223,6 +223,10 @@ export const startCalculation = async (
 
     // TODO: perturbation時はreference pointsの値を取っておけば移動がかなり高速化できる気がする
 
+    // FIXME:
+    // 描画領域分割数＝worker数のせいでworker=1のとき移動すると落ちる
+    // これらは別に設定できるようにするべき
+
     calculationRects = divideRect(getOffsetRects(), getWorkerCount(), minSide);
   } else {
     // 移動していない場合は再利用するCacheがないので消す

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -286,7 +286,6 @@ export const startCalculation = async (
 
         const comp = isCompleted(completed);
 
-        // TODO: たぶん適度にdebounceしたほうがいい
         onBufferChanged(rect, comp);
 
         if (comp) {

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -323,6 +323,8 @@ export const startCalculation = async (
       endX,
       xn,
       xn2,
+      refX: currentParams.x.toString(),
+      refY: currentParams.y.toString(),
     });
   });
 };

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -221,7 +221,9 @@ export const startCalculation = async (
     // 新しく計算しない部分を先に描画しておく
     onBufferChanged(iterationBufferTransferedRect, false);
 
-    // TODO: perturbation時はreference pointsの値を取っておけば移動がかなり高速化できる気がする
+    // TODO:
+    // perturbation時はreference pointsの値を取っておけば移動がかなり高速化できる気がする
+    // ただしどのくらいの距離まで有効なのか、有効でなくなったことをどう検知したらいいのかわからん
 
     // FIXME:
     // 描画領域分割数＝worker数のせいでworker=1のとき移動すると落ちる

--- a/src/math.ts
+++ b/src/math.ts
@@ -131,3 +131,41 @@ export function dReduce(a: ComplexArbitrary): ComplexArbitrary {
 export function toComplex(n: ComplexArbitrary): Complex {
   return { re: n.re.toNumber(), im: n.im.toNumber() };
 }
+
+export function* seqGenerator(n: number) {
+  let i = n;
+  while (i > 1) {
+    yield i;
+    i = Math.floor(i / 2);
+  }
+  yield 1;
+}
+
+export function dividerSequence(n: number) {
+  const result = [];
+  for (const i of seqGenerator(n)) {
+    result.push(i);
+  }
+  // 最初の2要素は荒すぎるので落とす
+  return result.slice(2);
+}
+
+/**
+ * できるだけ等間隔に要素を取りつつ指定した長さに縮める
+ */
+export function thin<T>(arr: T[], length: number): T[] {
+  if (length >= arr.length || length < 3) {
+    return arr;
+  }
+
+  const result = [arr[0]];
+  const interval = (arr.length - 1) / (length - 1);
+
+  for (let i = 1; i < length - 1; i++) {
+    result.push(arr[Math.round(i * interval)]);
+  }
+
+  result.push(arr[arr.length - 1]);
+
+  return result;
+}

--- a/src/math.ts
+++ b/src/math.ts
@@ -169,3 +169,20 @@ export function thin<T>(arr: T[], length: number): T[] {
 
   return result;
 }
+
+export function generateLowResDiffSequence(
+  resolutionCount: number,
+  areaWidth: number,
+  areaHeight: number
+) {
+  let xDiffs = thin(dividerSequence(areaWidth), resolutionCount);
+  let yDiffs = thin(dividerSequence(areaHeight), resolutionCount);
+
+  if (xDiffs.length !== yDiffs.length) {
+    const minLen = Math.min(xDiffs.length, yDiffs.length);
+    xDiffs = thin(xDiffs, minLen);
+    yDiffs = thin(yDiffs, minLen);
+  }
+
+  return { xDiffs, yDiffs };
+}

--- a/src/rendering.ts
+++ b/src/rendering.ts
@@ -57,10 +57,10 @@ export const bufferLocalLogicalIndex = (
   const ratioX = resolution.width / rect.width;
   const ratioY = resolution.height / rect.height;
 
-  const adaptedX = Math.floor(localX * ratioX);
-  const adaptedY = Math.floor(localY * ratioY);
+  const scaledX = Math.floor(localX * ratioX);
+  const scaledY = Math.floor(localY * ratioY);
 
-  return adaptedX + adaptedY * resolution.width;
+  return scaledX + scaledY * resolution.width;
 };
 
 export const renderIterationsToPixel = (

--- a/src/rendering.ts
+++ b/src/rendering.ts
@@ -2,7 +2,7 @@ import p5 from "p5";
 import { getCanvasWidth } from "./camera";
 import { GLITCHED_POINT_ITERATION } from "./mandelbrot";
 import { Rect } from "./rect";
-import { IterationBuffer } from "./types";
+import { IterationBuffer, Resolution } from "./types";
 import { Palette } from "./color";
 
 export const fillColor = (
@@ -46,10 +46,22 @@ export const fillColor = (
 };
 
 export const bufferLocalLogicalIndex = (
-  x: number,
-  y: number,
-  rect: Rect
-): number => x - rect.x + (y - rect.y) * rect.width;
+  worldX: number,
+  worldY: number,
+  rect: Rect,
+  resolution: Resolution
+): number => {
+  const localX = worldX - rect.x;
+  const localY = worldY - rect.y;
+
+  const ratioX = resolution.width / rect.width;
+  const ratioY = resolution.height / rect.height;
+
+  const adaptedX = Math.floor(localX * ratioX);
+  const adaptedY = Math.floor(localY * ratioY);
+
+  return adaptedX + adaptedY * resolution.width;
+};
 
 export const renderIterationsToPixel = (
   worldRect: Rect,
@@ -64,7 +76,7 @@ export const renderIterationsToPixel = (
   const density = graphics.pixelDensity();
 
   for (const iteration of iterationsResult) {
-    const { rect, buffer } = iteration;
+    const { rect, buffer, resolution } = iteration;
 
     // worldRectとiterationのrectが一致する箇所だけ描画する
     const startY = Math.max(rect.y, worldRect.y);
@@ -72,14 +84,24 @@ export const renderIterationsToPixel = (
     const endY = Math.min(rect.y + rect.height, worldRect.y + worldRect.height);
     const endX = Math.min(rect.x + rect.width, worldRect.x + worldRect.width);
 
-    for (let y = startY; y < endY; y++) {
-      for (let x = startX; x < endX; x++) {
+    for (let worldY = startY; worldY < endY; worldY++) {
+      for (let worldX = startX; worldX < endX; worldX++) {
         // バッファ内で対応する点のiterationを取得
-        const idx = bufferLocalLogicalIndex(x, y, rect);
+
+        const idx = bufferLocalLogicalIndex(worldX, worldY, rect, resolution);
         const n = buffer[idx];
 
         const pixels = graphics.pixels as unknown as Uint8ClampedArray;
-        fillColor(x, y, canvasWidth, pixels, palette, n, maxIteration, density);
+        fillColor(
+          worldX,
+          worldY,
+          canvasWidth,
+          pixels,
+          palette,
+          n,
+          maxIteration,
+          density
+        );
       }
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,9 +2,20 @@ import { BigNumber } from "bignumber.js";
 import { Rect } from "./rect";
 import { Complex } from "./math";
 
+export interface Resolution {
+  width: number;
+  height: number;
+}
+
 export interface WorkerResult {
   type: "result";
   iterations: ArrayBuffer;
+}
+
+export interface WorkerIntermediateResult {
+  type: "intermediateResult";
+  iterations: ArrayBuffer;
+  resolution: Resolution;
 }
 
 export interface WorkerProgress {
@@ -67,4 +78,5 @@ export type MandelbrotWorkerType = (typeof mandelbrotWorkerTypes)[number];
 export interface IterationBuffer {
   rect: Rect;
   buffer: Uint32Array;
+  resolution: Resolution;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,8 +71,8 @@ export interface ReferencePointCalculationWorkerParams {
 
 export const mandelbrotWorkerTypes = [
   "normal",
-  "doublejs",
   "perturbation",
+  "doublejs",
 ] as const;
 export type MandelbrotWorkerType = (typeof mandelbrotWorkerTypes)[number];
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,7 +56,8 @@ export interface MandelbrotCalculationWorkerParams {
   endY: number;
   xn: Complex[];
   xn2: Complex[];
-  glitchChecker: number[];
+  refX: string;
+  refY: string;
 }
 
 export interface ReferencePointCalculationWorkerParams {

--- a/src/workers/mandelbrot-perturbation-worker.ts
+++ b/src/workers/mandelbrot-perturbation-worker.ts
@@ -5,6 +5,7 @@ import {
   complexArbitary,
   dSub,
   dividerSequence,
+  generateLowResDiffSequence,
   mulIm,
   mulRe,
   nNorm,
@@ -35,7 +36,6 @@ self.addEventListener("message", (event) => {
 
   const areaWidth = endX - startX;
   const areaHeight = endY - startY;
-
   const pixelNum = areaHeight * areaWidth;
   const iterations = new Uint32Array(pixelNum);
 
@@ -108,22 +108,17 @@ self.addEventListener("message", (event) => {
 
   const context = { xn, xn2 };
 
-  const resolutionCount = 6;
-
-  let xDiffSeq = thin(dividerSequence(areaWidth), resolutionCount);
-  let yDiffSeq = thin(dividerSequence(areaHeight), resolutionCount);
-
-  if (xDiffSeq.length !== yDiffSeq.length) {
-    const minLen = Math.min(xDiffSeq.length, yDiffSeq.length);
-    xDiffSeq = thin(xDiffSeq, minLen);
-    yDiffSeq = thin(yDiffSeq, minLen);
-  }
+  const { xDiffs, yDiffs } = generateLowResDiffSequence(
+    6,
+    areaWidth,
+    areaHeight
+  );
 
   let calculatedCount = 0;
 
-  for (let i = 0; i < xDiffSeq.length; i++) {
-    const xDiff = xDiffSeq[i];
-    const yDiff = yDiffSeq[i];
+  for (let i = 0; i < xDiffs.length; i++) {
+    const xDiff = xDiffs[i];
+    const yDiff = yDiffs[i];
 
     const lowResAreaWidth = Math.floor(areaWidth / xDiff);
     const lowResAreaHeight = Math.floor(areaHeight / yDiff);

--- a/src/workers/mandelbrot-perturbation-worker.ts
+++ b/src/workers/mandelbrot-perturbation-worker.ts
@@ -29,6 +29,8 @@ self.addEventListener("message", (event) => {
     endY,
     xn,
     xn2,
+    refX,
+    refY,
   } = event.data as MandelbrotCalculationWorkerParams;
 
   const areaWidth = endX - startX;
@@ -38,6 +40,7 @@ self.addEventListener("message", (event) => {
   const iterations = new Uint32Array(pixelNum);
 
   const c = complexArbitary(cxStr, cyStr);
+  const ref = complexArbitary(refX, refY);
   const r = new BigNumber(rStr);
 
   function calcIterationAt(
@@ -61,7 +64,7 @@ self.addEventListener("message", (event) => {
       pixelHeight
     );
     // Δ0
-    const deltaC = toComplex(dSub(current, c));
+    const deltaC = toComplex(dSub(current, ref));
 
     let iteration = 0;
     let refIteration = 0;


### PR DESCRIPTION
## できるようにしたこと
- ある描画範囲について、低解像度から徐々に描画を反映できるようにした
- 既に計算した部分は2重に計算しないようになっているので速度は特に変わらない
   - 無駄なループは走っているが計算部分のコストが支配的なので特に速度に影響なかった
- perturbationのみ対応
   - doubleの場合は拡大がe-14までなので、そもそもそんなに時間かかる箇所は描画しなさそう
   - あとは一瞬しか表示されない途中経過を描画することにより、最大4倍(50ms -> 200ms)くらい重くなるので本末転倒

## 課題
- reference pointの計算中に場所を動かすと画面がおかしくなる
   - 動かしたあとの差分計算のみ行われるから。前回の計算が途中で終わったことを検知して再描画しなおしたらよさそう
- 深い場所での左右移動、reference pointを保存しておけばかなり早くできそう
   - ただしどのくらいの距離で有効なのか、どうなったら有効じゃなくなったことを判定できるのかわからん

## スクリーンショット
![image](https://github.com/k-chop/p5mandelbrot/assets/241973/ce0aec91-11dd-40f6-8e6a-447b6a5968d1)
