### PR TITLE
POICardに画像のプレビューを表示できるようにした

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "p5": "^1.7.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-promise-suspense": "^0.3.4",
     "tailwind-merge": "^1.14.0",
     "tailwindcss-animate": "^1.0.6"
   }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "clsx": "^2.0.0",
     "double.js": "^1.1.0",
     "eventmit": "^2.0.4",
+    "idb-keyval": "^6.2.1",
     "lucide-react": "^0.263.1",
     "p5": "^1.7.0",
     "react": "^18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ dependencies:
   react-dom:
     specifier: ^18.2.0
     version: 18.2.0(react@18.2.0)
+  react-promise-suspense:
+    specifier: ^0.3.4
+    version: 0.3.4
   tailwind-merge:
     specifier: ^1.14.0
     version: 1.14.0
@@ -1788,6 +1791,10 @@ packages:
     resolution: {integrity: sha512-ajC4xDTMb8ydU8+VCwd/NLZzjl3piZXguctx+4vcbieC+aRHhHHoTG5vlwndebPyejAoBfUDTs3Ykax4xRTgXw==}
     dev: false
 
+  /fast-deep-equal@2.0.1:
+    resolution: {integrity: sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==}
+    dev: false
+
   /fast-glob@3.3.1:
     resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
     engines: {node: '>=8.6.0'}
@@ -2315,6 +2322,12 @@ packages:
   /react-is@18.2.0:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
     dev: true
+
+  /react-promise-suspense@0.3.4:
+    resolution: {integrity: sha512-I42jl7L3Ze6kZaq+7zXWSunBa3b1on5yfvUW6Eo/3fFOj6dZ5Bqmcd264nJbTK/gn1HjjILAjSwnZbV4RpSaNQ==}
+    dependencies:
+      fast-deep-equal: 2.0.1
+    dev: false
 
   /react-refresh@0.14.0:
     resolution: {integrity: sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ dependencies:
   eventmit:
     specifier: ^2.0.4
     version: 2.0.4
+  idb-keyval:
+    specifier: ^6.2.1
+    version: 6.2.1
   lucide-react:
     specifier: ^0.263.1
     version: 0.263.1(react@18.2.0)
@@ -1882,6 +1885,10 @@ packages:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
     dependencies:
       react-is: 16.13.1
+    dev: false
+
+  /idb-keyval@6.2.1:
+    resolution: {integrity: sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg==}
     dev: false
 
   /import-fresh@3.3.0:

--- a/src/canvas-reference.ts
+++ b/src/canvas-reference.ts
@@ -1,0 +1,18 @@
+import type * as p5Type from "p5";
+
+// p5.Imageはcanvas持っているのに型定義には存在しない
+type Image = p5Type.Image & { canvas: HTMLCanvasElement };
+
+let p5: p5Type;
+
+export const setP5 = (p5Instance: p5Type) => {
+  p5 = p5Instance;
+};
+
+export const getResizedCanvasImageDataURL = (height: number = 100) => {
+  const img = p5.get() as Image;
+  // 0にしておくと指定した方の高さに合わせてリサイズしてくれる
+  img.resize(0, height);
+
+  return img.canvas.toDataURL();
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,6 +13,9 @@ import {
   setColorIndex,
   setupCamera,
 } from "./camera";
+import { setP5 } from "./canvas-reference";
+import { chromaJsPalettes } from "./color/color-chromajs";
+import { p5jsPalettes } from "./color/color-p5js";
 import {
   calcVars,
   cycleMode,
@@ -32,6 +35,7 @@ import {
   zoom,
 } from "./mandelbrot";
 import { Rect } from "./rect";
+import { drawCrossHair } from "./rendering";
 import { createStore, getStore, updateStore } from "./store/store";
 import { readPOIListFromStorage } from "./store/sync-storage/poi-list";
 import {
@@ -41,9 +45,6 @@ import {
 import "./style.css";
 import { AppRoot } from "./view/app-root";
 import { currentWorkerType, resetWorkers, setWorkerCount } from "./workers";
-import { chromaJsPalettes } from "./color/color-chromajs";
-import { p5jsPalettes } from "./color/color-p5js";
-import { drawCrossHair } from "./rendering";
 
 resetWorkers();
 
@@ -154,6 +155,8 @@ const sketch = (p: p5) => {
     p.colorMode(p.HSB, 360, 100, 100, 100);
 
     p.cursor(p.CROSS);
+
+    setP5(p);
   };
 
   p.mousePressed = () => {

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -92,10 +92,11 @@ export const getCanvasSize = () => ({ width, height });
 export const getCurrentParams = () => currentParams;
 
 export const cloneParams = (params: MandelbrotParams): MandelbrotParams => ({
-  ...params,
   x: BigNumber(params.x),
   y: BigNumber(params.y),
   r: BigNumber(params.r),
+  N: params.N,
+  mode: params.mode,
 });
 
 export const getProgressString = () =>

--- a/src/store/preview-store.ts
+++ b/src/store/preview-store.ts
@@ -1,0 +1,13 @@
+import { get, set, del } from "idb-keyval";
+
+export const savePreview = (id: string, imageDataURL: string) => {
+  set(id, imageDataURL);
+};
+
+export const loadPreview = async (id: string) => {
+  return await get(id);
+};
+
+export const deletePreview = async (id: string) => {
+  await del(id);
+};

--- a/src/store/sync-storage/poi-list.ts
+++ b/src/store/sync-storage/poi-list.ts
@@ -1,12 +1,14 @@
 import BigNumber from "bignumber.js";
-import { MandelbrotParams } from "../../types";
+import { MandelbrotParams, POIData } from "../../types";
 
-export const writePOIListToStorage = (poiList: MandelbrotParams[]) => {
+export const writePOIListToStorage = (
+  poiList: (MandelbrotParams | POIData)[],
+) => {
   const serialized = JSON.stringify(poiList.map(serializedMandelbrotParams));
   localStorage.setItem("poiList", serialized);
 };
 
-export const readPOIListFromStorage = (): MandelbrotParams[] => {
+export const readPOIListFromStorage = (): POIData[] => {
   const serialized = localStorage.getItem("poiList");
   if (!serialized) return [];
 
@@ -14,8 +16,11 @@ export const readPOIListFromStorage = (): MandelbrotParams[] => {
   return rawList.map(deserializedMandelbrotParams);
 };
 
-const serializedMandelbrotParams = (params: MandelbrotParams) => {
+const serializedMandelbrotParams = (params: any) => {
+  const id = params.id == null ? crypto.randomUUID() : params.id;
+
   return {
+    id,
     x: params.x.toString(),
     y: params.y.toString(),
     r: params.r.toString(),
@@ -24,8 +29,11 @@ const serializedMandelbrotParams = (params: MandelbrotParams) => {
   };
 };
 
-const deserializedMandelbrotParams = (params: any): MandelbrotParams => {
+const deserializedMandelbrotParams = (params: any): POIData => {
+  const id = params.id == null ? crypto.randomUUID() : params.id;
+
   return {
+    id,
     x: new BigNumber(params.x),
     y: new BigNumber(params.y),
     r: new BigNumber(params.r),

--- a/src/store/sync-storage/poi-list.ts
+++ b/src/store/sync-storage/poi-list.ts
@@ -1,9 +1,12 @@
 import BigNumber from "bignumber.js";
 import { MandelbrotParams, POIData } from "../../types";
 
-export const writePOIListToStorage = (
-  poiList: (MandelbrotParams | POIData)[],
-) => {
+export const createNewPOIData = (params: MandelbrotParams): POIData => ({
+  id: crypto.randomUUID(),
+  ...params,
+});
+
+export const writePOIListToStorage = (poiList: POIData[]) => {
   const serialized = JSON.stringify(poiList.map(serializedMandelbrotParams));
   localStorage.setItem("poiList", serialized);
 };
@@ -16,11 +19,9 @@ export const readPOIListFromStorage = (): POIData[] => {
   return rawList.map(deserializedMandelbrotParams);
 };
 
-const serializedMandelbrotParams = (params: any) => {
-  const id = params.id == null ? crypto.randomUUID() : params.id;
-
+const serializedMandelbrotParams = (params: POIData) => {
   return {
-    id,
+    id: params.id,
     x: params.x.toString(),
     y: params.y.toString(),
     r: params.r.toString(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,10 @@ export interface MandelbrotParams {
   mode: MandelbrotWorkerType;
 }
 
+export interface POIData extends MandelbrotParams {
+  id: string; // UUID
+}
+
 export interface MandelbrotCalculationWorkerParams {
   pixelHeight: number;
   pixelWidth: number;

--- a/src/view/right-sidebar/poi-card-preview.tsx
+++ b/src/view/right-sidebar/poi-card-preview.tsx
@@ -1,0 +1,19 @@
+import { loadPreview } from "@/store/preview-store";
+import usePromise from "react-promise-suspense";
+
+type Props = {
+  poiId: string;
+};
+
+export const POICardPreview = ({ poiId }: Props) => {
+  const data = usePromise(loadPreview, [poiId]);
+
+  if (data == null)
+    return (
+      <div className="flex h-[100px] w-[100px] items-center justify-center border-2">
+        No Image
+      </div>
+    );
+
+  return <img src={data} />;
+};

--- a/src/view/right-sidebar/poi-card.tsx
+++ b/src/view/right-sidebar/poi-card.tsx
@@ -1,36 +1,46 @@
 import { IconArrowBigLeftLine, IconTrash } from "@tabler/icons-react";
-import { MandelbrotParams } from "../../types";
+import { POIData } from "../../types";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { POICardPreview } from "./poi-card-preview";
+import { Suspense } from "react";
 
 type POICardProps = {
-  poi: MandelbrotParams;
+  poi: POIData;
   onDelete: () => void;
   onApply: () => void;
 };
 
 export const POICard = ({ poi, onDelete, onApply }: POICardProps) => {
-  const { r, N } = poi;
-
-  // TODO: できればbackgroundImageで画像のプレビューを表示したい
+  const { r, N, id } = poi;
 
   return (
     <Card className="p-2">
-      <div className="flex justify-between">
-        <div>r</div>
-        <div>{r.toPrecision(10)}</div>
-      </div>
-      <div className="flex justify-between">
-        <div>N</div>
-        <div>{N.toFixed(0)}</div>
-      </div>
-      <div className="mt-2 flex justify-between">
-        <Button variant="default" size="icon" onClick={onApply}>
-          <IconArrowBigLeftLine />
-        </Button>
-        <Button variant="destructive" size="icon" onClick={onDelete}>
-          <IconTrash />
-        </Button>
+      <div className="flex">
+        <div className="">
+          <Suspense fallback={"loading..."}>
+            <POICardPreview poiId={id} />
+          </Suspense>
+        </div>
+        <div className="ml-2 flex flex-grow flex-col">
+          <div className="flex justify-between">
+            <div>r</div>
+            <div>{r.toPrecision(10)}</div>
+          </div>
+          <div className="flex justify-between">
+            <div>N</div>
+            <div>{N.toFixed(0)}</div>
+          </div>
+
+          <div className="mt-2 flex justify-between">
+            <Button variant="default" size="icon" onClick={onApply}>
+              <IconArrowBigLeftLine />
+            </Button>
+            <Button variant="destructive" size="icon" onClick={onDelete}>
+              <IconTrash />
+            </Button>
+          </div>
+        </div>
       </div>
     </Card>
   );

--- a/src/view/right-sidebar/poi.tsx
+++ b/src/view/right-sidebar/poi.tsx
@@ -26,7 +26,7 @@ export const POI = () => {
           <div className="flex flex-col gap-2">
             {poiList.map((poi, index) => (
               <POICard
-                key={index}
+                key={poi.id}
                 poi={poi}
                 onDelete={() => deletePOIAt(index)}
                 onApply={() => applyPOI(poi)}

--- a/src/view/right-sidebar/use-poi.tsx
+++ b/src/view/right-sidebar/use-poi.tsx
@@ -1,11 +1,11 @@
 import { useCallback } from "react";
-import { MandelbrotParams } from "../../types";
+import { MandelbrotParams, POIData } from "../../types";
 import { updateStore, useStoreValue } from "../../store/store";
 import { cloneParams, setCurrentParams } from "../../mandelbrot";
 import { writePOIListToStorage } from "../../store/sync-storage/poi-list";
 
 export const usePOI = () => {
-  const poiList: MandelbrotParams[] = useStoreValue("poi");
+  const poiList: POIData[] = useStoreValue("poi");
 
   const addPOI = useCallback(
     (newPOI: MandelbrotParams) => {

--- a/src/view/right-sidebar/use-poi.tsx
+++ b/src/view/right-sidebar/use-poi.tsx
@@ -2,15 +2,25 @@ import { useCallback } from "react";
 import { MandelbrotParams, POIData } from "../../types";
 import { updateStore, useStoreValue } from "../../store/store";
 import { cloneParams, setCurrentParams } from "../../mandelbrot";
-import { writePOIListToStorage } from "../../store/sync-storage/poi-list";
+import {
+  createNewPOIData,
+  writePOIListToStorage,
+} from "../../store/sync-storage/poi-list";
+import { getResizedCanvasImageDataURL } from "@/canvas-reference";
+import { deletePreview, savePreview } from "@/store/preview-store";
 
 export const usePOI = () => {
   const poiList: POIData[] = useStoreValue("poi");
 
   const addPOI = useCallback(
-    (newPOI: MandelbrotParams) => {
+    (newParams: MandelbrotParams) => {
+      const newPOI = createNewPOIData(newParams);
       const newPOIList = [newPOI, ...poiList];
       writePOIListToStorage(newPOIList);
+
+      const imageDataURL = getResizedCanvasImageDataURL();
+      savePreview(newPOI.id, imageDataURL);
+
       updateStore("poi", newPOIList);
     },
     [poiList],
@@ -18,9 +28,13 @@ export const usePOI = () => {
 
   const deletePOIAt = useCallback(
     (index: number) => {
+      const del = poiList[index];
       const newPOIList = poiList.filter((_, i) => i !== index);
       writePOIListToStorage(newPOIList);
+
       updateStore("poi", newPOIList);
+
+      deletePreview(del.id);
     },
     [poiList],
   );

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,12 +1,13 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  darkMode: ["class"],
+  darkMode: "class",
   content: [
     "./pages/**/*.{ts,tsx}",
     "./components/**/*.{ts,tsx}",
     "./app/**/*.{ts,tsx}",
     "./src/**/*.{ts,tsx}",
   ],
+  safelist: ["dark"],
   theme: {
     container: {
       center: true,


### PR DESCRIPTION
## やったこと
POICardにプレビューを表示するようにした。
今まではロードするまでどれが何だか分からなかった...

## 保存形式
保存したデータはdataURLの形式でIndexedDBに保存している。
100x100のサイズだったら正直localStorageに保存でよかったかも。
このプレビューは保存時のcanvasの状態を保存しているので、生成途中で保存すると解像度が低いまま登録されてしまう。
今後改善するかもしれない。

## ついでに
ライトモードになってしまってたのを修正。
htmlに直接 `class="dark"` を書くとtailwindのランタイムjsに消されてしまうっぽい？
tailwindのconfigのsafelistに入れたら直った

## マイグレーション
既に保存したPOIは保存し直さないとプレビューは保存されない。
まぁ現状自分以外使ってるやつおらんやろ！！の精神

## スクリーンショット
![image](https://github.com/k-chop/p5mandelbrot/assets/241973/2585c0b0-3306-449c-ae08-aeb00ed03bbe)
