### PR TITLE
Reference Orbitの計算時に追加していたxn2は不要なので削除

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -26,7 +26,6 @@ export interface WorkerProgress {
 export interface ReferencePointResult {
   type: "result";
   xn: Complex[];
-  xn2: Complex[];
   blaTable: BLATableItem[][];
 }
 
@@ -59,7 +58,6 @@ export interface MandelbrotCalculationWorkerParams {
   startY: number;
   endY: number;
   xn: Complex[];
-  xn2: Complex[];
   blaTable: BLATableItem[][];
   refX: string;
   refY: string;

--- a/src/workers/mandelbrot-perturbation-worker.ts
+++ b/src/workers/mandelbrot-perturbation-worker.ts
@@ -28,7 +28,6 @@ self.addEventListener("message", (event) => {
     startY,
     endY,
     xn,
-    xn2,
     blaTable,
     refX,
     refY,
@@ -48,7 +47,7 @@ self.addEventListener("message", (event) => {
     pixelY: number,
     context: ReferencePointContext,
   ): number {
-    const { xn, xn2, blaTable } = context;
+    const { xn, blaTable } = context;
     const maxRefIteration = xn.length - 1;
 
     // Δn
@@ -133,8 +132,8 @@ self.addEventListener("message", (event) => {
         const _deltaNIm = deltaNIm;
 
         // (2 * Xn + Δn) * Δn に展開して計算
-        const dzrT = xn2[refIteration].re + _deltaNRe;
-        const dziT = xn2[refIteration].im + _deltaNIm;
+        const dzrT = xn[refIteration].re * 2 + _deltaNRe;
+        const dziT = xn[refIteration].im * 2 + _deltaNIm;
 
         deltaNRe = mulRe(dzrT, dziT, _deltaNRe, _deltaNIm) + deltaC.re;
         deltaNIm = mulIm(dzrT, dziT, _deltaNRe, _deltaNIm) + deltaC.im;
@@ -147,7 +146,7 @@ self.addEventListener("message", (event) => {
     return Math.min(iteration, maxIteration);
   }
 
-  const context = { xn, xn2, blaTable };
+  const context = { xn, blaTable };
 
   const { xDiffs, yDiffs } = generateLowResDiffSequence(
     6,


### PR DESCRIPTION
何かの名残で残っていたものと思われる
これがあってもdoubleの掛け算を2回省略できるだけ
1万要素程度だとほとんど変わりないが、5万要素くらいになってくるとworkerへの転送コストの方が大きかった

実際workerNum=16, N=43000でxn2ありなしverを比較したら500msほど改善した