### PR TITLE
WorkerPoolぽいものを実装した

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -20,7 +20,6 @@ import {
   cycleMode,
   getCanvasSize,
   getCurrentParams,
-  getPreviousRenderTime,
   paramsChanged,
   resetIterationCount,
   resetRadius,
@@ -31,7 +30,6 @@ import {
   startCalculation,
   zoom,
 } from "./mandelbrot";
-import { Rect } from "./rect";
 import { drawCrossHair } from "./rendering";
 import { createStore, getStore, updateStore } from "./store/store";
 import { readPOIListFromStorage } from "./store/sync-storage/poi-list";
@@ -43,7 +41,10 @@ import "./style.css";
 import { AppRoot } from "./view/app-root";
 import { extractMandelbrotParams } from "./lib/params";
 import { d3ChromaticPalettes } from "./color/color-d3-chromatic";
-import { prepareWorkerPool } from "./worker-pool/worker-pool";
+import {
+  getProgressString,
+  prepareWorkerPool,
+} from "./worker-pool/worker-pool";
 
 const drawInfo = (p: p5) => {
   const { mouseX, mouseY, r, N } = calcVars(
@@ -60,8 +61,7 @@ const drawInfo = (p: p5) => {
   };
 
   const params = getCurrentParams();
-  const progress = 0; // getProgressString();
-  const millis = getPreviousRenderTime();
+  const progress = getProgressString();
 
   updateStore("centerX", params.x);
   updateStore("centerY", params.y);
@@ -74,7 +74,6 @@ const drawInfo = (p: p5) => {
   }
 
   updateStore("progress", progress);
-  updateStore("millis", millis);
 };
 
 let currentCursor: "cross" | "grab" = "cross";

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -2,27 +2,19 @@ import BigNumber from "bignumber.js";
 import {
   clearIterationCache,
   translateRectInIterationCache,
-  upsertIterationCache,
 } from "./aggregator";
 import { BLATableItem, Complex } from "./math";
 import { divideRect, Rect } from "./rect";
-import { updateStore } from "./store/store";
+import { updateStore, getStore } from "./store/store";
+import { MandelbrotParams, OffsetParams } from "./types";
+import { calcReferencePointWithWorker } from "./workers";
 import {
-  MandelbrotParams,
-  OffsetParams,
-  WorkerIntermediateResult,
-  WorkerProgress,
-  WorkerResult,
-} from "./types";
-import {
-  activeWorkerCount,
-  calcReferencePointWithWorker,
   cycleWorkerType,
   getWorkerCount,
-  registerWorkerTask,
-  setWorkerType,
-  terminateWorkers,
-} from "./workers";
+  prepareWorkerPool,
+  registerBatch,
+} from "./worker-pool/worker-pool";
+import { renderToResultBuffer } from "./camera";
 
 const DEFAULT_N = 500;
 const DEFAULT_WIDTH = 800;
@@ -75,7 +67,7 @@ export const togglePinReference = () => {
   console.debug("params: ", { refX, refY, x, y });
 };
 
-const progresses = Array.from({ length: getWorkerCount() }, () => 0);
+// const progresses = Array.from({ length: getWorkerCount() }, () => 0);
 
 let currentParams: MandelbrotParams = {
   x: new BigNumber(
@@ -136,8 +128,8 @@ export const cloneParams = (params: MandelbrotParams): MandelbrotParams => ({
   mode: params.mode,
 });
 
-export const getProgressString = () =>
-  ((progresses.reduce((p, c) => p + c) * 100) / activeWorkerCount()).toFixed();
+// export const getProgressString = () =>
+//   ((progresses.reduce((p, c) => p + c) * 100) / activeWorkerCount()).toFixed();
 
 export const getPreviousRenderTime = () => lastTime;
 
@@ -151,8 +143,10 @@ export const setCurrentParams = (params: Partial<MandelbrotParams>) => {
   const needResetOffset = params.r != null && !currentParams.r.eq(params.r);
 
   currentParams = { ...currentParams, ...params };
+
   if (needModeChange) {
-    setWorkerType(currentParams.mode);
+    const workerCount = getStore("workerCount");
+    prepareWorkerPool(workerCount, currentParams.mode);
     setOffsetParams({ x: 0, y: 0 });
   }
   if (needResetOffset) {
@@ -189,18 +183,16 @@ export const paramsChanged = () => {
   return !isSameParams(lastCalc, currentParams);
 };
 
-export const startCalculation = async (
-  onBufferChanged: (updatedRect: Rect, isCompleted: boolean) => void,
-) => {
+export const startCalculation = async (onComplete: () => void) => {
   updateCurrentParams();
 
   if (running) {
-    terminateWorkers();
+    // terminateWorkers();
   }
 
   running = true;
   completed = 0;
-  progresses.fill(0);
+  // progresses.fill(0);
 
   const before = performance.now();
 
@@ -232,17 +224,18 @@ export const startCalculation = async (
     translateRectInIterationCache(offsetX, offsetY);
 
     // 新しく計算しない部分を先に描画しておく
-    onBufferChanged(iterationBufferTransferedRect, false);
+    renderToResultBuffer(iterationBufferTransferedRect);
 
     // TODO:
     // perturbation時はreference pointsの値を取っておけば移動がかなり高速化できる気がする
     // ただしどのくらいの距離まで有効なのか、有効でなくなったことをどう検知したらいいのかわからん
 
-    // FIXME:
-    // 描画領域分割数＝worker数のせいでworker=1のとき移動すると落ちる
-    // これらは別に設定できるようにするべき
-
-    calculationRects = divideRect(getOffsetRects(), getWorkerCount(), minSide);
+    const expectedDivideCount = Math.max(getWorkerCount(), 2);
+    calculationRects = divideRect(
+      getOffsetRects(),
+      expectedDivideCount,
+      minSide,
+    );
   } else {
     // 移動していない場合は再利用するCacheがないので消す
     clearIterationCache();
@@ -279,82 +272,95 @@ export const startCalculation = async (
     lastReferenceCache.blaTable = blaTable;
   }
 
-  registerWorkerTask(calculationRects, (worker, rect, idx, _, isCompleted) => {
-    const startX = rect.x;
-    const endX = rect.x + rect.width;
-    const startY = rect.y;
-    const endY = rect.y + rect.height;
+  // registerWorkerTask(calculationRects, (worker, rect, idx, _, isCompleted) => {
+  //   const startX = rect.x;
+  //   const endX = rect.x + rect.width;
+  //   const startY = rect.y;
+  //   const endY = rect.y + rect.height;
 
-    const f = (
-      ev: MessageEvent<
-        WorkerResult | WorkerIntermediateResult | WorkerProgress
-      >,
-    ) => {
-      const data = ev.data;
-      if (data.type == "result") {
-        const { iterations } = data;
+  //   const f = (
+  //     ev: MessageEvent<
+  //       WorkerResult | WorkerIntermediateResult | WorkerProgress
+  //     >,
+  //   ) => {
+  //     const data = ev.data;
+  //     if (data.type == "result") {
+  //       const { iterations } = data;
 
-        const iterationsResult = new Uint32Array(iterations);
-        upsertIterationCache(rect, iterationsResult, {
-          width: rect.width,
-          height: rect.height,
-        });
+  //       const iterationsResult = new Uint32Array(iterations);
+  //       upsertIterationCache(rect, iterationsResult, {
+  //         width: rect.width,
+  //         height: rect.height,
+  //       });
 
-        progresses[idx] = 1.0;
-        completed++;
+  //       // progresses[idx] = 1.0;
+  //       completed++;
 
-        const comp = isCompleted(completed);
+  //       const comp = isCompleted(completed);
 
-        onBufferChanged(rect, comp);
+  //       onBufferChanged(rect, comp);
 
-        if (comp) {
-          running = false;
-          const after = performance.now();
-          lastTime = (after - before).toFixed();
-        }
+  //       if (comp) {
+  //         running = false;
+  //         const after = performance.now();
+  //         lastTime = (after - before).toFixed();
+  //       }
 
-        worker.removeEventListener("message", f);
-      } else if (data.type === "intermediateResult") {
-        const { iterations, resolution } = data;
-        upsertIterationCache(rect, new Uint32Array(iterations), resolution);
+  //       worker.removeEventListener("message", f);
+  //     } else if (data.type === "intermediateResult") {
+  //       const { iterations, resolution } = data;
+  //       upsertIterationCache(rect, new Uint32Array(iterations), resolution);
 
-        onBufferChanged(rect, false);
-      } else {
-        const { progress } = data;
-        progresses[idx] = progress;
-      }
-    };
+  //       onBufferChanged(rect, false);
+  //     } else {
+  //       const { progress } = data;
+  //       // progresses[idx] = progress;
+  //     }
+  //   };
 
-    worker.addEventListener("message", f);
-    worker.addEventListener("error", () => {
-      completed++;
-    });
+  //   worker.addEventListener("message", f);
+  //   worker.addEventListener("error", () => {
+  //     completed++;
+  //   });
 
-    let refX = currentParams.x.toString();
-    let refY = currentParams.y.toString();
+  let refX = currentParams.x.toString();
+  let refY = currentParams.y.toString();
 
-    if (isReferencePinned) {
-      refX = lastReferenceCache.x.toString();
-      refY = lastReferenceCache.y.toString();
-    }
+  if (isReferencePinned) {
+    refX = lastReferenceCache.x.toString();
+    refY = lastReferenceCache.y.toString();
+  }
 
-    worker.postMessage({
-      cx: currentParams.x.toString(),
-      cy: currentParams.y.toString(),
-      r: currentParams.r.toString(),
-      N: currentParams.N,
-      pixelHeight: height,
-      pixelWidth: width,
-      startY,
-      endY,
-      startX,
-      endX,
-      xn,
-      blaTable,
-      refX,
-      refY,
-    });
+  const units = calculationRects.map((rect) => ({
+    rect,
+    mandelbrotParams: currentParams,
+  }));
+  registerBatch(units, {
+    onComplete,
+    refX,
+    refY,
+    pixelWidth: width,
+    pixelHeight: height,
+    xn,
+    blaTable,
   });
+
+  // worker.postMessage({
+  //   cx: currentParams.x.toString(),
+  //   cy: currentParams.y.toString(),
+  //   r: currentParams.r.toString(),
+  //   N: currentParams.N,
+  //   pixelHeight: height,
+  //   pixelWidth: width,
+  //   startY,
+  //   endY,
+  //   startX,
+  //   endX,
+  //   xn,
+  //   blaTable,
+  //   refX,
+  //   refY,
+  // });
 };
 
 const isSameParams = (a: MandelbrotParams, b: MandelbrotParams) =>

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -194,12 +194,13 @@ export const startCalculation = async (onComplete: () => void) => {
   // progresses.fill(0);
 
   const before = performance.now();
+  const divideRectCount = getWorkerCount();
 
-  const minSide = Math.floor(Math.sqrt((width * height) / getWorkerCount()));
+  const minSide = Math.floor(Math.sqrt((width * height) / divideRectCount));
 
   let calculationRects = divideRect(
     [{ x: 0, y: 0, width, height }],
-    getWorkerCount(),
+    divideRectCount,
     minSide,
   );
 
@@ -229,7 +230,7 @@ export const startCalculation = async (onComplete: () => void) => {
     // perturbation時はreference pointsの値を取っておけば移動がかなり高速化できる気がする
     // ただしどのくらいの距離まで有効なのか、有効でなくなったことをどう検知したらいいのかわからん
 
-    const expectedDivideCount = Math.max(getWorkerCount(), 2);
+    const expectedDivideCount = Math.max(divideRectCount, 2);
     calculationRects = divideRect(
       getOffsetRects(),
       expectedDivideCount,

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -66,8 +66,6 @@ export const togglePinReference = () => {
   console.debug("params: ", { refX, refY, x, y });
 };
 
-// const progresses = Array.from({ length: getWorkerCount() }, () => 0);
-
 let currentParams: MandelbrotParams = {
   x: new BigNumber(
     "-1.408537400223374550983496866638703877765950056271735005951863022034495341910960396585990889377247354329184721916097300836171707822353071514393502045045428218599916142953125",

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -32,7 +32,6 @@ let lastCalc: MandelbrotParams = {
   mode: "normal",
 };
 
-let lastTime = "0";
 let prevBatchId = "";
 
 let width = DEFAULT_WIDTH;
@@ -128,11 +127,6 @@ export const cloneParams = (params: MandelbrotParams): MandelbrotParams => ({
   mode: params.mode,
 });
 
-// export const getProgressString = () =>
-//   ((progresses.reduce((p, c) => p + c) * 100) / activeWorkerCount()).toFixed();
-
-export const getPreviousRenderTime = () => lastTime;
-
 export const updateCurrentParams = () => {
   lastCalc = { ...currentParams };
 };
@@ -190,10 +184,7 @@ export const startCalculation = async (onComplete: () => void) => {
   startBatch(currentBatchId);
   cancelBatch(prevBatchId);
   prevBatchId = currentBatchId;
-  // completed = 0;
-  // progresses.fill(0);
 
-  const before = performance.now();
   const divideRectCount = getWorkerCount();
 
   const minSide = Math.floor(Math.sqrt((width * height) / divideRectCount));

--- a/src/types.ts
+++ b/src/types.ts
@@ -108,4 +108,5 @@ export interface BatchContext {
 
   progressMap: Map<string, number>;
   startedAt: number;
+  finishedAt?: number;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import { BigNumber } from "bignumber.js";
 import { Rect } from "./rect";
 import { BLATableItem, Complex } from "./math";
+import { BatchCompleteCallback } from "./worker-pool/worker-facade";
 
 export interface Resolution {
   width: number;
@@ -79,4 +80,28 @@ export interface IterationBuffer {
   rect: Rect;
   buffer: Uint32Array;
   resolution: Resolution;
+}
+
+export interface MandelbrotRenderingUnit {
+  mandelbrotParams: MandelbrotParams;
+  rect: Rect;
+}
+
+export interface MandelbrotJob extends MandelbrotRenderingUnit {
+  id: string;
+  batchId: string;
+}
+
+export interface BatchContext {
+  onComplete: BatchCompleteCallback;
+
+  refX: string;
+  refY: string;
+  pixelWidth: number;
+  pixelHeight: number;
+  xn: Complex[];
+  blaTable: BLATableItem[][];
+
+  progressMap: Map<string, number>;
+  startedAt: number;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,10 @@
 import { BigNumber } from "bignumber.js";
 import { Rect } from "./rect";
 import { BLATableItem, Complex } from "./math";
-import { BatchCompleteCallback } from "./worker-pool/worker-facade";
+import {
+  BatchCompleteCallback,
+  BatchProgressChangedCallback,
+} from "./worker-pool/worker-facade";
 
 export interface Resolution {
   width: number;
@@ -94,6 +97,7 @@ export interface MandelbrotJob extends MandelbrotRenderingUnit {
 
 export interface BatchContext {
   onComplete: BatchCompleteCallback;
+  onChangeProgress: BatchProgressChangedCallback;
 
   refX: string;
   refY: string;

--- a/src/view/footer/index.tsx
+++ b/src/view/footer/index.tsx
@@ -3,11 +3,6 @@ import { useStoreValue } from "../../store/store";
 export const Footer = () => {
   // TODO: debounceした方がいいかも
   const progress = useStoreValue("progress");
-  const millis = useStoreValue("millis");
 
-  if (progress !== "100") {
-    return <>Generating... {progress}%</>;
-  }
-
-  return <>Done! time: {millis}ms</>;
+  return <>{progress}</>;
 };

--- a/src/view/right-sidebar/settings.tsx
+++ b/src/view/right-sidebar/settings.tsx
@@ -1,5 +1,4 @@
 import { updateStore, useStoreValue } from "../../store/store";
-import { setWorkerCount } from "../../workers";
 import { DEFAULT_WORKER_COUNT } from "../../store/sync-storage/settings";
 import { Slider } from "@/components/ui/slider";
 import { useState } from "react";
@@ -7,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { readPOIListFromClipboard } from "@/store/sync-storage/poi-list";
 import { useToast } from "@/components/ui/use-toast";
 import { IconCircleCheck } from "@tabler/icons-react";
+import { prepareWorkerPool } from "@/worker-pool/worker-pool";
 
 const createWorkerCountMarks = () => {
   const base = DEFAULT_WORKER_COUNT;
@@ -96,7 +96,7 @@ export const Settings = () => {
           onValueCommit={([value]) => {
             const v = parseInt(workerCountMarks[value].label);
             updateStore("workerCount", v);
-            setWorkerCount();
+            prepareWorkerPool();
           }}
         />
       </div>

--- a/src/worker-pool/worker-facade.ts
+++ b/src/worker-pool/worker-facade.ts
@@ -1,0 +1,154 @@
+import {
+  BatchContext,
+  MandelbrotJob,
+  MandelbrotWorkerType,
+  WorkerIntermediateResult,
+  WorkerProgress,
+  WorkerResult,
+} from "@/types";
+import { workerPaths } from "@/workers";
+
+export type WorkerResultCallback = (
+  result: WorkerResult,
+  job: MandelbrotJob,
+) => void;
+export type WorkerIntermediateResultCallback = (
+  result: WorkerIntermediateResult,
+  job: MandelbrotJob,
+) => void;
+export type WorkerProgressCallback = (
+  progress: WorkerProgress,
+  job: MandelbrotJob,
+) => void;
+export type BatchCompleteCallback = (elapsed: number) => void;
+
+export interface MandelbrotFacadeLike {
+  startCalculate(job: MandelbrotJob, batchContext: BatchContext): void;
+
+  terminate(callback?: () => void): void;
+  terminateAsync(): Promise<void>;
+
+  onResult(callback: WorkerResultCallback): void;
+  onIntermediateResult(callback: WorkerIntermediateResultCallback): void;
+  onProgress(callback: WorkerProgressCallback): void;
+
+  clearCallbacks(): void;
+
+  isRunning(): boolean;
+}
+
+export class WorkerFacade implements MandelbrotFacadeLike {
+  worker: Worker;
+  running = false;
+
+  resultCallback?: WorkerResultCallback;
+  intermediateResultCallback?: WorkerIntermediateResultCallback;
+  progressCallback?: WorkerProgressCallback;
+
+  constructor(workerType: MandelbrotWorkerType) {
+    const workerConstructor = workerPaths[workerType];
+    this.worker = new workerConstructor();
+  }
+
+  isRunning = () => {
+    return this.running;
+  };
+
+  startCalculate = (job: MandelbrotJob, batchContext: BatchContext) => {
+    const f = (
+      ev: MessageEvent<
+        WorkerResult | WorkerIntermediateResult | WorkerProgress
+      >,
+    ) => {
+      const data = ev.data;
+
+      switch (data.type) {
+        case "result": {
+          const { iterations } = data;
+
+          const iterationsResult = new Uint32Array(iterations);
+
+          this.running = false;
+          this.resultCallback?.(
+            { type: "result", iterations: iterationsResult },
+            job,
+          );
+
+          this.worker.removeEventListener("message", f);
+          break;
+        }
+        case "intermediateResult": {
+          const { iterations, resolution } = data;
+          this.intermediateResultCallback?.(
+            {
+              type: "intermediateResult",
+              iterations: new Uint32Array(iterations),
+              resolution,
+            },
+            job,
+          );
+          break;
+        }
+        case "progress": {
+          const { progress } = data;
+          this.progressCallback?.({ type: "progress", progress }, job);
+          break;
+        }
+      }
+    };
+
+    const { rect, mandelbrotParams } = job;
+    const { pixelHeight, pixelWidth, xn, blaTable, refX, refY } = batchContext;
+
+    this.worker.addEventListener("message", f);
+    this.worker.postMessage({
+      cx: mandelbrotParams.x.toString(),
+      cy: mandelbrotParams.y.toString(),
+      r: mandelbrotParams.r.toString(),
+      N: mandelbrotParams.N,
+      pixelHeight,
+      pixelWidth,
+      startX: rect.x,
+      endX: rect.x + rect.width,
+      startY: rect.y,
+      endY: rect.y + rect.height,
+      xn,
+      blaTable,
+      refX,
+      refY,
+    });
+
+    this.running = true;
+  };
+
+  terminate = (callback?: () => void) => {
+    this.worker.terminate();
+    this.running = false;
+    callback?.();
+  };
+
+  terminateAsync = () => {
+    this.running = false;
+    this.worker.terminate();
+
+    return Promise.resolve();
+  };
+
+  onResult = (callback: WorkerResultCallback) => {
+    this.resultCallback = callback;
+  };
+
+  onIntermediateResult = (callback: WorkerIntermediateResultCallback) => {
+    this.intermediateResultCallback = callback;
+  };
+
+  onProgress = (callback: WorkerProgressCallback) => {
+    this.progressCallback = callback;
+  };
+
+  clearCallbacks = () => {
+    this.resultCallback = undefined;
+    this.intermediateResultCallback = undefined;
+    this.progressCallback = undefined;
+  };
+}

--- a/src/worker-pool/worker-facade.ts
+++ b/src/worker-pool/worker-facade.ts
@@ -21,6 +21,7 @@ export type WorkerProgressCallback = (
   job: MandelbrotJob,
 ) => void;
 export type BatchCompleteCallback = (elapsed: number) => void;
+export type BatchProgressChangedCallback = (progressStr: string) => void;
 
 export interface MandelbrotFacadeLike {
   startCalculate(job: MandelbrotJob, batchContext: BatchContext): void;

--- a/src/worker-pool/worker-pool.ts
+++ b/src/worker-pool/worker-pool.ts
@@ -46,7 +46,13 @@ const getLatestBatchContext = () => {
 export const getProgressString = () => {
   const batchContext = getLatestBatchContext();
 
-  if (!batchContext) return "";
+  if (!batchContext) {
+    if (acceptingBatchIds.size > 0) {
+      // FIXME: 超手抜き、Reference Orbitの計算もbatchの中に入れるべき
+      return "Calculating Reference Orbit...";
+    }
+    return "";
+  }
 
   if (batchContext.finishedAt) {
     return `Done! (${Math.floor(

--- a/src/worker-pool/worker-pool.ts
+++ b/src/worker-pool/worker-pool.ts
@@ -25,16 +25,29 @@ type BatchId = string;
 
 const runningWorkerFacadeMap = new Map<JobId, MandelbrotFacadeLike>();
 const batchContextMap = new Map<BatchId, BatchContext>();
+const acceptingBatchIds = new Set<BatchId>();
 
 const onWorkerProgress: WorkerProgressCallback = (result, job) => {
   const { progress } = result;
+  const batchContext = batchContextMap.get(job.batchId);
 
-  batchContextMap.get(job.batchId)?.progressMap?.set(job.id, progress);
+  // 停止が間に合わなかったケース。何もしない
+  if (batchContext == null) {
+    return;
+  }
+
+  batchContext.progressMap.set(job.id, progress);
 };
 
 const onWorkerResult: WorkerResultCallback = (result, job) => {
   const { iterations } = result;
   const { rect } = job;
+  const batchContext = batchContextMap.get(job.batchId);
+
+  // 停止が間に合わなかったケース。何もしない
+  if (batchContext == null) {
+    return;
+  }
 
   const iterationsResult = new Uint32Array(iterations);
   upsertIterationCache(rect, iterationsResult, {
@@ -43,7 +56,7 @@ const onWorkerResult: WorkerResultCallback = (result, job) => {
   });
 
   // jobを完了させる
-  batchContextMap.get(job.batchId)?.progressMap?.set(job.id, 1.0);
+  batchContext.progressMap.set(job.id, 1.0);
   runningList = runningList.filter((j) => j.id !== job.id);
 
   runningWorkerFacadeMap.delete(job.id);
@@ -53,7 +66,6 @@ const onWorkerResult: WorkerResultCallback = (result, job) => {
   // バッチが完了していたらcallbackを呼び、BatchContextを削除する
   // FIXME: waitingListのbatchIdも見る必要がある？
   if (runningList.length === 0 && waitingList.length === 0) {
-    const batchContext = batchContextMap.get(job.batchId)!;
     const elapsed = performance.now() - batchContext.startedAt;
     batchContext.onComplete(elapsed);
     batchContextMap.delete(job.batchId);
@@ -68,6 +80,11 @@ const onWorkerIntermediateResult: WorkerIntermediateResultCallback = (
 ) => {
   const { iterations, resolution } = result;
   const { rect } = job;
+
+  // 停止が間に合わなかったケース。何もしない
+  if (!batchContextMap.has(job.batchId)) {
+    return;
+  }
 
   upsertIterationCache(rect, new Uint32Array(iterations), resolution);
   renderToResultBuffer(rect);
@@ -90,15 +107,16 @@ export const cycleWorkerType = (): MandelbrotWorkerType => {
   return nextMode;
 };
 
-export function prepareWorkerPool(
-  count: number = getStore("workerCount"),
+/**
+ * 指定した数になるまでWorkerPoolを埋める
+ */
+function fillWorkerFacade(
+  upTo: number = getStore("workerCount"),
   workerType: MandelbrotWorkerType = getStore("mode"),
 ) {
-  updateStore("mode", workerType);
+  let fillCount = 0;
 
-  resetWorkers();
-
-  for (let i = 0; i < count; i++) {
+  for (let i = 0; pool.length < upTo && i < upTo; i++) {
     const workerFacade = new WorkerFacade(workerType);
 
     workerFacade.onResult(onWorkerResult);
@@ -106,7 +124,32 @@ export function prepareWorkerPool(
     workerFacade.onProgress(onWorkerProgress);
 
     pool.push(workerFacade);
+
+    fillCount++;
   }
+
+  if (fillCount > 0) {
+    console.info(
+      `Worker filled: fill count = ${fillCount}, pool size = ${pool.length}`,
+    );
+  }
+}
+
+/**
+ * WorkerPoolを再構築する
+ * countやworkerTypeが変わった場合に呼ばれる
+ */
+export function prepareWorkerPool(
+  count: number = getStore("workerCount"),
+  workerType: MandelbrotWorkerType = getStore("mode"),
+) {
+  console.log(`prepareWorkerPool: ${count}, ${workerType}`);
+
+  updateStore("mode", workerType);
+
+  resetWorkers();
+
+  fillWorkerFacade(count, workerType);
 }
 
 /**
@@ -128,10 +171,20 @@ export function resetWorkers() {
 }
 
 export function registerBatch(
+  batchId: BatchId,
   units: MandelbrotRenderingUnit[],
   batchContext: Omit<BatchContext, "progressMap" | "startedAt">,
 ) {
-  const batchId = crypto.randomUUID();
+  console.log("registerBatch", batchId, units.length);
+
+  if (!acceptingBatchIds.has(batchId)) {
+    console.log("Denied: already cancelled. batchId =", batchId);
+    return;
+  }
+  // FIXME: ここじゃないけどprogressを表示できるようにする
+
+  // FIXME: ここじゃないけどworker数と分割数を別にできるようにする
+
   const progressMap = new Map<string, number>();
 
   for (const unit of units) {
@@ -159,6 +212,8 @@ function findFreeWorkerFacade() {
 }
 
 function tick() {
+  const hasWaitingJob = waitingList.length > 0;
+
   while (runningList.length < pool.length && waitingList.length > 0) {
     const job = waitingList.shift()!;
     const workerFacade = findFreeWorkerFacade();
@@ -166,6 +221,12 @@ function tick() {
     if (!workerFacade) break;
 
     start(workerFacade, job);
+  }
+
+  if (hasWaitingJob) {
+    console.info(
+      `running: ${runningList.length}, waiting: ${waitingList.length}`,
+    );
   }
 }
 
@@ -177,24 +238,66 @@ function start(workerFacade: MandelbrotFacadeLike, job: MandelbrotJob) {
   runningWorkerFacadeMap.set(job.id, workerFacade);
 }
 
+export function startBatch(batchId: BatchId) {
+  acceptingBatchIds.add(batchId);
+}
+
+export function isAcceptingBatch(batchId: BatchId) {
+  return acceptingBatchIds.has(batchId);
+}
+
 /**
  * 指定したバッチIDのジョブをキャンセルする
  */
-export async function terminate(batchId: string) {
+export function cancelBatch(batchId: string) {
+  acceptingBatchIds.delete(batchId);
+
   // 待ちリストからは単純に削除
   waitingList = waitingList.filter((job) => job.batchId !== batchId);
 
   const runningJobs = runningList.filter((job) => job.batchId === batchId);
 
-  const promises = runningJobs.map((job) => {
-    const workerFacade = runningWorkerFacadeMap.get(job.id)!;
-    return workerFacade.terminateAsync();
+  console.log("cancelBatch", batchId, runningJobs.length, runningList);
+
+  const facades = runningJobs.map((job) => {
+    const facade = runningWorkerFacadeMap.get(job.id);
+    runningWorkerFacadeMap.delete(job.id);
+
+    return facade;
   });
 
-  await Promise.all(promises);
+  for (const facade of facades) {
+    if (!facade) continue;
+
+    facade.clearCallbacks();
+    facade.terminate();
+  }
+  removeFromPool(facades);
+
+  fillWorkerFacade();
 
   runningList = runningList.filter((job) => job.batchId !== batchId);
   batchContextMap.delete(batchId);
 
   tick();
+}
+
+function removeFromPool(facades: (MandelbrotFacadeLike | undefined)[]) {
+  let removeCount = 0;
+
+  for (const facade of facades) {
+    if (!facade) continue;
+    const index = pool.indexOf(facade);
+
+    if (index !== -1) {
+      pool.splice(index, 1);
+      removeCount++;
+    }
+  }
+
+  if (removeCount > 0) {
+    console.info(
+      `Worker removed: remove count = ${removeCount}, pool size = ${pool.length}`,
+    );
+  }
 }

--- a/src/worker-pool/worker-pool.ts
+++ b/src/worker-pool/worker-pool.ts
@@ -221,9 +221,6 @@ export function registerBatch(
     console.log("Denied: already cancelled. batchId =", batchId);
     return;
   }
-  // FIXME: ここじゃないけどprogressを表示できるようにする
-
-  // FIXME: ここじゃないけどworker数と分割数を別にできるようにする
 
   const progressMap = new Map<string, number>();
 

--- a/src/worker-pool/worker-pool.ts
+++ b/src/worker-pool/worker-pool.ts
@@ -77,10 +77,11 @@ const onWorkerResult: WorkerResultCallback = (result, job) => {
   renderToResultBuffer(rect);
 
   // バッチが完了していたらcallbackを呼び、BatchContextを削除する
-  const waitingListInSameBatch = waitingList.find(
-    (j) => j.batchId !== job.batchId,
+  const waitingJobInSameBatch = waitingList.find(
+    (j) => j.batchId === job.batchId,
   );
-  if (runningList.length === 0 && waitingListInSameBatch == null) {
+
+  if (runningList.length === 0 && waitingJobInSameBatch == null) {
     const elapsed = performance.now() - batchContext.startedAt;
     batchContext.onComplete(elapsed);
     batchContextMap.delete(job.batchId);

--- a/src/worker-pool/worker-pool.ts
+++ b/src/worker-pool/worker-pool.ts
@@ -1,0 +1,200 @@
+import {
+  BatchContext,
+  MandelbrotJob,
+  MandelbrotRenderingUnit,
+  MandelbrotWorkerType,
+  mandelbrotWorkerTypes,
+} from "@/types";
+import {
+  WorkerIntermediateResultCallback,
+  WorkerProgressCallback,
+  WorkerResultCallback,
+  WorkerFacade,
+  MandelbrotFacadeLike,
+} from "./worker-facade";
+import { upsertIterationCache } from "@/aggregator";
+import { renderToResultBuffer } from "@/camera";
+import { getStore, updateStore } from "@/store/store";
+
+let waitingList: MandelbrotJob[] = [];
+let runningList: MandelbrotJob[] = [];
+let pool: MandelbrotFacadeLike[] = [];
+
+type JobId = string;
+type BatchId = string;
+
+const runningWorkerFacadeMap = new Map<JobId, MandelbrotFacadeLike>();
+const batchContextMap = new Map<BatchId, BatchContext>();
+
+const onWorkerProgress: WorkerProgressCallback = (result, job) => {
+  const { progress } = result;
+
+  batchContextMap.get(job.batchId)?.progressMap?.set(job.id, progress);
+};
+
+const onWorkerResult: WorkerResultCallback = (result, job) => {
+  const { iterations } = result;
+  const { rect } = job;
+
+  const iterationsResult = new Uint32Array(iterations);
+  upsertIterationCache(rect, iterationsResult, {
+    width: rect.width,
+    height: rect.height,
+  });
+
+  // jobを完了させる
+  batchContextMap.get(job.batchId)?.progressMap?.set(job.id, 1.0);
+  runningList = runningList.filter((j) => j.id !== job.id);
+
+  runningWorkerFacadeMap.delete(job.id);
+
+  renderToResultBuffer(rect);
+
+  // バッチが完了していたらcallbackを呼び、BatchContextを削除する
+  // FIXME: waitingListのbatchIdも見る必要がある？
+  if (runningList.length === 0 && waitingList.length === 0) {
+    const batchContext = batchContextMap.get(job.batchId)!;
+    const elapsed = performance.now() - batchContext.startedAt;
+    batchContext.onComplete(elapsed);
+    batchContextMap.delete(job.batchId);
+  }
+
+  tick();
+};
+
+const onWorkerIntermediateResult: WorkerIntermediateResultCallback = (
+  result,
+  job,
+) => {
+  const { iterations, resolution } = result;
+  const { rect } = job;
+
+  upsertIterationCache(rect, new Uint32Array(iterations), resolution);
+  renderToResultBuffer(rect);
+};
+
+export const getWorkerCount = (): number => {
+  return pool.length;
+};
+
+export const cycleWorkerType = (): MandelbrotWorkerType => {
+  const currentMode = getStore("mode");
+
+  const currentIndex = mandelbrotWorkerTypes.findIndex(
+    (v) => v === currentMode,
+  );
+
+  const nextMode =
+    mandelbrotWorkerTypes[(currentIndex + 1) % mandelbrotWorkerTypes.length];
+
+  return nextMode;
+};
+
+export function prepareWorkerPool(
+  count: number = getStore("workerCount"),
+  workerType: MandelbrotWorkerType = getStore("mode"),
+) {
+  updateStore("mode", workerType);
+
+  resetWorkers();
+
+  for (let i = 0; i < count; i++) {
+    const workerFacade = new WorkerFacade(workerType);
+
+    workerFacade.onResult(onWorkerResult);
+    workerFacade.onIntermediateResult(onWorkerIntermediateResult);
+    workerFacade.onProgress(onWorkerProgress);
+
+    pool.push(workerFacade);
+  }
+}
+
+/**
+ * WorkerPoolを溜まっていたJobごと全部リセットする
+ */
+export function resetWorkers() {
+  pool.forEach((workerFacade) => {
+    workerFacade.clearCallbacks();
+    workerFacade.terminate();
+  });
+  pool = [];
+
+  // queueに溜まってるJobも全部消す
+  runningList = [];
+  waitingList = [];
+
+  runningWorkerFacadeMap.clear();
+  batchContextMap.clear();
+}
+
+export function registerBatch(
+  units: MandelbrotRenderingUnit[],
+  batchContext: Omit<BatchContext, "progressMap" | "startedAt">,
+) {
+  const batchId = crypto.randomUUID();
+  const progressMap = new Map<string, number>();
+
+  for (const unit of units) {
+    const job = {
+      ...unit,
+      id: crypto.randomUUID(),
+      batchId,
+    };
+
+    waitingList.push(job);
+    progressMap.set(job.id, 0);
+  }
+
+  batchContextMap.set(batchId, {
+    ...batchContext,
+    progressMap,
+    startedAt: performance.now(),
+  });
+
+  tick();
+}
+
+function findFreeWorkerFacade() {
+  return pool.find((worker) => !worker.isRunning());
+}
+
+function tick() {
+  while (runningList.length < pool.length && waitingList.length > 0) {
+    const job = waitingList.shift()!;
+    const workerFacade = findFreeWorkerFacade();
+
+    if (!workerFacade) break;
+
+    start(workerFacade, job);
+  }
+}
+
+function start(workerFacade: MandelbrotFacadeLike, job: MandelbrotJob) {
+  const batchContext = batchContextMap.get(job.batchId)!;
+  workerFacade.startCalculate(job, batchContext);
+
+  runningList.push(job);
+  runningWorkerFacadeMap.set(job.id, workerFacade);
+}
+
+/**
+ * 指定したバッチIDのジョブをキャンセルする
+ */
+export async function terminate(batchId: string) {
+  // 待ちリストからは単純に削除
+  waitingList = waitingList.filter((job) => job.batchId !== batchId);
+
+  const runningJobs = runningList.filter((job) => job.batchId === batchId);
+
+  const promises = runningJobs.map((job) => {
+    const workerFacade = runningWorkerFacadeMap.get(job.id)!;
+    return workerFacade.terminateAsync();
+  });
+
+  await Promise.all(promises);
+
+  runningList = runningList.filter((job) => job.batchId !== batchId);
+  batchContextMap.delete(batchId);
+
+  tick();
+}

--- a/src/workers.ts
+++ b/src/workers.ts
@@ -25,35 +25,36 @@ export const workerPaths: Record<MandelbrotWorkerType, new () => Worker> = {
   perturbation: MandelbrotPerturbationWorker,
 };
 
-export const currentWorkerType = (): MandelbrotWorkerType => _currentWorkerType;
+export const deprecated_currentWorkerType = (): MandelbrotWorkerType =>
+  _currentWorkerType;
 
-export const cycleWorkerType = (): MandelbrotWorkerType => {
+export const deprecated_cycleWorkerType = (): MandelbrotWorkerType => {
   const currentIndex = mandelbrotWorkerTypes.findIndex(
     (v) => v === _currentWorkerType,
   );
   _currentWorkerType =
     mandelbrotWorkerTypes[(currentIndex + 1) % mandelbrotWorkerTypes.length];
 
-  resetWorkers();
+  deprecated_resetWorkers();
   return _currentWorkerType;
 };
 
-export const setWorkerType = (type: MandelbrotWorkerType): void => {
+export const deprecated_setWorkerType = (type: MandelbrotWorkerType): void => {
   _currentWorkerType = type;
-  resetWorkers();
+  deprecated_resetWorkers();
 };
 
-export const setWorkerCount = (
+export const deprecated_setWorkerCount = (
   count: number = getStore("workerCount"),
 ): void => {
   _workerCount = count;
 };
 
-export const getWorkerCount = (): number => _workerCount;
+export const deprecated_getWorkerCount = (): number => _workerCount;
 
 export const activeWorkerCount = (): number => _activeWorkerCount;
 
-export const resetWorkers = (): void => {
+export const deprecated_resetWorkers = (): void => {
   _workers.forEach((worker) => worker.terminate());
   _workers.splice(0);
 
@@ -63,9 +64,9 @@ export const resetWorkers = (): void => {
   }
 };
 
-export const terminateWorkers = (): void => {
+export const deprecated_terminateWorkers = (): void => {
   _workers.forEach((worker) => worker.terminate());
-  resetWorkers();
+  deprecated_resetWorkers();
 };
 
 export const registerWorkerTask = (

--- a/src/workers.ts
+++ b/src/workers.ts
@@ -2,97 +2,17 @@ import {
   MandelbrotWorkerType,
   ReferencePointCalculationWorkerParams,
   ReferencePointResult,
-  mandelbrotWorkerTypes,
 } from "./types";
 import MandelbrotWorker from "./workers/mandelbrot-worker?worker&inline";
 import MandelbrotPerturbationWorker from "./workers/mandelbrot-perturbation-worker?worker&inline";
 import CalcReferencePointWorker from "./workers/calc-reference-point?worker&inline";
-import { Rect } from "./rect";
-import { getStore } from "./store/store";
 import { ReferencePointContext } from "./workers/calc-reference-point";
 
-// 処理領域の分割しやすさの関係でワーカーの数は1または偶数に制限しておく
-const DEFAULT_WORKER_COUNT = 16;
-
-const _workers: Worker[] = [];
-let _currentWorkerType: MandelbrotWorkerType = "normal";
-let _workerCount = DEFAULT_WORKER_COUNT;
-let _activeWorkerCount = _workers.length;
 let _referencePointWorker: Worker;
 
 export const workerPaths: Record<MandelbrotWorkerType, new () => Worker> = {
   normal: MandelbrotWorker,
   perturbation: MandelbrotPerturbationWorker,
-};
-
-export const deprecated_currentWorkerType = (): MandelbrotWorkerType =>
-  _currentWorkerType;
-
-export const deprecated_cycleWorkerType = (): MandelbrotWorkerType => {
-  const currentIndex = mandelbrotWorkerTypes.findIndex(
-    (v) => v === _currentWorkerType,
-  );
-  _currentWorkerType =
-    mandelbrotWorkerTypes[(currentIndex + 1) % mandelbrotWorkerTypes.length];
-
-  deprecated_resetWorkers();
-  return _currentWorkerType;
-};
-
-export const deprecated_setWorkerType = (type: MandelbrotWorkerType): void => {
-  _currentWorkerType = type;
-  deprecated_resetWorkers();
-};
-
-export const deprecated_setWorkerCount = (
-  count: number = getStore("workerCount"),
-): void => {
-  _workerCount = count;
-};
-
-export const deprecated_getWorkerCount = (): number => _workerCount;
-
-export const activeWorkerCount = (): number => _activeWorkerCount;
-
-export const deprecated_resetWorkers = (): void => {
-  _workers.forEach((worker) => worker.terminate());
-  _workers.splice(0);
-
-  for (let i = 0; i < _workerCount; i++) {
-    const workerConstructor = workerPaths[_currentWorkerType];
-    _workers.push(new workerConstructor());
-  }
-};
-
-export const deprecated_terminateWorkers = (): void => {
-  _workers.forEach((worker) => worker.terminate());
-  deprecated_resetWorkers();
-};
-
-export const registerWorkerTask = (
-  calculationRects: Rect[],
-  f: (
-    worker: Worker,
-    rect: Rect,
-    idx: number,
-    workers: Worker[],
-    isCompleted: (completed: number) => boolean,
-  ) => void,
-): void => {
-  _activeWorkerCount = calculationRects.length;
-
-  for (let i = 0; i < calculationRects.length; i++) {
-    const rect = calculationRects[i];
-    const worker = _workers[i];
-
-    f(
-      worker,
-      rect,
-      i,
-      _workers,
-      (completed) => completed >= calculationRects.length,
-    );
-  }
 };
 
 export async function referencePointWorker() {


### PR DESCRIPTION
## WorkerPool
queueにJobを溜められるようになったので、画面分割数とworker数を分離することができるようになった
今のところ画面分割数を変える術はないので、worker数1のときに画面移動したときにしか恩恵を受けられない
低画質プレビューもあるから、表示に関してはworker数＝画面分割数がいちばん良い

## WorkerFacade
WebWorker以外に誰が計算するんだよという感じだが、
ネットワーク越しに激強PCに計算してもらって結果だけもらえるようにする野望があるので
インターフェースだけ切っておいた

## 感想
- `startCalculation` がだいぶ行数減った
   - 領域分割やreference orbitの計算コードもここに書くべきではないので後ほど移動する
- ファイル＝モジュールみたいな扱い方をしていてimportが節操なくなってきたのでどうにかしたい

## スクリーンショット
分割数を256, worker数を1にしたときの切り替え

https://github.com/k-chop/p5mandelbrot/assets/241973/763789f6-972d-4491-afef-873ca772707d