### PR TITLE
worker起動時のコストを減らすため、ReferencePointの計算結果をBufferにしてから各workerへ渡す

### DIFF
--- a/src/lib/bla-table-item-buffer.ts
+++ b/src/lib/bla-table-item-buffer.ts
@@ -1,0 +1,93 @@
+import { BLATableItem } from "@/math";
+
+const ITEM_BYTE_LENGTH = 44;
+
+// このファイルはほとんどChatGPTくんによって生成されました
+
+export function blaTableItemToBuffer(item: BLATableItem): ArrayBuffer {
+  const buffer = new ArrayBuffer(ITEM_BYTE_LENGTH);
+  const floatView = new Float64Array(buffer, 0, 5); // 8 bytes * 5
+  const intView = new Int32Array(buffer, 40, 1); // 4 bytes
+
+  floatView[0] = item.a.re;
+  floatView[1] = item.a.im;
+  floatView[2] = item.b.re;
+  floatView[3] = item.b.im;
+  floatView[4] = item.r;
+  intView[0] = item.l;
+
+  return buffer;
+}
+
+export function bufferToBLATableItem(buffer: ArrayBuffer): BLATableItem {
+  const floatView = new Float64Array(buffer, 0, 5);
+  const intView = new Int32Array(buffer, 40, 1);
+
+  return {
+    a: { re: floatView[0], im: floatView[1] },
+    b: { re: floatView[2], im: floatView[3] },
+    r: floatView[4],
+    l: intView[0],
+  };
+}
+
+export function blaTableItemsToBuffer(items: BLATableItem[][]): ArrayBuffer {
+  // 行の数と、それぞれの行の要素数を格納するのに必要なバイト数を加算
+  let totalSize = 4; // 最初の4バイトは行の数
+  items.forEach((row) => {
+    totalSize += 4; // 各行の要素数を格納するための4バイト
+    totalSize += row.length * ITEM_BYTE_LENGTH; // 実際の各行のデータ
+  });
+
+  const buffer = new ArrayBuffer(totalSize);
+  const view = new Int32Array(buffer);
+
+  // 最初のエントリに行の数を設定
+  view[0] = items.length;
+  let offset = 1; // Int32のエントリとしてのオフセット
+
+  items.forEach((row) => {
+    view[offset] = row.length; // 各行の要素数を設定
+    offset += 1; // 次の要素数のためにオフセットを1つ進める
+
+    row.forEach((item) => {
+      const itemBuffer = blaTableItemToBuffer(item);
+      // Int32のエントリではなく、バイトとしてのオフセットを計算する必要がある
+      const byteOffset = offset * 4;
+      new Uint8Array(buffer, byteOffset, ITEM_BYTE_LENGTH).set(
+        new Uint8Array(itemBuffer),
+      );
+      offset += ITEM_BYTE_LENGTH / 4; // 次のアイテムのためにオフセットをアイテムのバイト長分進める
+    });
+  });
+
+  return buffer;
+}
+
+export function bufferToBLATableItems(buffer: ArrayBuffer): BLATableItem[][] {
+  const view = new Int32Array(buffer);
+  const rows = view[0]; // 最初のエントリは行の数
+  const items: BLATableItem[][] = [];
+
+  let offset = 1; // Int32のエントリとしてのオフセット
+
+  for (let i = 0; i < rows; i++) {
+    const rowLength = view[offset];
+    const rowItems: BLATableItem[] = [];
+    offset += 1; // 次の要素数のためにオフセットを1つ進める
+
+    for (let j = 0; j < rowLength; j++) {
+      // Int32のエントリではなく、バイトとしてのオフセットを計算する
+      const byteOffset = offset * 4;
+      const itemBuffer = buffer.slice(
+        byteOffset,
+        byteOffset + ITEM_BYTE_LENGTH,
+      );
+      rowItems.push(bufferToBLATableItem(itemBuffer));
+      offset += ITEM_BYTE_LENGTH / 4; // 次のアイテムのためにオフセットをアイテムのバイト長分進める
+    }
+    items.push(rowItems);
+  }
+
+  return items;
+}

--- a/src/lib/xn-buffer.ts
+++ b/src/lib/xn-buffer.ts
@@ -1,0 +1,28 @@
+import { Complex } from "@/math";
+
+const COMPLEX_BYTE_LENGTH = 16;
+
+// このファイルはほとんどChatGPTくんによって生成されました
+
+export function complexArrayToBuffer(complexArray: Complex[]): ArrayBuffer {
+  const buffer = new ArrayBuffer(complexArray.length * COMPLEX_BYTE_LENGTH);
+  const view = new Float64Array(buffer);
+
+  complexArray.forEach((complex, index) => {
+    view[index * 2] = complex.re;
+    view[index * 2 + 1] = complex.im;
+  });
+
+  return buffer;
+}
+
+export function bufferToComplexArray(buffer: ArrayBuffer): Complex[] {
+  const complexArray: Complex[] = [];
+  const view = new Float64Array(buffer);
+
+  for (let i = 0; i < view.length; i += 2) {
+    complexArray.push({ re: view[i], im: view[i + 1] });
+  }
+
+  return complexArray;
+}

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -6,7 +6,12 @@ import {
 import { BLATableItem, Complex } from "./math";
 import { divideRect, Rect } from "./rect";
 import { updateStore, getStore } from "./store/store";
-import { MandelbrotParams, OffsetParams } from "./types";
+import {
+  BLATableBuffer,
+  MandelbrotParams,
+  OffsetParams,
+  XnBuffer,
+} from "./types";
 import { calcReferencePointWithWorker } from "./workers";
 import {
   cancelBatch,
@@ -41,13 +46,13 @@ let height = DEFAULT_HEIGHT;
 const lastReferenceCache: {
   x: BigNumber;
   y: BigNumber;
-  xn: Complex[];
-  blaTable: BLATableItem[][];
+  xn: XnBuffer;
+  blaTable: BLATableBuffer;
 } = {
   x: new BigNumber(0),
   y: new BigNumber(0),
-  xn: [],
-  blaTable: [],
+  xn: new ArrayBuffer(0),
+  blaTable: new ArrayBuffer(0),
 };
 
 let isReferencePinned = false;
@@ -232,7 +237,7 @@ export const startCalculation = async (onComplete: () => void) => {
 
   const calcReferencePoint = async () => {
     if (currentParams.mode !== "perturbation") {
-      return { xn: [], blaTable: [] };
+      return { xn: new ArrayBuffer(0), blaTable: new ArrayBuffer(0) };
     }
 
     if (isReferencePinned) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,8 +29,8 @@ export interface WorkerProgress {
 
 export interface ReferencePointResult {
   type: "result";
-  xn: Complex[];
-  blaTable: BLATableItem[][];
+  xn: XnBuffer;
+  blaTable: BLATableBuffer;
 }
 
 export interface OffsetParams {
@@ -61,11 +61,14 @@ export interface MandelbrotCalculationWorkerParams {
   endX: number;
   startY: number;
   endY: number;
-  xn: Complex[];
-  blaTable: BLATableItem[][];
+  xn: XnBuffer;
+  blaTable: BLATableBuffer;
   refX: string;
   refY: string;
 }
+
+export type XnBuffer = ArrayBuffer;
+export type BLATableBuffer = ArrayBuffer;
 
 export interface ReferencePointCalculationWorkerParams {
   complexCenterX: string;
@@ -103,8 +106,8 @@ export interface BatchContext {
   refY: string;
   pixelWidth: number;
   pixelHeight: number;
-  xn: Complex[];
-  blaTable: BLATableItem[][];
+  xn: XnBuffer;
+  blaTable: BLATableBuffer;
 
   progressMap: Map<string, number>;
   startedAt: number;

--- a/src/worker-pool/worker-pool.ts
+++ b/src/worker-pool/worker-pool.ts
@@ -289,6 +289,13 @@ export function isAcceptingBatch(batchId: BatchId) {
   return acceptingBatchIds.has(batchId);
 }
 
+// 範囲分割、reference orbitの計算をバッチではないことにしたため、いびつな対応が必要になった
+// これらをバッチの一部として含めることで、なんとかなる？
+// 各処理の中でawaitしつつ処理を止められたかどうかを確認していく？
+// どっちにしろ時間かかる処理はawaitするしかない
+// あとはJobの依存関係を定義して、積むのは一気にやっちゃう・・・？
+// 一気に積めば、処理途中のことを考えなくていい
+
 /**
  * 指定したバッチIDのジョブをキャンセルする
  */

--- a/src/workers/calc-reference-point.ts
+++ b/src/workers/calc-reference-point.ts
@@ -18,14 +18,20 @@ import {
   toComplex,
 } from "../math";
 import { pixelToComplexCoordinateComplexArbitrary } from "../math/complex-plane";
-import { ReferencePointCalculationWorkerParams } from "../types";
-import { bufferToComplexArray, complexArrayToBuffer } from "@/lib/xn-buffer";
 import {
-  blaTableItemsToBuffer,
-  bufferToBLATableItems,
-} from "@/lib/bla-table-item-buffer";
+  ReferencePointCalculationWorkerParams,
+  XnBuffer,
+  BLATableBuffer,
+} from "../types";
+import { complexArrayToBuffer } from "@/lib/xn-buffer";
+import { blaTableItemsToBuffer } from "@/lib/bla-table-item-buffer";
 
 export type ReferencePointContext = {
+  xn: XnBuffer;
+  blaTable: BLATableBuffer;
+};
+
+export type ReferencePointContextPopulated = {
   xn: Complex[];
   blaTable: BLATableItem[][];
 };
@@ -33,7 +39,7 @@ export type ReferencePointContext = {
 function calcReferencePoint(
   center: ComplexArbitrary,
   maxIteration: number,
-): Omit<ReferencePointContext, "blaTable"> {
+): { xn: Complex[] } {
   // [re_0, im_0, re_1, im_1, ...]
   const xnn = new Float64Array(maxIteration * 2);
 
@@ -152,10 +158,8 @@ async function setup() {
     const pixelSpacing = radius.toNumber() / Math.max(pixelWidth, pixelHeight);
     const blaTable = calcBLACoefficient(xn, pixelSpacing);
 
-    const xnConverted = bufferToComplexArray(complexArrayToBuffer(xn));
-    const blaTableConverted = bufferToBLATableItems(
-      blaTableItemsToBuffer(blaTable),
-    );
+    const xnConverted = complexArrayToBuffer(xn);
+    const blaTableConverted = blaTableItemsToBuffer(blaTable);
 
     self.postMessage({
       type: "result",

--- a/src/workers/calc-reference-point.ts
+++ b/src/workers/calc-reference-point.ts
@@ -19,6 +19,11 @@ import {
 } from "../math";
 import { pixelToComplexCoordinateComplexArbitrary } from "../math/complex-plane";
 import { ReferencePointCalculationWorkerParams } from "../types";
+import { bufferToComplexArray, complexArrayToBuffer } from "@/lib/xn-buffer";
+import {
+  blaTableItemsToBuffer,
+  bufferToBLATableItems,
+} from "@/lib/bla-table-item-buffer";
 
 export type ReferencePointContext = {
   xn: Complex[];
@@ -147,7 +152,16 @@ async function setup() {
     const pixelSpacing = radius.toNumber() / Math.max(pixelWidth, pixelHeight);
     const blaTable = calcBLACoefficient(xn, pixelSpacing);
 
-    self.postMessage({ type: "result", xn, blaTable });
+    const xnConverted = bufferToComplexArray(complexArrayToBuffer(xn));
+    const blaTableConverted = bufferToBLATableItems(
+      blaTableItemsToBuffer(blaTable),
+    );
+
+    self.postMessage({
+      type: "result",
+      xn: xnConverted,
+      blaTable: blaTableConverted,
+    });
   });
 }
 

--- a/src/workers/mandelbrot-perturbation-worker.ts
+++ b/src/workers/mandelbrot-perturbation-worker.ts
@@ -13,7 +13,9 @@ import {
 } from "../math";
 import { pixelToComplexCoordinateComplexArbitrary } from "../math/complex-plane";
 import { MandelbrotCalculationWorkerParams } from "../types";
-import { ReferencePointContext } from "./calc-reference-point";
+import { ReferencePointContextPopulated } from "./calc-reference-point";
+import { bufferToComplexArray } from "@/lib/xn-buffer";
+import { bufferToBLATableItems } from "@/lib/bla-table-item-buffer";
 
 self.addEventListener("message", (event) => {
   const {
@@ -27,11 +29,14 @@ self.addEventListener("message", (event) => {
     endX,
     startY,
     endY,
-    xn,
-    blaTable,
+    xn: xnBuffer,
+    blaTable: blaTableBuffer,
     refX,
     refY,
   } = event.data as MandelbrotCalculationWorkerParams;
+
+  const xn = bufferToComplexArray(xnBuffer);
+  const blaTable = bufferToBLATableItems(blaTableBuffer);
 
   const areaWidth = endX - startX;
   const areaHeight = endY - startY;
@@ -45,7 +50,7 @@ self.addEventListener("message", (event) => {
   function calcIterationAt(
     pixelX: number,
     pixelY: number,
-    context: ReferencePointContext,
+    context: ReferencePointContextPopulated,
   ): number {
     const { xn, blaTable } = context;
     const maxRefIteration = xn.length - 1;


### PR DESCRIPTION
workerのprofiler

|before|after|
|----|----|
|[![Image from Gyazo](https://i.gyazo.com/60d61d2b807506401bb6fdc10b5192b6.png)](https://gyazo.com/60d61d2b807506401bb6fdc10b5192b6)|[![Image from Gyazo](https://i.gyazo.com/53c8e70e50405d90365044868c5abae2.png)](https://gyazo.com/53c8e70e50405d90365044868c5abae2)|

ArrayBufferなので転送前のstructuredCloneのコストが減り、転送後の変換コストが増えた
beforeでは各workerの起動に100msごとかかっていたが、afterでは10ms程度
このPRでは描画にかかる時間は変化しないが、workerへの転送コストが減ったため起動自体はほぼ同時になった

このあとSharedArrayBufferを使うか、ReadableStreamをtransferして・・・と思っていたが、
現状でほぼ転送コストはない気がするのでそこまでやんなくてもいいかなぁ・・・

worker側でいったん全部変換するのにそこそこかかっているので、次は全変換せずに必要な分だけ取り出すのを試してみるかも