### PR TITLE
blaTableのdecode処理を400msほど高速化

### DIFF
--- a/src/lib/bla-table-item-buffer.ts
+++ b/src/lib/bla-table-item-buffer.ts
@@ -4,7 +4,7 @@ const ITEM_BYTE_LENGTH = 44;
 
 // このファイルはほとんどChatGPTくんによって生成されました
 
-export function blaTableItemToBuffer(item: BLATableItem): ArrayBuffer {
+export function encodeBlaTableItem(item: BLATableItem): ArrayBuffer {
   const buffer = new ArrayBuffer(ITEM_BYTE_LENGTH);
   const floatView = new Float64Array(buffer, 0, 5); // 8 bytes * 5
   const intView = new Int32Array(buffer, 40, 1); // 4 bytes
@@ -19,7 +19,7 @@ export function blaTableItemToBuffer(item: BLATableItem): ArrayBuffer {
   return buffer;
 }
 
-export function bufferToBLATableItem(
+export function decodeBLATableItem(
   view: DataView,
   offset: number,
 ): BLATableItem {
@@ -38,7 +38,7 @@ export function bufferToBLATableItem(
   };
 }
 
-export function blaTableItemsToBuffer(items: BLATableItem[][]): ArrayBuffer {
+export function encodeBlaTableItems(items: BLATableItem[][]): ArrayBuffer {
   // 行の数と、それぞれの行の要素数を格納するのに必要なバイト数を加算
   let totalSize = 4; // 最初の4バイトは行の数
   items.forEach((row) => {
@@ -58,7 +58,7 @@ export function blaTableItemsToBuffer(items: BLATableItem[][]): ArrayBuffer {
     offset += 1; // 次の要素数のためにオフセットを1つ進める
 
     row.forEach((item) => {
-      const itemBuffer = blaTableItemToBuffer(item);
+      const itemBuffer = encodeBlaTableItem(item);
       // Int32のエントリではなく、バイトとしてのオフセットを計算する必要がある
       const byteOffset = offset * 4;
       new Uint8Array(buffer, byteOffset, ITEM_BYTE_LENGTH).set(
@@ -71,7 +71,7 @@ export function blaTableItemsToBuffer(items: BLATableItem[][]): ArrayBuffer {
   return buffer;
 }
 
-export function bufferToBLATableItems(buffer: ArrayBuffer): BLATableItem[][] {
+export function decodeBLATableItems(buffer: ArrayBuffer): BLATableItem[][] {
   const view = new DataView(buffer);
   const rows = view.getInt32(0, true); // 最初のエントリは行の数
   const items: BLATableItem[][] = [];
@@ -87,7 +87,7 @@ export function bufferToBLATableItems(buffer: ArrayBuffer): BLATableItem[][] {
       // Int32のエントリではなく、バイトとしてのオフセットを計算する
       const byteOffset = offset * 4;
 
-      rowItems.push(bufferToBLATableItem(view, byteOffset));
+      rowItems.push(decodeBLATableItem(view, byteOffset));
       offset += ITEM_BYTE_LENGTH / 4; // 次のアイテムのためにオフセットをアイテムのバイト長分進める
     }
     items.push(rowItems);

--- a/src/lib/xn-buffer.ts
+++ b/src/lib/xn-buffer.ts
@@ -4,7 +4,7 @@ const COMPLEX_BYTE_LENGTH = 16;
 
 // このファイルはほとんどChatGPTくんによって生成されました
 
-export function complexArrayToBuffer(complexArray: Complex[]): ArrayBuffer {
+export function encodeComplexArray(complexArray: Complex[]): ArrayBuffer {
   const buffer = new ArrayBuffer(complexArray.length * COMPLEX_BYTE_LENGTH);
   const view = new Float64Array(buffer);
 
@@ -16,7 +16,7 @@ export function complexArrayToBuffer(complexArray: Complex[]): ArrayBuffer {
   return buffer;
 }
 
-export function bufferToComplexArray(buffer: ArrayBuffer): Complex[] {
+export function decodeComplexArray(buffer: ArrayBuffer): Complex[] {
   const complexArray: Complex[] = [];
   const view = new Float64Array(buffer);
 

--- a/src/workers/calc-reference-point.ts
+++ b/src/workers/calc-reference-point.ts
@@ -23,8 +23,8 @@ import {
   XnBuffer,
   BLATableBuffer,
 } from "../types";
-import { complexArrayToBuffer } from "@/lib/xn-buffer";
-import { blaTableItemsToBuffer } from "@/lib/bla-table-item-buffer";
+import { encodeComplexArray } from "@/lib/xn-buffer";
+import { encodeBlaTableItems } from "@/lib/bla-table-item-buffer";
 
 export type ReferencePointContext = {
   xn: XnBuffer;
@@ -158,8 +158,8 @@ async function setup() {
     const pixelSpacing = radius.toNumber() / Math.max(pixelWidth, pixelHeight);
     const blaTable = calcBLACoefficient(xn, pixelSpacing);
 
-    const xnConverted = complexArrayToBuffer(xn);
-    const blaTableConverted = blaTableItemsToBuffer(blaTable);
+    const xnConverted = encodeComplexArray(xn);
+    const blaTableConverted = encodeBlaTableItems(blaTable);
 
     self.postMessage({
       type: "result",

--- a/src/workers/mandelbrot-perturbation-worker.ts
+++ b/src/workers/mandelbrot-perturbation-worker.ts
@@ -14,8 +14,8 @@ import {
 import { pixelToComplexCoordinateComplexArbitrary } from "../math/complex-plane";
 import { MandelbrotCalculationWorkerParams } from "../types";
 import { ReferencePointContextPopulated } from "./calc-reference-point";
-import { bufferToComplexArray } from "@/lib/xn-buffer";
-import { bufferToBLATableItems } from "@/lib/bla-table-item-buffer";
+import { decodeComplexArray } from "@/lib/xn-buffer";
+import { decodeBLATableItems } from "@/lib/bla-table-item-buffer";
 
 self.addEventListener("message", (event) => {
   const {
@@ -35,8 +35,8 @@ self.addEventListener("message", (event) => {
     refY,
   } = event.data as MandelbrotCalculationWorkerParams;
 
-  const xn = bufferToComplexArray(xnBuffer);
-  const blaTable = bufferToBLATableItems(blaTableBuffer);
+  const xn = decodeComplexArray(xnBuffer);
+  const blaTable = decodeBLATableItems(blaTableBuffer);
 
   const areaWidth = endX - startX;
   const areaHeight = endY - startY;


### PR DESCRIPTION
## 概要
- 1エントリdeocdeするたびにTypedArray作ってたり、無駄にsliceしていた箇所を修正
     - DataViewを最初に1つ作ってあとはそれ経由でdecodeするようにした
     - N=45000でも80000要素くらいあるのでちゃんと効いた

## 比較

|before|after|
|----|----|
|[![Image from Gyazo](https://i.gyazo.com/9aea39e98c7be0e7074ba7372069bb09.png)](https://gyazo.com/9aea39e98c7be0e7074ba7372069bb09)|[![Image from Gyazo](https://i.gyazo.com/6cf1919bc253a952d7758ee78ad8210d.png)](https://gyazo.com/6cf1919bc253a952d7758ee78ad8210d)|

全体の生成時間も200~300msくらいは減った