### PR TITLE
計算途中のworkerをterminateを使わずにキャンセルできるようにした

### DIFF
--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -281,6 +281,8 @@ export const startCalculation = async (onComplete: () => void) => {
     mandelbrotParams: currentParams,
   }));
 
+  const terminator = new SharedArrayBuffer(units.length);
+
   registerBatch(currentBatchId, units, {
     onComplete,
     onChangeProgress: () => {},
@@ -290,6 +292,7 @@ export const startCalculation = async (onComplete: () => void) => {
     pixelHeight: height,
     xn,
     blaTable,
+    terminator,
   });
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,6 +99,8 @@ export interface MandelbrotRenderingUnit {
 export interface MandelbrotJob extends MandelbrotRenderingUnit {
   id: string;
   batchId: string;
+  // jobが実際に走るタイミングで設定される
+  workerIdx?: number;
 }
 
 export interface BatchContext {

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,6 +66,8 @@ export interface MandelbrotCalculationWorkerParams {
   refX: string;
   refY: string;
   jobId: string;
+  terminator: SharedArrayBuffer;
+  workerIdx: number;
 }
 
 export type XnBuffer = ArrayBuffer;
@@ -109,6 +111,7 @@ export interface BatchContext {
   pixelHeight: number;
   xn: XnBuffer;
   blaTable: BLATableBuffer;
+  terminator: SharedArrayBuffer;
 
   progressMap: Map<string, number>;
   startedAt: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,6 +65,7 @@ export interface MandelbrotCalculationWorkerParams {
   blaTable: BLATableBuffer;
   refX: string;
   refY: string;
+  jobId: string;
 }
 
 export type XnBuffer = ArrayBuffer;

--- a/src/worker-pool/worker-facade.ts
+++ b/src/worker-pool/worker-facade.ts
@@ -33,6 +33,8 @@ export interface MandelbrotFacadeLike {
   terminate(callback?: () => void): void;
   terminateAsync(): Promise<void>;
 
+  cancel(batchContext: BatchContext, job: MandelbrotJob): void;
+
   onResult(callback: WorkerResultCallback): void;
   onIntermediateResult(callback: WorkerIntermediateResultCallback): void;
   onProgress(callback: WorkerProgressCallback): void;
@@ -150,6 +152,16 @@ export class WorkerFacade implements MandelbrotFacadeLike {
     this.worker.terminate();
 
     return Promise.resolve();
+  };
+
+  cancel = ({ terminator }: BatchContext, { workerIdx }: MandelbrotJob) => {
+    if (workerIdx == null) {
+      return;
+    }
+
+    this.running = false;
+    const t = new Uint8Array(terminator);
+    Atomics.store(t, workerIdx, 1);
   };
 
   onResult = (callback: WorkerResultCallback) => {

--- a/src/worker-pool/worker-facade.ts
+++ b/src/worker-pool/worker-facade.ts
@@ -24,7 +24,11 @@ export type BatchCompleteCallback = (elapsed: number) => void;
 export type BatchProgressChangedCallback = (progressStr: string) => void;
 
 export interface MandelbrotFacadeLike {
-  startCalculate(job: MandelbrotJob, batchContext: BatchContext): void;
+  startCalculate(
+    job: MandelbrotJob,
+    batchContext: BatchContext,
+    workerIdx: number,
+  ): void;
 
   terminate(callback?: () => void): void;
   terminateAsync(): Promise<void>;
@@ -55,7 +59,11 @@ export class WorkerFacade implements MandelbrotFacadeLike {
     return this.running;
   };
 
-  startCalculate = (job: MandelbrotJob, batchContext: BatchContext) => {
+  startCalculate = (
+    job: MandelbrotJob,
+    batchContext: BatchContext,
+    workerIdx: number,
+  ) => {
     const f = (
       ev: MessageEvent<
         WorkerResult | WorkerIntermediateResult | WorkerProgress
@@ -99,7 +107,8 @@ export class WorkerFacade implements MandelbrotFacadeLike {
     };
 
     const { rect, mandelbrotParams, id } = job;
-    const { pixelHeight, pixelWidth, xn, blaTable, refX, refY } = batchContext;
+    const { pixelHeight, pixelWidth, xn, blaTable, refX, refY, terminator } =
+      batchContext;
 
     this.worker.addEventListener("message", f);
     this.worker.postMessage({
@@ -119,6 +128,8 @@ export class WorkerFacade implements MandelbrotFacadeLike {
       refX,
       refY,
       jobId: id,
+      terminator,
+      workerIdx,
     });
 
     this.running = true;

--- a/src/worker-pool/worker-facade.ts
+++ b/src/worker-pool/worker-facade.ts
@@ -103,6 +103,7 @@ export class WorkerFacade implements MandelbrotFacadeLike {
 
     this.worker.addEventListener("message", f);
     this.worker.postMessage({
+      type: "calc",
       cx: mandelbrotParams.x.toString(),
       cy: mandelbrotParams.y.toString(),
       r: mandelbrotParams.r.toString(),

--- a/src/worker-pool/worker-facade.ts
+++ b/src/worker-pool/worker-facade.ts
@@ -98,7 +98,7 @@ export class WorkerFacade implements MandelbrotFacadeLike {
       }
     };
 
-    const { rect, mandelbrotParams } = job;
+    const { rect, mandelbrotParams, id } = job;
     const { pixelHeight, pixelWidth, xn, blaTable, refX, refY } = batchContext;
 
     this.worker.addEventListener("message", f);
@@ -117,6 +117,7 @@ export class WorkerFacade implements MandelbrotFacadeLike {
       blaTable,
       refX,
       refY,
+      jobId: id,
     });
 
     this.running = true;

--- a/src/worker-pool/worker-facade.ts
+++ b/src/worker-pool/worker-facade.ts
@@ -111,6 +111,10 @@ export class WorkerFacade implements MandelbrotFacadeLike {
       batchContext;
 
     this.worker.addEventListener("message", f);
+
+    const t = new Uint8Array(terminator);
+    Atomics.store(t, workerIdx, 0);
+
     this.worker.postMessage({
       type: "calc",
       cx: mandelbrotParams.x.toString(),

--- a/src/worker-pool/worker-pool.ts
+++ b/src/worker-pool/worker-pool.ts
@@ -85,7 +85,7 @@ const onWorkerResult: WorkerResultCallback = (result, job) => {
   const { rect } = job;
   const batchContext = batchContextMap.get(job.batchId);
 
-  // 停止が間に合わなかったケース。何もしない
+  // 停止が間に合わなかったケースや既にcancelされているケース。何もしない
   if (batchContext == null) {
     return;
   }
@@ -266,8 +266,8 @@ function tick() {
     start(workerIdx, job);
   }
 
-  if (hasWaitingJob) {
-    console.info(
+  if (hasWaitingJob || runningList.length === 0) {
+    console.debug(
       `running: ${runningList.length}, waiting: ${waitingList.length}`,
     );
   }
@@ -278,7 +278,7 @@ function start(workerIdx: number, job: MandelbrotJob) {
   const workerFacade = pool[workerIdx];
   workerFacade.startCalculate(job, batchContext, workerIdx);
 
-  runningList.push(job);
+  runningList.push({ ...job, workerIdx });
   runningWorkerFacadeMap.set(job.id, workerFacade);
 }
 
@@ -310,22 +310,18 @@ export function cancelBatch(batchId: string) {
 
   console.log("cancelBatch", batchId, runningJobs.length, runningList);
 
-  const facades = runningJobs.map((job) => {
+  const batchContext = batchContextMap.get(batchId)!;
+
+  runningJobs.forEach((job) => {
     const facade = runningWorkerFacadeMap.get(job.id);
     runningWorkerFacadeMap.delete(job.id);
 
-    return facade;
+    if (facade == null) return;
+
+    facade.cancel(batchContext, job);
   });
 
-  for (const facade of facades) {
-    if (!facade) continue;
-
-    facade.clearCallbacks();
-    facade.terminate();
-  }
-  removeFromPool(facades);
-
-  fillWorkerFacade();
+  batchContext?.onComplete(0);
 
   runningList = runningList.filter((job) => job.batchId !== batchId);
   batchContextMap.delete(batchId);

--- a/src/worker-pool/worker-pool.ts
+++ b/src/worker-pool/worker-pool.ts
@@ -250,8 +250,8 @@ export function registerBatch(
   tick();
 }
 
-function findFreeWorkerFacade() {
-  return pool.find((worker) => !worker.isRunning());
+function findFreeWorkerFacadeIndex() {
+  return pool.findIndex((worker) => !worker.isRunning());
 }
 
 function tick() {
@@ -259,11 +259,11 @@ function tick() {
 
   while (runningList.length < pool.length && waitingList.length > 0) {
     const job = waitingList.shift()!;
-    const workerFacade = findFreeWorkerFacade();
+    const workerIdx = findFreeWorkerFacadeIndex();
 
-    if (!workerFacade) break;
+    if (!pool[workerIdx]) break;
 
-    start(workerFacade, job);
+    start(workerIdx, job);
   }
 
   if (hasWaitingJob) {
@@ -273,9 +273,10 @@ function tick() {
   }
 }
 
-function start(workerFacade: MandelbrotFacadeLike, job: MandelbrotJob) {
+function start(workerIdx: number, job: MandelbrotJob) {
   const batchContext = batchContextMap.get(job.batchId)!;
-  workerFacade.startCalculate(job, batchContext);
+  const workerFacade = pool[workerIdx];
+  workerFacade.startCalculate(job, batchContext, workerIdx);
 
   runningList.push(job);
   runningWorkerFacadeMap.set(job.id, workerFacade);

--- a/src/workers/mandelbrot-perturbation-worker.ts
+++ b/src/workers/mandelbrot-perturbation-worker.ts
@@ -17,7 +17,11 @@ import { ReferencePointContextPopulated } from "./calc-reference-point";
 import { decodeComplexArray } from "@/lib/xn-buffer";
 import { decodeBLATableItems } from "@/lib/bla-table-item-buffer";
 
-self.addEventListener("message", (event) => {
+const cancelHandler = (data: { jobId: string }) => {
+  console.debug(`${data.jobId}: cancelled`);
+};
+
+const calcHandler = (data: MandelbrotCalculationWorkerParams) => {
   const {
     pixelHeight,
     pixelWidth,
@@ -34,7 +38,7 @@ self.addEventListener("message", (event) => {
     refX,
     refY,
     jobId,
-  } = event.data as MandelbrotCalculationWorkerParams;
+  } = data;
 
   console.debug(`${jobId}: start`);
 
@@ -211,4 +215,17 @@ self.addEventListener("message", (event) => {
   self.postMessage({ type: "result", iterations }, [iterations.buffer]);
 
   console.debug(`${jobId}: end`);
+};
+
+self.addEventListener("message", (event) => {
+  switch (event.data.type) {
+    case "calc": {
+      calcHandler(event.data);
+      break;
+    }
+    case "cancel": {
+      cancelHandler(event.data);
+      break;
+    }
+  }
 });

--- a/src/workers/mandelbrot-perturbation-worker.ts
+++ b/src/workers/mandelbrot-perturbation-worker.ts
@@ -17,10 +17,6 @@ import { ReferencePointContextPopulated } from "./calc-reference-point";
 import { decodeComplexArray } from "@/lib/xn-buffer";
 import { decodeBLATableItems } from "@/lib/bla-table-item-buffer";
 
-const cancelHandler = (data: { jobId: string }) => {
-  console.debug(`${data.jobId}: cancelled`);
-};
-
 const calcHandler = (data: MandelbrotCalculationWorkerParams) => {
   const {
     pixelHeight,
@@ -234,10 +230,6 @@ self.addEventListener("message", (event) => {
   switch (event.data.type) {
     case "calc": {
       calcHandler(event.data);
-      break;
-    }
-    case "cancel": {
-      cancelHandler(event.data);
       break;
     }
   }

--- a/src/workers/mandelbrot-perturbation-worker.ts
+++ b/src/workers/mandelbrot-perturbation-worker.ts
@@ -33,7 +33,10 @@ self.addEventListener("message", (event) => {
     blaTable: blaTableBuffer,
     refX,
     refY,
+    jobId,
   } = event.data as MandelbrotCalculationWorkerParams;
+
+  console.debug(`${jobId}: start`);
 
   const xn = decodeComplexArray(xnBuffer);
   const blaTable = decodeBLATableItems(blaTableBuffer);
@@ -206,4 +209,6 @@ self.addEventListener("message", (event) => {
   }
 
   self.postMessage({ type: "result", iterations }, [iterations.buffer]);
+
+  console.debug(`${jobId}: end`);
 });


### PR DESCRIPTION
## 概要
今まではbatchのキャンセル時、worker.terminateして再度作り直していた
これでは毎回worker作成コストがかかるので、途中で止められるようにした
SharedArrayBufferを使っているのでサポートされてないブラウザでは動かない

## SharedArrayBuffer
外からworkerに停止メッセージを送る方法を最初に試したが
whileぶん回し中にmessageを処理するためのウェイトを挟まねばならず、2倍くらい遅くなってしまった
なのでSharedArrayBufferを用い、フラグが立ってたら処理中断、という形にした

ループ中に毎回値のチェックが入るが、速度に影響はほぼない
書き込みはAtomicsを使っているが、読み込みはatomicにする必要ないのでそのまま読んでいる

## 課題
reference pointをピン留めしたときの挙動がなんかおかしいので修正する