### PR TITLE
かかった時間を詳しく表示できるようにした

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@radix-ui/react-dialog": "1.0.5",
     "@radix-ui/react-label": "2.0.2",
     "@radix-ui/react-scroll-area": "1.0.5",
+    "@radix-ui/react-separator": "1.0.3",
     "@radix-ui/react-slider": "1.1.2",
     "@radix-ui/react-slot": "1.0.2",
     "@radix-ui/react-tabs": "1.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@radix-ui/react-scroll-area':
         specifier: 1.0.5
         version: 1.0.5(@types/react-dom@18.3.0)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-separator':
+        specifier: 1.0.3
+        version: 1.0.3(@types/react-dom@18.3.0)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-slider':
         specifier: 1.1.2
         version: 1.1.2(@types/react-dom@18.3.0)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -708,6 +711,19 @@ packages:
 
   '@radix-ui/react-scroll-area@1.0.5':
     resolution: {integrity: sha512-b6PAgH4GQf9QEn8zbT2XUHpW5z8BzqEc7Kl11TwDrvuTrxlkcjTD5qa/bxgKr+nmuXKu4L/W5UZ4mlP/VG/5Gw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-separator@1.0.3':
+    resolution: {integrity: sha512-itYmTy/kokS21aiV5+Z56MZB54KrhPgn6eHDKkFeOLR34HMN2s8PaN47qZZAGnvupcjxHaFZnW4pQEh0BvvVuw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2583,6 +2599,16 @@ snapshots:
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.3.0)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.3.1)(react@18.3.1)
       '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.3.1)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.1
+      '@types/react-dom': 18.3.0
+
+  '@radix-ui/react-separator@1.0.3(@types/react-dom@18.3.0)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.24.5
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.3.0)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,0 +1,29 @@
+import * as React from "react"
+import * as SeparatorPrimitive from "@radix-ui/react-separator"
+
+import { cn } from "@/lib/utils"
+
+const Separator = React.forwardRef<
+  React.ElementRef<typeof SeparatorPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
+>(
+  (
+    { className, orientation = "horizontal", decorative = true, ...props },
+    ref
+  ) => (
+    <SeparatorPrimitive.Root
+      ref={ref}
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border",
+        orientation === "horizontal" ? "h-[1px] w-full" : "h-full w-[1px]",
+        className
+      )}
+      {...props}
+    />
+  )
+)
+Separator.displayName = SeparatorPrimitive.Root.displayName
+
+export { Separator }

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,117 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Table = React.forwardRef<
+  HTMLTableElement,
+  React.HTMLAttributes<HTMLTableElement>
+>(({ className, ...props }, ref) => (
+  <div className="relative w-full overflow-auto">
+    <table
+      ref={ref}
+      className={cn("w-full caption-bottom text-sm", className)}
+      {...props}
+    />
+  </div>
+))
+Table.displayName = "Table"
+
+const TableHeader = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+))
+TableHeader.displayName = "TableHeader"
+
+const TableBody = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tbody
+    ref={ref}
+    className={cn("[&_tr:last-child]:border-0", className)}
+    {...props}
+  />
+))
+TableBody.displayName = "TableBody"
+
+const TableFooter = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tfoot
+    ref={ref}
+    className={cn(
+      "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
+      className
+    )}
+    {...props}
+  />
+))
+TableFooter.displayName = "TableFooter"
+
+const TableRow = React.forwardRef<
+  HTMLTableRowElement,
+  React.HTMLAttributes<HTMLTableRowElement>
+>(({ className, ...props }, ref) => (
+  <tr
+    ref={ref}
+    className={cn(
+      "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+      className
+    )}
+    {...props}
+  />
+))
+TableRow.displayName = "TableRow"
+
+const TableHead = React.forwardRef<
+  HTMLTableCellElement,
+  React.ThHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cn(
+      "h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0",
+      className
+    )}
+    {...props}
+  />
+))
+TableHead.displayName = "TableHead"
+
+const TableCell = React.forwardRef<
+  HTMLTableCellElement,
+  React.TdHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <td
+    ref={ref}
+    className={cn("p-4 align-middle [&:has([role=checkbox])]:pr-0", className)}
+    {...props}
+  />
+))
+TableCell.displayName = "TableCell"
+
+const TableCaption = React.forwardRef<
+  HTMLTableCaptionElement,
+  React.HTMLAttributes<HTMLTableCaptionElement>
+>(({ className, ...props }, ref) => (
+  <caption
+    ref={ref}
+    className={cn("mt-4 text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+TableCaption.displayName = "TableCaption"
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -41,10 +41,7 @@ import "./style.css";
 import { AppRoot } from "./view/app-root";
 import { extractMandelbrotParams } from "./lib/params";
 import { d3ChromaticPalettes } from "./color/color-d3-chromatic";
-import {
-  getProgressString,
-  prepareWorkerPool,
-} from "./worker-pool/worker-pool";
+import { getProgressData, prepareWorkerPool } from "./worker-pool/worker-pool";
 
 const drawInfo = (p: p5) => {
   const { mouseX, mouseY, r, N } = calcVars(
@@ -61,7 +58,7 @@ const drawInfo = (p: p5) => {
   };
 
   const params = getCurrentParams();
-  const progress = getProgressString();
+  const progress = getProgressData();
 
   updateStore("centerX", params.x);
   updateStore("centerY", params.y);

--- a/src/types.ts
+++ b/src/types.ts
@@ -131,6 +131,11 @@ export interface Span {
   elapsed: number;
 }
 
+export interface ResultSpans {
+  total: number;
+  spans: Span[];
+}
+
 export interface BatchContext {
   onComplete: BatchCompleteCallback;
   onChangeProgress: BatchProgressChangedCallback;

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export interface Resolution {
 export interface WorkerResult {
   type: "result";
   iterations: ArrayBuffer;
+  elapsed: number;
 }
 
 export interface WorkerIntermediateResult {
@@ -31,6 +32,7 @@ export interface ReferencePointResult {
   type: "result" | "terminated";
   xn: XnBuffer;
   blaTable: BLATableBuffer;
+  elapsed: number;
 }
 
 export interface ReferencePointProgress {
@@ -124,6 +126,11 @@ export interface CalcReferencePointJob extends MandelbrotJobBase {
   mandelbrotParams: MandelbrotParams;
 }
 
+export interface Span {
+  name: string;
+  elapsed: number;
+}
+
 export interface BatchContext {
   onComplete: BatchCompleteCallback;
   onChangeProgress: BatchProgressChangedCallback;
@@ -141,6 +148,13 @@ export interface BatchContext {
   refProgress: number;
   startedAt: number;
   finishedAt?: number;
+  spans: Span[];
 }
+
+export type InitialOmittedBatchContextKeys =
+  | "progressMap"
+  | "startedAt"
+  | "refProgress"
+  | "spans";
 
 export type JobType = "calc-iteration" | "calc-reference-point";

--- a/src/view/footer/index.tsx
+++ b/src/view/footer/index.tsx
@@ -182,7 +182,7 @@ const SpansDetail = (props: { name: string; spans: Span[] }) => {
 
 const nameToLabel = (name: string) => {
   if (name.includes("reference")) {
-    return "Calculate Reference Point";
+    return "Calculate Reference Orbit";
   }
   if (name.includes("iteration")) {
     return "Calculate Iteration";

--- a/src/view/footer/index.tsx
+++ b/src/view/footer/index.tsx
@@ -1,8 +1,112 @@
+import { ResultSpans } from "@/types";
 import { useStoreValue } from "../../store/store";
+import clsx from "clsx";
+import React from "react";
+
+const convertSpans = (value: any): ResultSpans | undefined => {
+  if (value !== null && typeof value === "object") {
+    const total = value.total;
+    const spans = value.spans;
+
+    if (typeof total === "number" && Array.isArray(spans)) {
+      return { total, spans };
+    }
+  }
+
+  return undefined;
+};
 
 export const Footer = () => {
-  // TODO: debounceした方がいいかも
   const progress = useStoreValue("progress");
 
-  return <>{progress}</>;
+  if (typeof progress === "string") {
+    return <>{progress}</>;
+  }
+
+  const result = convertSpans(progress);
+  if (result == null) return "Invalid Result";
+
+  const { total, spans } = result;
+
+  return (
+    <div>
+      <BarGraph total={total} spans={spans} />
+    </div>
+  );
+};
+
+const colorMap = (label: string) => {
+  if (label.includes("reference")) {
+    return "bg-jade-7";
+  }
+  if (label.includes("iteration")) {
+    return "bg-iris-7";
+  }
+  return "bg-ruby-7";
+};
+
+const BarGraph = (props: ResultSpans) => {
+  const { total, spans } = props;
+
+  return (
+    <div className="flex w-full items-center">
+      <div className="mr-4 flex-none">Done! ({total}ms)</div>
+      <div className="flex flex-grow">
+        <Bar spans={spans} total={total} />
+      </div>
+    </div>
+  );
+};
+
+const Bar = (props: ResultSpans) => {
+  const { spans, total } = props;
+
+  const maxWorkerElapsed = Math.max(
+    ...spans.filter((s) => s.name.includes("iteration")).map((s) => s.elapsed),
+  );
+  const workerExceptedSpans = spans.filter(
+    (s) => !s.name.includes("iteration"),
+  );
+
+  return (
+    <div className="flex h-8 w-full bg-gray-7">
+      {workerExceptedSpans.map(({ name, elapsed }, idx) => (
+        <BarContent key={idx} name={name} elapsed={elapsed} total={total} />
+      ))}
+      <BarContent name="iteration" elapsed={maxWorkerElapsed} total={total} />
+    </div>
+  );
+};
+
+const BarContent = (props: {
+  name: string;
+  elapsed: number;
+  total: number;
+}) => {
+  const { name, elapsed, total } = props;
+
+  const [displayText, setDisplayText] = React.useState(`${name}: ${elapsed}ms`);
+  const ref = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    if (ref.current && ref.current.offsetWidth < ref.current.scrollWidth) {
+      // 実際の幅がコンテナの幅より大きい場合は、`elapsed` のみを表示
+      setDisplayText(`${elapsed}ms`);
+    }
+  }, [name, elapsed]);
+
+  const width = (elapsed / total) * 100;
+  const bgColorClassName = colorMap(name);
+  return (
+    <div
+      ref={ref}
+      className={clsx(
+        "flex items-center justify-center overflow-hidden overflow-ellipsis whitespace-nowrap text-whiteA-12",
+        bgColorClassName,
+      )}
+      style={{ width: `${width}%` }}
+    >
+      {displayText}
+    </div>
+  );
 };

--- a/src/view/footer/index.tsx
+++ b/src/view/footer/index.tsx
@@ -8,6 +8,7 @@ import {
   TooltipTrigger,
   TooltipContent,
 } from "@radix-ui/react-tooltip";
+import { Separator } from "@/components/ui/separator";
 
 const convertSpans = (value: any): ResultSpans | undefined => {
   if (value !== null && typeof value === "object") {
@@ -118,12 +119,13 @@ const BarContent = (props: {
 
   const width = (elapsed / total) * 100;
   const bgColorClassName = colorMap(name);
+
   return (
     <Tooltip delayDuration={0}>
       <div
         ref={ref}
         className={clsx(
-          "flex items-center justify-center overflow-hidden overflow-ellipsis whitespace-nowrap text-whiteA-12",
+          "flex w-52 items-center justify-center overflow-hidden overflow-ellipsis whitespace-nowrap text-whiteA-12",
           bgColorClassName,
         )}
         style={{ width: `${width}%` }}
@@ -131,16 +133,70 @@ const BarContent = (props: {
         <TooltipTrigger>{displayText}</TooltipTrigger>
       </div>
       <TooltipContent>
-        <div className="rounded-md bg-iris-5 p-2 text-whiteA-12">
-          {spans.map((span, idx) => {
-            return (
-              <div key={idx}>
-                {span.name}: {span.elapsed}ms
-              </div>
-            );
-          })}
+        <div
+          className={clsx(
+            "w-52 rounded-md p-2 text-whiteA-12",
+            bgColorClassName,
+          )}
+        >
+          <SpansDetail name={name} spans={spans} />
         </div>
       </TooltipContent>
     </Tooltip>
+  );
+};
+
+const SpansDetail = (props: { name: string; spans: Span[] }) => {
+  const { name, spans } = props;
+
+  const label = nameToLabel(name);
+
+  if (spans.length === 1) {
+    return (
+      <div>
+        <div className="pb-2">{label}</div>
+        <ListItem label="Total" value={`${spans[0].elapsed} ms`} />
+      </div>
+    );
+  }
+
+  const elapses = spans.map((s) => s.elapsed);
+  const maxElapsed = Math.max(...elapses);
+  const minElapsed = Math.min(...elapses);
+  const totalElapsed = elapses.reduce((acc, cur) => acc + cur, 0);
+  const averageElapsed = (totalElapsed / elapses.length).toFixed(1);
+
+  return (
+    <div>
+      <div className="pb-2">{label}</div>
+      <ListItem label="Max" value={`${maxElapsed} ms`} />
+      <Separator />
+      <ListItem label="Min" value={`${minElapsed} ms`} />
+      <Separator />
+      <ListItem label="Count" value={`${elapses.length} workers`} />
+      <Separator />
+      <ListItem label="Average" value={`${averageElapsed} ms`} />
+    </div>
+  );
+};
+
+const nameToLabel = (name: string) => {
+  if (name.includes("reference")) {
+    return "Calculate Reference Point";
+  }
+  if (name.includes("iteration")) {
+    return "Calculate Iteration";
+  }
+  return name;
+};
+
+const ListItem = (props: { label: string; value: string }) => {
+  const { label, value } = props;
+
+  return (
+    <div className="flex justify-between">
+      <div>{label}:</div>
+      <div>{value}</div>
+    </div>
   );
 };

--- a/src/worker-pool/worker-facade.ts
+++ b/src/worker-pool/worker-facade.ts
@@ -92,12 +92,12 @@ export class CalcIterationWorker implements MandelbrotFacadeLike {
 
       switch (data.type) {
         case "result": {
-          const { iterations } = data;
+          const { iterations, elapsed } = data;
 
           const iterationsResult = new Uint32Array(iterations);
 
           this.resultCallback?.(
-            { type: "result", iterations: iterationsResult },
+            { type: "result", iterations: iterationsResult, elapsed },
             job,
           );
 
@@ -268,8 +268,8 @@ export class CalcReferencePointWorker implements MandelbrotFacadeLike {
         this.worker.removeEventListener("message", handler);
         this.running = false;
 
-        const { xn, blaTable } = ev.data;
-        this.resultCallback?.({ xn, blaTable }, job);
+        const { xn, blaTable, elapsed } = ev.data;
+        this.resultCallback?.({ xn, blaTable, elapsed }, job);
       }
       if (type === "progress") {
         const { progress } = ev.data;

--- a/src/worker-pool/worker-pool.ts
+++ b/src/worker-pool/worker-pool.ts
@@ -7,6 +7,8 @@ import {
   MandelbrotJob,
   MandelbrotRenderingUnit,
   MandelbrotWorkerType,
+  ResultSpans,
+  Span,
   WorkerIntermediateResult,
   mandelbrotWorkerTypes,
 } from "@/types";
@@ -86,7 +88,7 @@ const getLatestBatchContext = () => {
   return batchContext;
 };
 
-export const getProgressString = () => {
+export const getProgressData = (): string | ResultSpans => {
   const batchContext = getLatestBatchContext();
 
   if (!batchContext) {
@@ -94,13 +96,10 @@ export const getProgressString = () => {
   }
 
   if (batchContext.finishedAt) {
-    const allElapsed = batchContext.spans
-      .map((e) => `${e.name}: ${Math.floor(e.elapsed)}ms`)
-      .join(", ");
-
-    return `Done! (${Math.floor(
-      batchContext.finishedAt - batchContext.startedAt,
-    )}ms), ${allElapsed}`;
+    return {
+      total: Math.floor(batchContext.finishedAt - batchContext.startedAt),
+      spans: batchContext.spans,
+    };
   }
 
   const { progressMap, mandelbrotParams, refProgress } = batchContext;
@@ -167,7 +166,7 @@ const onCalcReferencePointWorkerResult: RefPointResultCallback = (
   batchContext.blaTable = blaTable;
   batchContext.spans.push({
     name: "reference_orbit",
-    elapsed,
+    elapsed: Math.floor(elapsed),
   });
 
   runningList = runningList.filter((j) => j.id !== job.id);
@@ -200,7 +199,7 @@ const onCalcIterationWorkerResult: WorkerResultCallback = (result, job) => {
 
   batchContext.spans.push({
     name: `iteration_${job.workerIdx}`,
-    elapsed,
+    elapsed: Math.floor(elapsed),
   });
 
   renderToResultBuffer(rect);

--- a/src/workers/calc-reference-point.ts
+++ b/src/workers/calc-reference-point.ts
@@ -29,6 +29,7 @@ import { encodeBlaTableItems } from "@/lib/bla-table-item-buffer";
 export type ReferencePointContext = {
   xn: XnBuffer;
   blaTable: BLATableBuffer;
+  elapsed: number;
 };
 
 export type ReferencePointContextPopulated = {
@@ -157,6 +158,7 @@ async function setup() {
       workerIdx,
     } = event.data as ReferencePointCalculationWorkerParams;
 
+    const startedAt = performance.now();
     console.debug(`${jobId}: start (ref)`);
 
     const terminateChecker = new Uint8Array(terminator);
@@ -198,10 +200,13 @@ async function setup() {
     const xnConverted = encodeComplexArray(xn);
     const blaTableConverted = encodeBlaTableItems(blaTable);
 
+    const elapsed = performance.now() - startedAt;
+
     self.postMessage({
       type: "result",
       xn: xnConverted,
       blaTable: blaTableConverted,
+      elapsed,
     });
 
     console.debug(`${jobId}: completed (ref)`);

--- a/src/workers/mandelbrot-perturbation-worker.ts
+++ b/src/workers/mandelbrot-perturbation-worker.ts
@@ -38,6 +38,7 @@ const calcHandler = (data: MandelbrotCalculationWorkerParams) => {
     workerIdx,
   } = data;
 
+  const startedAt = performance.now();
   console.debug(`${jobId}: start`);
 
   const terminateChecker = new Uint8Array(terminator);
@@ -223,7 +224,10 @@ const calcHandler = (data: MandelbrotCalculationWorkerParams) => {
     console.debug(`${jobId}: completed`);
   }
 
-  self.postMessage({ type: "result", iterations }, [iterations.buffer]);
+  const elapsed = performance.now() - startedAt;
+  self.postMessage({ type: "result", iterations, elapsed }, [
+    iterations.buffer,
+  ]);
 };
 
 self.addEventListener("message", (event) => {

--- a/src/workers/mandelbrot-worker.ts
+++ b/src/workers/mandelbrot-worker.ts
@@ -17,6 +17,8 @@ self.addEventListener("message", (event) => {
     endY,
   } = event.data as MandelbrotCalculationWorkerParams;
 
+  const startedAt = performance.now();
+
   const iterations = new Uint32Array((endY - startY) * (endX - startX));
 
   const cx = parseFloat(cxStr);
@@ -55,5 +57,8 @@ self.addEventListener("message", (event) => {
     });
   }
 
-  self.postMessage({ type: "result", iterations }, [iterations.buffer]);
+  const elapsed = performance.now() - startedAt;
+  self.postMessage({ type: "result", iterations, elapsed }, [
+    iterations.buffer,
+  ]);
 });


### PR DESCRIPTION
## 概要
かかった時間の割合を棒グラフで表示できるようにした

[![Image from Gyazo](https://i.gyazo.com/9331cae0ca421bb7231b7c973bfbb4fb.png)](https://gyazo.com/9331cae0ca421bb7231b7c973bfbb4fb)

マウスオーバーすると詳細が見れる
[![Image from Gyazo](https://i.gyazo.com/2ead760d4a011a0f1dc196bc9d74d1d6.png)](https://gyazo.com/2ead760d4a011a0f1dc196bc9d74d1d6)
最初は生の値を表示してたけど128個の時とかすごいことになるのでmin/max/avgだけ表示するようにした
並列計算できないReference Orbitの場合はラベルとかかった時間だけ表示にしている

個々の時間はそれぞれworkerが起動してからカウントしているので、
Done!の横に出る数値と合わないのはworkerの起動コストとかその他

perturbationでない通常モードではよくこうなっている
[![Image from Gyazo](https://i.gyazo.com/d7459e5f9df65b2dc73dfdde9391f089.png)](https://gyazo.com/d7459e5f9df65b2dc73dfdde9391f089)