### PR TITLE
画像の保存ボタンを追加

### DIFF
--- a/src/canvas-reference.ts
+++ b/src/canvas-reference.ts
@@ -9,7 +9,11 @@ export const setP5 = (p5Instance: p5Type) => {
   p5 = p5Instance;
 };
 
-export const getResizedCanvasImageDataURL = (height: number = 100) => {
+/*
+ * canvasの画像をリサイズした後にDataURLを返す
+ * 0を指定すると元のサイズで保存する
+ */
+export const getResizedCanvasImageDataURL = (height: number = 0) => {
   const img = p5.get() as Image;
   // 0にしておくと指定した方の高さに合わせてリサイズしてくれる
   img.resize(0, height);

--- a/src/view/header/actions.tsx
+++ b/src/view/header/actions.tsx
@@ -6,27 +6,33 @@ import { IconCircleCheck, IconShare } from "@tabler/icons-react";
 export const Actions = () => {
   return (
     <div>
-      <Button
-        variant="outline"
-        size="sm"
-        onClick={() => {
-          copyCurrentParamsToClipboard();
-
-          toast({
-            description: (
-              <div className="flex items-center justify-center gap-2">
-                <IconCircleCheck />
-                Current location URL copied to clipboard!
-              </div>
-            ),
-            variant: "primary",
-            duration: 2000,
-          });
-        }}
-      >
-        <IconShare className="mr-1 h-6 w-6" />
-        Share
-      </Button>
+      <ShareButton />
     </div>
+  );
+};
+
+const ShareButton = () => {
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={() => {
+        copyCurrentParamsToClipboard();
+
+        toast({
+          description: (
+            <div className="flex items-center justify-center gap-2">
+              <IconCircleCheck />
+              Current location URL copied to clipboard!
+            </div>
+          ),
+          variant: "primary",
+          duration: 2000,
+        });
+      }}
+    >
+      <IconShare className="mr-1 h-6 w-6" />
+      Share
+    </Button>
   );
 };

--- a/src/view/header/actions.tsx
+++ b/src/view/header/actions.tsx
@@ -1,0 +1,32 @@
+import { Button } from "@/components/ui/button";
+import { toast } from "@/components/ui/use-toast";
+import { copyCurrentParamsToClipboard } from "@/lib/params";
+import { IconCircleCheck, IconShare } from "@tabler/icons-react";
+
+export const Actions = () => {
+  return (
+    <div>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => {
+          copyCurrentParamsToClipboard();
+
+          toast({
+            description: (
+              <div className="flex items-center justify-center gap-2">
+                <IconCircleCheck />
+                Current location URL copied to clipboard!
+              </div>
+            ),
+            variant: "primary",
+            duration: 2000,
+          });
+        }}
+      >
+        <IconShare className="mr-1 h-6 w-6" />
+        Share
+      </Button>
+    </div>
+  );
+};

--- a/src/view/header/actions.tsx
+++ b/src/view/header/actions.tsx
@@ -1,3 +1,4 @@
+import { getResizedCanvasImageDataURL } from "@/canvas-reference";
 import { Button } from "@/components/ui/button";
 import { toast } from "@/components/ui/use-toast";
 import { copyCurrentParamsToClipboard } from "@/lib/params";
@@ -49,16 +50,20 @@ const SaveImageButton = () => {
       variant="outline"
       size="sm"
       onClick={() => {
-        // TODO: Implement image saving
+        const imageDataURL = getResizedCanvasImageDataURL(0);
+        const link = document.createElement("a");
+        link.download = `mandelbrot-${Date.now()}.png`;
+        link.href = imageDataURL;
+        link.click();
 
         toast({
           description: (
             <div className="flex items-center justify-center gap-2">
-              <IconDots />
-              Saving image...
+              <IconCircleCheck />
+              Image saved!
             </div>
           ),
-          variant: "default",
+          variant: "primary",
           duration: 2000,
         });
       }}

--- a/src/view/header/actions.tsx
+++ b/src/view/header/actions.tsx
@@ -1,12 +1,18 @@
 import { Button } from "@/components/ui/button";
 import { toast } from "@/components/ui/use-toast";
 import { copyCurrentParamsToClipboard } from "@/lib/params";
-import { IconCircleCheck, IconShare } from "@tabler/icons-react";
+import {
+  IconCircleCheck,
+  IconShare,
+  IconDownload,
+  IconDots,
+} from "@tabler/icons-react";
 
 export const Actions = () => {
   return (
-    <div>
+    <div className="flex gap-x-2">
       <ShareButton />
+      <SaveImageButton />
     </div>
   );
 };
@@ -33,6 +39,32 @@ const ShareButton = () => {
     >
       <IconShare className="mr-1 h-6 w-6" />
       Share
+    </Button>
+  );
+};
+
+const SaveImageButton = () => {
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={() => {
+        // TODO: Implement image saving
+
+        toast({
+          description: (
+            <div className="flex items-center justify-center gap-2">
+              <IconDots />
+              Saving image...
+            </div>
+          ),
+          variant: "default",
+          duration: 2000,
+        });
+      }}
+    >
+      <IconDownload className="mr-1 h-6 w-6" />
+      Save Image
     </Button>
   );
 };

--- a/src/view/header/index.tsx
+++ b/src/view/header/index.tsx
@@ -8,6 +8,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { Actions } from "./actions";
 
 export const Header = () => {
   const [opened, { open, toggle }] = useModalState();
@@ -23,7 +24,7 @@ export const Header = () => {
         </DialogContent>
       </Dialog>
       <div className="mt-2 grid grid-cols-2">
-        <div></div>
+        <Actions />
         <div className="col-end-7 flex items-center gap-1">
           <Button variant="outline" size="icon-sm" asChild>
             <a href="https://github.com/k-chop/p5mandelbrot" target="_blank">

--- a/src/view/header/index.tsx
+++ b/src/view/header/index.tsx
@@ -1,19 +1,16 @@
-import { IconHelp, IconPin } from "@tabler/icons-react";
+import { IconHelp } from "@tabler/icons-react";
 import { useModalState } from "../modal/use-modal-state";
 import { Instructions } from "./instructions";
-import { Button, buttonVariants } from "@/components/ui/button";
+import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { useStoreValue } from "@/store/store";
-import { Kbd } from "@/components/kbd";
 
 export const Header = () => {
   const [opened, { open, toggle }] = useModalState();
-  const isReferencePinned = useStoreValue("isReferencePinned");
 
   return (
     <>
@@ -26,13 +23,7 @@ export const Header = () => {
         </DialogContent>
       </Dialog>
       <div className="mt-2 grid grid-cols-2">
-        <div>
-          {isReferencePinned && (
-            <div className="flex gap-1 border-b-2 border-destructive">
-              <IconPin /> Reference Point Pinned (Press <Kbd>p</Kbd> to unpin)
-            </div>
-          )}
-        </div>
+        <div></div>
         <div className="col-end-7 flex items-center gap-1">
           <Button variant="outline" size="icon-sm" asChild>
             <a href="https://github.com/k-chop/p5mandelbrot" target="_blank">

--- a/src/view/right-sidebar/index.tsx
+++ b/src/view/right-sidebar/index.tsx
@@ -1,3 +1,4 @@
+import { Informations } from "./informations";
 import { Operations } from "./operations";
 import { Parameters } from "./parameters";
 
@@ -5,6 +6,7 @@ export const RightSidebar = () => {
   return (
     <div className="grid gap-2">
       <Parameters />
+      <Informations />
       <Operations />
     </div>
   );

--- a/src/view/right-sidebar/informations.tsx
+++ b/src/view/right-sidebar/informations.tsx
@@ -1,0 +1,27 @@
+import { Kbd } from "@/components/kbd";
+import { Card, CardContent } from "@/components/ui/card";
+import { useStoreValue } from "@/store/store";
+import { IconPin } from "@tabler/icons-react";
+
+export const Informations = () => {
+  const isReferencePinned = useStoreValue("isReferencePinned");
+
+  if (!isReferencePinned) return null;
+
+  return (
+    <Card className="mx-2">
+      <CardContent className="p-0 px-2 pt-1">
+        {isReferencePinned && (
+          <div className="flex flex-col gap-1">
+            <div className="flex">
+              <IconPin /> Reference Orbit Pinned
+            </div>
+            <div>
+              (Press <Kbd>p</Kbd> to unpin)
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/view/right-sidebar/poi-card.tsx
+++ b/src/view/right-sidebar/poi-card.tsx
@@ -25,7 +25,7 @@ export const POICard = ({ poi, onDelete, onApply }: POICardProps) => {
         <div className="ml-2 flex flex-grow flex-col">
           <div className="flex justify-between">
             <div>r</div>
-            <div>{r.toPrecision(10)}</div>
+            <div>{r.toPrecision(5)}</div>
           </div>
           <div className="flex justify-between">
             <div>N</div>

--- a/src/view/right-sidebar/poi.tsx
+++ b/src/view/right-sidebar/poi.tsx
@@ -1,19 +1,12 @@
 import { POICard } from "./poi-card";
-import {
-  IconCircleCheck,
-  IconCirclePlus,
-  IconShare,
-} from "@tabler/icons-react";
+import { IconCirclePlus } from "@tabler/icons-react";
 import { usePOI } from "./use-poi";
 import { cloneParams, getCurrentParams } from "../../mandelbrot";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { useToast } from "@/components/ui/use-toast";
-import { copyCurrentParamsToClipboard } from "@/lib/params";
 
 export const POI = () => {
   const { poiList, addPOI, deletePOIAt, applyPOI } = usePOI();
-  const { toast } = useToast();
 
   return (
     <>

--- a/src/view/right-sidebar/poi.tsx
+++ b/src/view/right-sidebar/poi.tsx
@@ -17,7 +17,7 @@ export const POI = () => {
 
   return (
     <>
-      <div className="pr-4">
+      <div>
         <div className="mb-2 flex justify-between">
           <Button
             variant="ghost"
@@ -51,7 +51,7 @@ export const POI = () => {
         </div>
       </div>
       <ScrollArea className="h-[500px]">
-        <div className="pr-4">
+        <div>
           <div className="flex flex-col gap-2">
             {poiList.map((poi, index) => (
               <POICard

--- a/src/view/right-sidebar/poi.tsx
+++ b/src/view/right-sidebar/poi.tsx
@@ -20,29 +20,9 @@ export const POI = () => {
       <div>
         <div className="mb-2 flex justify-between">
           <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => {
-              copyCurrentParamsToClipboard();
-
-              toast({
-                description: (
-                  <div className="flex items-center justify-center gap-2">
-                    <IconCircleCheck />
-                    Current location URL copied to clipboard!
-                  </div>
-                ),
-                variant: "primary",
-                duration: 2000,
-              });
-            }}
-          >
-            <IconShare className="mr-1 h-6 w-6" />
-            Share
-          </Button>
-          <Button
             variant="default"
             size="sm"
+            className="w-full"
             onClick={() => addPOI(cloneParams(getCurrentParams()))}
           >
             <IconCirclePlus className="mr-2 h-6 w-6" />

--- a/src/view/right-sidebar/use-poi.tsx
+++ b/src/view/right-sidebar/use-poi.tsx
@@ -18,7 +18,7 @@ export const usePOI = () => {
       const newPOIList = [newPOI, ...poiList];
       writePOIListToStorage(newPOIList);
 
-      const imageDataURL = getResizedCanvasImageDataURL();
+      const imageDataURL = getResizedCanvasImageDataURL(100);
       savePreview(newPOI.id, imageDataURL);
 
       updateStore("poi", newPOIList);


### PR DESCRIPTION
## 概要
逆になんで今までなかったんですか？

## 補足
Shareボタンも移動して、操作系はHeaderに持ってきた
ピン留めは既に機能してないが、とりあえずヘッダにあると競合するので右側に持ってきた

POIリストの高さを固定値にしているせいですごくガタガタするので、
canvasの縦幅を超えないように可変の高さを持たせたいがCSS力が足りてない

あと画面幅が広いときひどい見た目になるのでその辺も調整したいがCSS力が以下略

## スクリーンショット
![image](https://github.com/k-chop/p5mandelbrot/assets/241973/ba56fd41-b66e-4f75-b275-01557d325b88)
