### PR TITLE
Reference Orbitを安全な範囲で再利用して描画時間を減らす

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -314,7 +314,7 @@ const entrypoint = () => {
     // UI state
     canvasLocked: false,
     // mandelbrot state
-    isReferencePinned: false,
+    shouldReuseRefOrbit: false,
   });
 
   // localStorageから復帰

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -44,7 +44,7 @@ let height = DEFAULT_HEIGHT;
 export const togglePinReference = () => {
   if (getCurrentParams().mode !== "perturbation") return;
 
-  const newValue = updateStoreWith("isReferencePinned", (t) => !t);
+  const newValue = updateStoreWith("shouldReuseRefOrbit", (t) => !t);
 
   console.debug(`Reference point has pinned: ${newValue}`);
 };
@@ -229,7 +229,7 @@ export const startCalculation = async (onComplete: () => void) => {
     pixelWidth: width,
     pixelHeight: height,
     terminator,
-    reuseLastReference: getStore("isReferencePinned"),
+    shouldReuseRefOrbit: getStore("shouldReuseRefOrbit"),
   });
 };
 

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -234,9 +234,6 @@ export const startCalculation = async (onComplete: () => void) => {
     clearIterationCache();
   }
 
-  let refX = currentParams.x.toString();
-  let refY = currentParams.y.toString();
-
   const units = calculationRects.map((rect) => ({
     rect,
     mandelbrotParams: currentParams,
@@ -250,8 +247,6 @@ export const startCalculation = async (onComplete: () => void) => {
     onComplete,
     onChangeProgress: () => {},
     mandelbrotParams: currentParams,
-    refX,
-    refY,
     pixelWidth: width,
     pixelHeight: height,
     terminator,

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -5,7 +5,7 @@ import {
 } from "./aggregator";
 import { BLATableItem, Complex } from "./math";
 import { divideRect, Rect } from "./rect";
-import { updateStore, getStore } from "./store/store";
+import { updateStore, getStore, updateStoreWith } from "./store/store";
 import {
   BLATableBuffer,
   MandelbrotParams,
@@ -41,33 +41,12 @@ let prevBatchId = "";
 let width = DEFAULT_WIDTH;
 let height = DEFAULT_HEIGHT;
 
-// 最後のReference Orbitの計算結果
-const lastReferenceCache: {
-  x: BigNumber;
-  y: BigNumber;
-  xn: XnBuffer;
-  blaTable: BLATableBuffer;
-} = {
-  x: new BigNumber(0),
-  y: new BigNumber(0),
-  xn: new ArrayBuffer(0),
-  blaTable: new ArrayBuffer(0),
-};
-
-let isReferencePinned = false;
-
 export const togglePinReference = () => {
   if (getCurrentParams().mode !== "perturbation") return;
 
-  isReferencePinned = !isReferencePinned;
-  updateStore("isReferencePinned", isReferencePinned);
+  const newValue = updateStoreWith("isReferencePinned", (t) => !t);
 
-  console.debug(`Reference point has pinned: ${isReferencePinned}`);
-
-  const { x: refX, y: refY } = lastReferenceCache;
-  const { x, y } = currentParams;
-
-  console.debug("params: ", { refX, refY, x, y });
+  console.debug(`Reference point has pinned: ${newValue}`);
 };
 
 let currentParams: MandelbrotParams = {
@@ -250,6 +229,7 @@ export const startCalculation = async (onComplete: () => void) => {
     pixelWidth: width,
     pixelHeight: height,
     terminator,
+    reuseLastReference: getStore("isReferencePinned"),
   });
 };
 

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -31,6 +31,16 @@ export const updateStore = (key: string, value: any) => {
   event.emit(key);
 };
 
+export const updateStoreWith = <T extends any>(
+  key: string,
+  f: (value: T) => T,
+) => {
+  const newValue = f(store[key]);
+  updateStore(key, newValue);
+
+  return newValue;
+};
+
 export const useStoreValue = (key: string) => {
   const [value, setValue] = useState(getStore(key));
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -163,3 +163,12 @@ export type InitialOmittedBatchContextKeys =
   | "spans";
 
 export type JobType = "calc-iteration" | "calc-reference-point";
+
+export type RefOrbitCache = {
+  x: BigNumber;
+  y: BigNumber;
+  r: BigNumber; // 縮小時は100%再利用して良いのでその判断のために必要
+  N: number;
+  xn: XnBuffer;
+  blaTable: BLATableBuffer;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -157,6 +157,8 @@ export interface BatchContext {
 }
 
 export type InitialOmittedBatchContextKeys =
+  | "refX"
+  | "refY"
   | "progressMap"
   | "startedAt"
   | "refProgress"

--- a/src/types.ts
+++ b/src/types.ts
@@ -148,7 +148,7 @@ export interface BatchContext {
   xn?: XnBuffer;
   blaTable?: BLATableBuffer;
   terminator: SharedArrayBuffer;
-  reuseLastReference: boolean;
+  shouldReuseRefOrbit: boolean;
 
   progressMap: Map<string, number>;
   refProgress: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -148,6 +148,7 @@ export interface BatchContext {
   xn?: XnBuffer;
   blaTable?: BLATableBuffer;
   terminator: SharedArrayBuffer;
+  reuseLastReference: boolean;
 
   progressMap: Map<string, number>;
   refProgress: number;

--- a/src/view/right-sidebar/informations.tsx
+++ b/src/view/right-sidebar/informations.tsx
@@ -4,14 +4,14 @@ import { useStoreValue } from "@/store/store";
 import { IconPin } from "@tabler/icons-react";
 
 export const Informations = () => {
-  const isReferencePinned = useStoreValue("isReferencePinned");
+  const shouldReuseRefOrbit = useStoreValue("shouldReuseRefOrbit");
 
-  if (!isReferencePinned) return null;
+  if (!shouldReuseRefOrbit) return null;
 
   return (
     <Card className="mx-2">
       <CardContent className="p-0 px-2 pt-1">
-        {isReferencePinned && (
+        {shouldReuseRefOrbit && (
           <div className="flex flex-col gap-1">
             <div className="flex">
               <IconPin /> Reference Orbit Pinned

--- a/src/worker-pool/reference-orbit-cache.ts
+++ b/src/worker-pool/reference-orbit-cache.ts
@@ -7,7 +7,9 @@ export const setRefOrbitCache = (cache: RefOrbitCache) => {
   latestRefOrbitCache = cache;
 };
 
-export const getRefOrbitCache = (params: MandelbrotParams) => {
+export const getRefOrbitCache = () => latestRefOrbitCache;
+
+export const getRefOrbitCacheIfAvailable = (params: MandelbrotParams) => {
   if (latestRefOrbitCache == null) {
     return null;
   }

--- a/src/worker-pool/reference-orbit-cache.ts
+++ b/src/worker-pool/reference-orbit-cache.ts
@@ -1,0 +1,42 @@
+import { MandelbrotParams, RefOrbitCache } from "@/types";
+
+let latestRefOrbitCache: RefOrbitCache | null = null;
+
+export const setRefOrbitCache = (cache: RefOrbitCache) => {
+  console.debug("setRefOrbitCache", cache);
+  latestRefOrbitCache = cache;
+};
+
+export const getRefOrbitCache = (params: MandelbrotParams) => {
+  if (latestRefOrbitCache == null) {
+    return null;
+  }
+
+  // maxIterationが違う場合は使わせない
+  if (latestRefOrbitCache.N !== params.N) {
+    return null;
+  }
+
+  if (
+    latestRefOrbitCache.x.eq(params.x) &&
+    latestRefOrbitCache.y.eq(params.y)
+  ) {
+    // 地点が同じでより深い場所でのキャッシュは間違いなく使える
+    if (latestRefOrbitCache.r.lt(params.r)) {
+      return latestRefOrbitCache;
+    }
+    // TODO: それより深い箇所でも使えるはず...
+  }
+
+  if (latestRefOrbitCache.r.eq(params.r)) {
+    // 同一拡大率の2画面分内での移動では使えることにしておく
+    if (
+      latestRefOrbitCache.x.minus(params.x).abs().lte(params.r.times(4)) &&
+      latestRefOrbitCache.y.minus(params.y).abs().lte(params.r.times(4))
+    ) {
+      return latestRefOrbitCache;
+    }
+  }
+
+  return null;
+};

--- a/src/worker-pool/worker-pool.ts
+++ b/src/worker-pool/worker-pool.ts
@@ -29,7 +29,11 @@ import {
   getWorkerPool,
   resetWorkerPool,
 } from "./pool-instance";
-import { getRefOrbitCache, setRefOrbitCache } from "./reference-orbit-cache";
+import {
+  getRefOrbitCache,
+  getRefOrbitCacheIfAvailable,
+  setRefOrbitCache,
+} from "./reference-orbit-cache";
 
 let waitingList: MandelbrotJob[] = [];
 let runningList: MandelbrotJob[] = [];
@@ -382,7 +386,11 @@ export function registerBatch(
   let refX = batchContext.mandelbrotParams.x.toString();
   let refY = batchContext.mandelbrotParams.y.toString();
 
-  const refOrbitCache = getRefOrbitCache(batchContext.mandelbrotParams);
+  // 再利用フラグが立っているなら問答無用でcacheを使い、そうでない場合は使える場合のみ使う
+  const refOrbitCache = batchContext.reuseLastReference
+    ? getRefOrbitCache()
+    : getRefOrbitCacheIfAvailable(batchContext.mandelbrotParams);
+
   if (refOrbitCache) {
     console.debug("Cache available. Using reference orbit cache");
 

--- a/src/worker-pool/worker-pool.ts
+++ b/src/worker-pool/worker-pool.ts
@@ -379,6 +379,8 @@ export function registerBatch(
   const progressMap = new Map<string, number>();
 
   const refPointJobId = crypto.randomUUID();
+  let refX = batchContext.mandelbrotParams.x.toString();
+  let refY = batchContext.mandelbrotParams.y.toString();
 
   const refOrbitCache = getRefOrbitCache(batchContext.mandelbrotParams);
   if (refOrbitCache) {
@@ -386,8 +388,8 @@ export function registerBatch(
 
     batchContext.xn = refOrbitCache.xn;
     batchContext.blaTable = refOrbitCache.blaTable;
-    batchContext.refX = refOrbitCache.x.toString();
-    batchContext.refY = refOrbitCache.y.toString();
+    refX = refOrbitCache.x.toString();
+    refY = refOrbitCache.y.toString();
   } else {
     waitingList.push({
       type: "calc-reference-point",
@@ -412,6 +414,8 @@ export function registerBatch(
 
   batchContextMap.set(batchId, {
     ...batchContext,
+    refX,
+    refY,
     progressMap,
     startedAt: performance.now(),
     refProgress: -1,

--- a/src/worker-pool/worker-pool.ts
+++ b/src/worker-pool/worker-pool.ts
@@ -387,7 +387,7 @@ export function registerBatch(
   let refY = batchContext.mandelbrotParams.y.toString();
 
   // 再利用フラグが立っているなら問答無用でcacheを使い、そうでない場合は使える場合のみ使う
-  const refOrbitCache = batchContext.reuseLastReference
+  const refOrbitCache = batchContext.shouldReuseRefOrbit
     ? getRefOrbitCache()
     : getRefOrbitCacheIfAvailable(batchContext.mandelbrotParams);
 


### PR DESCRIPTION
## 概要
- reference orbitを計算した位置とx, y地点が一緒でより浅い位置
- reference orbitを計算した位置との距離がrの4倍以内 (2画面分)

上記の条件を満たすときに前回計算したReference Orbitを再利用する
深いところではreference orbitの計算が8割以上なので、ちょっと左右を調整するときにかなり速くなる
合わせてピン留め機能も復活させた

## 再利用する値の範囲
いろいろ実験してみたが確実に安全（要出典）と言えるかなり狭い範囲のみ再利用している
rebasingもあるし深い位置でもreference orbit使いまわせるはずではある

この地点ではもう無効みたいなの判定するやつありそうなのであとで調べる