### PR TITLE
高速にキャンセルを繰り返したときにjobの実行が止まるバグの修正

### DIFF
--- a/src/worker-pool/reference-orbit-cache.ts
+++ b/src/worker-pool/reference-orbit-cache.ts
@@ -3,7 +3,6 @@ import { MandelbrotParams, RefOrbitCache } from "@/types";
 let latestRefOrbitCache: RefOrbitCache | null = null;
 
 export const setRefOrbitCache = (cache: RefOrbitCache) => {
-  console.debug("setRefOrbitCache", cache);
   latestRefOrbitCache = cache;
 };
 

--- a/src/worker-pool/worker-pool.ts
+++ b/src/worker-pool/worker-pool.ts
@@ -439,7 +439,7 @@ function tick(doneJobId: JobId | null = null) {
   const refPool = getWorkerPool("calc-reference-point");
   if (refPool.some((worker) => !worker.isReady() || worker.isRunning())) {
     // まだ準備ができていないworkerがいる場合は待つ
-    setTimeout(tick, 100);
+    setTimeout(() => tick(doneJobId), 100);
     return;
   }
 


### PR DESCRIPTION
## 概要
iterationを計算するworkerの終了を待っていなかったので、
terminateされてworkerが空く前にjob登録をしようとして失敗していたのを修正