### PR TITLE
パレットのoffsetを時間で切り替えるアニメーションモードを追加

### DIFF
--- a/src/color/index.ts
+++ b/src/color/index.ts
@@ -22,6 +22,7 @@ export type Palette = {
   size(): number;
 
   setOffset(offsetIndex: number): void;
+  cycleOffset(): void;
   setLength(length: number): void;
   setMirrored(mirrored: boolean): void;
 };
@@ -108,6 +109,10 @@ export class BasePalette implements Palette {
 
   public setOffset(offsetIndex: number): void {
     this.offsetIndex = offsetIndex;
+  }
+
+  public cycleOffset(): void {
+    this.offsetIndex = (this.offsetIndex + 1) % (this.colorLength * 2);
   }
 
   public setLength(length: number): void {

--- a/src/color/index.ts
+++ b/src/color/index.ts
@@ -22,7 +22,7 @@ export type Palette = {
   size(): number;
 
   setOffset(offsetIndex: number): void;
-  cycleOffset(): void;
+  cycleOffset(step?: number): void;
   setLength(length: number): void;
   setMirrored(mirrored: boolean): void;
 };
@@ -111,8 +111,8 @@ export class BasePalette implements Palette {
     this.offsetIndex = offsetIndex;
   }
 
-  public cycleOffset(): void {
-    this.offsetIndex = (this.offsetIndex + 1) % (this.colorLength * 2);
+  public cycleOffset(step = 1): void {
+    this.offsetIndex = (this.offsetIndex + step) % (this.colorLength * 2);
   }
 
   public setLength(length: number): void {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,9 +6,11 @@ import { getIterationTimeAt } from "./aggregator";
 import {
   addPalettes,
   clearResultBuffer,
+  getPalette,
   mergeToMainBuffer,
   nextBuffer,
   nextResultBuffer,
+  redraw,
   setColorIndex,
   setupCamera,
 } from "./camera";
@@ -78,6 +80,8 @@ let mouseDragged = false;
 let mouseClickedOn = { mouseX: 0, mouseY: 0 };
 let mouseReleasedOn = { mouseX: 0, mouseY: 0 };
 let mouseDraggedComplete = false;
+
+let elapsed = 0;
 
 const isInside = (p: p5) =>
   0 <= p.mouseX && p.mouseX <= p.width && 0 <= p.mouseY && p.mouseY <= p.height;
@@ -265,6 +269,13 @@ const sketch = (p: p5) => {
   };
 
   p.draw = () => {
+    elapsed += p.deltaTime;
+    if (elapsed > 60) {
+      elapsed = elapsed % 60;
+      getPalette().cycleOffset();
+      redraw();
+    }
+
     const mainBuffer = nextBuffer(p);
     const resultBuffer = nextResultBuffer(p);
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -269,11 +269,16 @@ const sketch = (p: p5) => {
   };
 
   p.draw = () => {
-    elapsed += p.deltaTime;
-    if (elapsed > 60) {
-      elapsed = elapsed % 60;
-      getPalette().cycleOffset();
-      redraw();
+    const time = getStore("animationTime");
+
+    if (time > 0) {
+      elapsed += p.deltaTime;
+
+      if (elapsed > time) {
+        elapsed = elapsed % time;
+        getPalette().cycleOffset();
+        redraw();
+      }
     }
 
     const mainBuffer = nextBuffer(p);
@@ -321,6 +326,7 @@ const entrypoint = () => {
     // Settings
     zoomRate: 2.0,
     workerCount: 2,
+    animationTime: 0,
     refPointWorkerCount: 1, // 仮
     // UI state
     canvasLocked: false,

--- a/src/store/sync-storage/settings.ts
+++ b/src/store/sync-storage/settings.ts
@@ -3,6 +3,7 @@ import { getStore } from "../store";
 export type Settings = {
   zoomRate: number;
   workerCount: number;
+  animationTime: number;
 };
 
 export const DEFAULT_WORKER_COUNT = navigator.hardwareConcurrency;
@@ -10,6 +11,7 @@ export const DEFAULT_WORKER_COUNT = navigator.hardwareConcurrency;
 const defaultSettings = {
   zoomRate: 2.0,
   workerCount: DEFAULT_WORKER_COUNT,
+  animationTime: 0,
 } satisfies Settings;
 
 export const isSettingField = (key: string): key is keyof Settings =>
@@ -19,6 +21,7 @@ export const writeSettingsToStorage = () => {
   const settings = {
     zoomRate: getStore("zoomRate"),
     workerCount: getStore("workerCount"),
+    animationTime: getStore("animationTime"),
   } satisfies Settings;
 
   const serialized = JSON.stringify(settings);

--- a/src/view/right-sidebar/settings.tsx
+++ b/src/view/right-sidebar/settings.tsx
@@ -37,14 +37,14 @@ export const Settings = () => {
   const workerCountValues = createWorkerCountValues();
   const animationTimeValues = [
     "0",
-    "6",
-    "16",
-    "33",
-    "60",
-    "100",
-    "300",
-    "600",
     "1000",
+    "600",
+    "300",
+    "100",
+    "60",
+    "33",
+    "16",
+    "6",
   ];
 
   const [zoomRatePreview, setZoomRatePreview] = useState(zoomRate);

--- a/src/view/right-sidebar/settings.tsx
+++ b/src/view/right-sidebar/settings.tsx
@@ -1,4 +1,4 @@
-import { updateStore, useStoreValue } from "../../store/store";
+import { getStore, updateStore, useStoreValue } from "../../store/store";
 import { DEFAULT_WORKER_COUNT } from "../../store/sync-storage/settings";
 import { Slider } from "@/components/ui/slider";
 import { useState } from "react";
@@ -8,6 +8,7 @@ import { useToast } from "@/components/ui/use-toast";
 import { IconCircleCheck } from "@tabler/icons-react";
 import { prepareWorkerPool } from "@/worker-pool/worker-pool";
 import { ValueSlider } from "@/components/slider-wrapper";
+import { set } from "idb-keyval";
 
 const createWorkerCountValues = () => {
   const base = DEFAULT_WORKER_COUNT;
@@ -34,9 +35,23 @@ export const Settings = () => {
 
   const zoomRateValues = ["1.2", "1.5", "2.0", "4.0", "6.0", "10", "50", "100"];
   const workerCountValues = createWorkerCountValues();
+  const animationTimeValues = [
+    "0",
+    "6",
+    "16",
+    "33",
+    "60",
+    "100",
+    "300",
+    "600",
+    "1000",
+  ];
 
   const [zoomRatePreview, setZoomRatePreview] = useState(zoomRate);
   const [workerCountPreview, setWorkerCountPreview] = useState(workerCount);
+  const [animationTime, setAnimationTime] = useState(() =>
+    getStore("animationTime"),
+  );
 
   return (
     <div className="flex max-w-80 flex-col gap-6">
@@ -60,6 +75,24 @@ export const Settings = () => {
           onValueCommit={(value) => {
             updateStore("workerCount", value);
             prepareWorkerPool();
+          }}
+        />
+      </div>
+      <div>
+        <div className="mb-1 ml-2">
+          Animation Frequency:{" "}
+          {animationTime === 0 ? "None" : `${animationTime} ms`}
+        </div>
+        <ValueSlider<number>
+          values={animationTimeValues}
+          defaultValue={animationTime}
+          valueConverter={(value) => parseInt(value)}
+          onValueChange={(value) => {
+            setAnimationTime(value);
+          }}
+          onValueCommit={(value) => {
+            setAnimationTime(value);
+            updateStore("animationTime", value);
           }}
         />
       </div>


### PR DESCRIPTION
## 概要
スライダーでoffsetを高速に切り替えて遊んでたらこれアニメーションさせられるじゃんと気付いたので勢いで実装した
Settingsタブから変更できる
[![Image from Gyazo](https://i.gyazo.com/dafb332c1f5587720d72c1887ab7bbbd.png)](https://gyazo.com/dafb332c1f5587720d72c1887ab7bbbd)

設定によっては144fpsでアニメーションしちゃうので注意
自分の環境ではファンが大回転はするけど特に重くはならなかった

## 動画
https://github.com/k-chop/p5mandelbrot/assets/241973/f8df386d-8477-4845-883b-b1cb4551d3d3

paletteLengthを減らしてアニメーションさせるとすごいことになる

https://github.com/k-chop/p5mandelbrot/assets/241973/493bf7c4-3dfd-45ff-a1ee-fceaf4ec0f27

パレットのoffsetを変えるだけなので生成中や移動時も特に問題なく動く
