### PR TITLE
Add headers to vite.config.ts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@ node_modules
 dist
 dist-ssr
 *.local
+.pnp*
+yarn.lock
+.yarn/*
+
 
 # Editor directories and files
 .vscode/*

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,4 +10,10 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  server: {
+    headers: {
+      'Cross-Origin-Opener-Policy': 'same-origin',
+      'Cross-Origin-Embedder-Policy': 'require-corp'
+    },
+  },
 });


### PR DESCRIPTION
Without these headers, runtime fails with 
```
mandelbrot.ts:214 Uncaught (in promise) ReferenceError: SharedArrayBuffer is not defined
    at startCalculation (mandelbrot.ts:214:22)
    at p.draw (main.tsx:306:7)
    at e2.default.redraw (p5.js?v=6beed1d0:11623:22)
    at _draw (p5.js?v=6beed1d0:10324:165)
```
on localhost. I used `yarn dev` to run it.