### PR TITLE
指定したworker数を最大限使わないことがあったのを修正

### DIFF
--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -161,12 +161,9 @@ export const startCalculation = async (onComplete: () => void) => {
 
   const divideRectCount = getWorkerCount("calc-iteration");
 
-  const minSide = Math.floor(Math.sqrt((width * height) / divideRectCount));
-
   let calculationRects = divideRect(
     [{ x: 0, y: 0, width, height }],
     divideRectCount,
-    minSide,
   );
 
   if (offsetParams.x !== 0 || offsetParams.y !== 0) {
@@ -196,11 +193,7 @@ export const startCalculation = async (onComplete: () => void) => {
     // ただしどのくらいの距離まで有効なのか、有効でなくなったことをどう検知したらいいのかわからん
 
     const expectedDivideCount = Math.max(divideRectCount, 2);
-    calculationRects = divideRect(
-      getOffsetRects(),
-      expectedDivideCount,
-      minSide,
-    );
+    calculationRects = divideRect(getOffsetRects(), expectedDivideCount);
   } else {
     // 移動していない場合は再利用するCacheがないので消す
     clearIterationCache();

--- a/src/rect.ts
+++ b/src/rect.ts
@@ -74,7 +74,7 @@ export const calculateDivideArea = (
 export const divideRect = (
   rects: Rect[],
   expectedDivideCount: number,
-  minSide = 100,
+  minSide = 1,
 ): Rect[] => {
   if (rects.length > expectedDivideCount) {
     throw new Error("rects.length > expectedDivideCount");


### PR DESCRIPTION
## Summary
- `minSide` が指定してあるせいでworkerを目いっぱい使わないことがあった
- `minSide` が不要と判断し削除
   - この最低100も謎だし `Math.floor(Math.sqrt((width * height) / divideRectCount));` も何の意図があってこの指定になってるのか謎
   - とりあえず0にだけならないようにしておいた
