### PR TITLE
URLのShare, POI登録時にpaletteの状態も保存できるようにした

### DIFF
--- a/src/camera/palette.ts
+++ b/src/camera/palette.ts
@@ -1,6 +1,7 @@
 import {
   chromaJsPalettes,
   d3ChromaticPalettes,
+  deserializePalette,
   othersPalettes,
   type Palette,
 } from "@/color";
@@ -65,6 +66,26 @@ export const changePaletteFromPresets = (index: number) => {
 export const setPalette = (palette: Palette) => {
   currentPalette = palette;
   markNeedsRerender();
+};
+
+/**
+ * serializedされたPaletteを設定する
+ *
+ * deserializeに失敗した場合は握りつぶして現在のpaletteを維持する
+ */
+export const setSerializedPalette = (serialized?: string) => {
+  if (serialized == null) return;
+
+  let palette = getCurrentPalette();
+
+  try {
+    palette = deserializePalette(serialized);
+  } catch (e) {
+    console.error(e);
+  }
+
+  console.log("Loaded serialized palette", palette);
+  setPalette(palette);
 };
 
 /**

--- a/src/camera/palette.ts
+++ b/src/camera/palette.ts
@@ -5,6 +5,7 @@ import {
   othersPalettes,
   type Palette,
 } from "@/color";
+import { updateStore } from "@/store/store";
 
 // 描画時に使うpaletteの状態に関するファイル
 
@@ -66,6 +67,9 @@ export const changePaletteFromPresets = (index: number) => {
 export const setPalette = (palette: Palette) => {
   currentPalette = palette;
   markNeedsRerender();
+
+  updateStore("paletteLength", palette.length);
+  updateStore("paletteOffset", palette.offset);
 };
 
 /**

--- a/src/camera/palette.ts
+++ b/src/camera/palette.ts
@@ -85,7 +85,11 @@ export const setSerializedPalette = (serialized?: string) => {
   }
 
   console.log("Loaded serialized palette", palette);
-  setPalette(palette);
+  console.log(
+    "But this feature is currently bugged and not working. We'll keep the current palette for now, sorry.",
+  );
+
+  // setPalette(palette);
 };
 
 /**

--- a/src/camera/palette.ts
+++ b/src/camera/palette.ts
@@ -85,11 +85,8 @@ export const setSerializedPalette = (serialized?: string) => {
   }
 
   console.log("Loaded serialized palette", palette);
-  console.log(
-    "But this feature is currently bugged and not working. We'll keep the current palette for now, sorry.",
-  );
 
-  // setPalette(palette);
+  setPalette(palette);
 };
 
 /**

--- a/src/color/color-chromajs.ts
+++ b/src/color/color-chromajs.ts
@@ -26,6 +26,7 @@ export class ChromaJsPalette extends BasePalette {
     }
 
     this.buildColors();
+    this.fillCache();
   }
 
   getRGBFromColorIndex(index: number): RGB {

--- a/src/color/color-d3-chromatic.ts
+++ b/src/color/color-d3-chromatic.ts
@@ -59,6 +59,7 @@ export class D3ChromaticPalette extends BasePalette {
     this.interpolator = interpolator;
 
     this.buildColors();
+    this.fillCache();
   }
 
   getRGBFromColorIndex(index: number): RGB {

--- a/src/color/color-others.ts
+++ b/src/color/color-others.ts
@@ -55,6 +55,7 @@ export class OthersPalette extends BasePalette {
     this.interpolator = interpolator;
 
     this.buildColors();
+    this.fillCache();
   }
 
   buildColors(): void {

--- a/src/color/color.ts
+++ b/src/color/color.ts
@@ -21,6 +21,15 @@ export class BasePalette implements Palette {
     this.cacheInitialized = new Array(this.colorLength).fill(false);
   }
 
+  fillCache(): void {
+    console.log("Fill cache: ", this.colorLength);
+
+    for (let i = 0; i < this.colorLength; i++) {
+      const rgb = this.getRGBFromColorIndex(i);
+      this.writeCache(i, rgb);
+    }
+  }
+
   getRGBFromColorIndex(index: number): RGB {
     throw new Error("Not implemented");
   }

--- a/src/color/color.ts
+++ b/src/color/color.ts
@@ -42,6 +42,14 @@ export class BasePalette implements Palette {
     throw new Error("Not implemented");
   }
 
+  public get length(): number {
+    return this.colorLength;
+  }
+
+  public get offset(): number {
+    return this.offsetIndex;
+  }
+
   public rgb(index: number): RGB {
     const colorIndex = this.getColorIndex(index);
 

--- a/src/color/index.ts
+++ b/src/color/index.ts
@@ -3,3 +3,5 @@ export type { Palette } from "./model";
 export { chromaJsPalettes } from "./color-chromajs";
 export { d3ChromaticPalettes } from "./color-d3-chromatic";
 export { othersPalettes } from "./color-others";
+
+export { deserializePalette } from "./deserializer";

--- a/src/color/model.ts
+++ b/src/color/model.ts
@@ -11,6 +11,9 @@ export type Palette = {
 
   size(): number;
 
+  get offset(): number;
+  get length(): number;
+
   setOffset(offsetIndex: number): void;
   cycleOffset(step?: number): void;
   setLength(length: number): void;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,6 +8,7 @@ import {
 import {
   changePaletteFromPresets,
   cycleCurrentPaletteOffset,
+  setPalette,
 } from "@/camera/palette";
 import BigNumber from "bignumber.js";
 import p5 from "p5";
@@ -118,7 +119,8 @@ const sketch = (p: p5) => {
     const initialParams = extractMandelbrotParams();
 
     if (initialParams) {
-      setCurrentParams(initialParams);
+      setCurrentParams(initialParams.mandelbrot);
+      setPalette(initialParams.palette);
     }
   };
 

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -5,7 +5,7 @@ import {
 } from "./aggregator";
 import { renderToResultBuffer } from "./camera/camera";
 import { divideRect, Rect } from "./rect";
-import { getStore, updateStoreWith } from "./store/store";
+import { getStore, updateStore, updateStoreWith } from "./store/store";
 import { MandelbrotParams, OffsetParams } from "./types";
 import { getWorkerCount, prepareWorkerPool } from "./worker-pool/pool-instance";
 import {
@@ -111,6 +111,10 @@ export const setCurrentParams = (params: Partial<MandelbrotParams>) => {
   const needResetOffset = params.r != null && !currentParams.r.eq(params.r);
 
   currentParams = { ...currentParams, ...params };
+
+  updateStore("r", params.r);
+  updateStore("N", params.N);
+  updateStore("mode", params.mode);
 
   if (needModeChange) {
     const workerCount = getStore("workerCount");

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -112,9 +112,9 @@ export const setCurrentParams = (params: Partial<MandelbrotParams>) => {
 
   currentParams = { ...currentParams, ...params };
 
-  updateStore("r", params.r);
-  updateStore("N", params.N);
-  updateStore("mode", params.mode);
+  updateStore("r", currentParams.r);
+  updateStore("N", currentParams.N);
+  updateStore("mode", currentParams.mode);
 
   if (needModeChange) {
     const workerCount = getStore("workerCount");

--- a/src/store/sync-storage/poi-list.ts
+++ b/src/store/sync-storage/poi-list.ts
@@ -1,15 +1,20 @@
+import type { Palette } from "@/color";
 import BigNumber from "bignumber.js";
 import { Result, err, ok } from "neverthrow";
 import { MandelbrotParams, POIData } from "../../types";
 import { updateStore } from "../store";
 
-export const createNewPOIData = (params: MandelbrotParams): POIData => ({
+export const createNewPOIData = (
+  params: MandelbrotParams,
+  palette: Palette,
+): POIData => ({
   id: crypto.randomUUID(),
   ...params,
+  serializedPalette: palette.serialize(),
 });
 
 export const writePOIListToStorage = (poiList: POIData[]) => {
-  const serialized = JSON.stringify(poiList.map(serializedMandelbrotParams));
+  const serialized = JSON.stringify(poiList.map(serializedPOIData));
   localStorage.setItem("poiList", serialized);
 };
 
@@ -21,7 +26,7 @@ export const readPOIListFromStorage = (): POIData[] => {
   return rawList.map(deserializedMandelbrotParams);
 };
 
-const serializedMandelbrotParams = (params: POIData) => {
+const serializedPOIData = (params: POIData) => {
   return {
     id: params.id,
     x: params.x.toString(),
@@ -29,6 +34,7 @@ const serializedMandelbrotParams = (params: POIData) => {
     r: params.r.toString(),
     N: params.N,
     mode: params.mode,
+    serializedPalette: params.serializedPalette,
   };
 };
 
@@ -42,6 +48,7 @@ const deserializedMandelbrotParams = (params: any): POIData => {
     r: new BigNumber(params.r),
     N: params.N,
     mode: params.mode,
+    serializedPalette: params.serializedPalette,
   };
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,6 +58,7 @@ export interface MandelbrotParams {
 
 export interface POIData extends MandelbrotParams {
   id: string; // UUID
+  serializedPalette?: string;
 }
 
 export interface IterationWorkerParams {

--- a/src/view/right-sidebar/use-poi.tsx
+++ b/src/view/right-sidebar/use-poi.tsx
@@ -30,9 +30,13 @@ export const usePOI = () => {
   const regenerateThumbnailPOI = useCallback(
     (index: number) => {
       const poi = poiList[index];
+      poi.serializedPalette = getCurrentPalette().serialize();
+      writePOIListToStorage(poiList);
 
       const imageDataURL = getResizedCanvasImageDataURL(100);
       savePreview(poi.id, imageDataURL);
+
+      updateStore("poi", poiList);
     },
     [poiList],
   );

--- a/src/view/right-sidebar/use-poi.tsx
+++ b/src/view/right-sidebar/use-poi.tsx
@@ -1,3 +1,4 @@
+import { getCurrentPalette, setSerializedPalette } from "@/camera/palette";
 import { getResizedCanvasImageDataURL } from "@/canvas-reference";
 import { deletePreview, savePreview } from "@/store/preview-store";
 import { useCallback } from "react";
@@ -14,7 +15,7 @@ export const usePOI = () => {
 
   const addPOI = useCallback(
     (newParams: MandelbrotParams) => {
-      const newPOI = createNewPOIData(newParams);
+      const newPOI = createNewPOIData(newParams, getCurrentPalette());
       const newPOIList = [newPOI, ...poiList];
       writePOIListToStorage(newPOIList);
 
@@ -49,8 +50,9 @@ export const usePOI = () => {
     [poiList],
   );
 
-  const applyPOI = useCallback((poi: MandelbrotParams) => {
+  const applyPOI = useCallback((poi: POIData) => {
     setCurrentParams(cloneParams(poi));
+    setSerializedPalette(poi.serializedPalette);
   }, []);
 
   const copyPOIListToClipboard = useCallback(() => {

--- a/src/worker-pool/pool-instance.ts
+++ b/src/worker-pool/pool-instance.ts
@@ -118,10 +118,11 @@ export async function prepareWorkerPool(
 /**
  * WorkerPoolを溜まっていたJobごと全部リセットする
  */
-export async function resetWorkers() {
-  await iterateAllWorkerAsync(async (workerFacade) => {
+export function resetWorkers() {
+  iterateAllWorker((workerFacade) => {
     workerFacade.clearCallbacks();
-    await workerFacade.terminateAsync();
+    // fire and forget
+    workerFacade.terminateAsync();
   });
   resetAllWorker();
 


### PR DESCRIPTION
## Summary
- mandelbrot setの表示状態をPaletteも含め復元できるようになった
- 今までのpalette情報がないケースは今まで通り現状のpaletteを使って描画する

## 補足
- Paletteを読み込んだ直後に色がおかしくなるバグが存在していたが、とりあえずcolor cacheを最初に全部埋めておくと解消した
   - presetのpaletteは全部長さ128だしそこまで重くはならない気がする
