### PR TITLE
履歴データを保存しておいて一発で飛べるようにした

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -32,6 +32,7 @@ import {
   togglePinReference,
   zoom,
 } from "./mandelbrot";
+import { initializePOIHistory } from "./poi-history/poi-history";
 import { drawCrossHair } from "./rendering";
 import { createStore, getStore, updateStore } from "./store/store";
 import { readPOIListFromStorage } from "./store/sync-storage/poi-list";
@@ -115,6 +116,8 @@ const sketch = (p: p5) => {
     p.cursor(p.CROSS);
 
     setP5(p);
+
+    initializePOIHistory();
 
     const initialParams = extractMandelbrotParams();
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -32,7 +32,10 @@ import {
   togglePinReference,
   zoom,
 } from "./mandelbrot";
-import { initializePOIHistory } from "./poi-history/poi-history";
+import {
+  addCurrentLocationToPOIHistory,
+  initializePOIHistory,
+} from "./poi-history/poi-history";
 import { drawCrossHair } from "./rendering";
 import { createStore, getStore, updateStore } from "./store/store";
 import { readPOIListFromStorage } from "./store/sync-storage/poi-list";
@@ -306,6 +309,8 @@ const sketch = (p: p5) => {
           // elapsed=0は中断時なのでなにもしない
           mouseDraggedComplete = false;
           mergeToMainBuffer();
+
+          addCurrentLocationToPOIHistory();
         }
       });
     }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -301,9 +301,12 @@ const sketch = (p: p5) => {
     drawInfo(p);
 
     if (paramsChanged()) {
-      startCalculation(() => {
-        mouseDraggedComplete = false;
-        mergeToMainBuffer();
+      startCalculation((elapsed: number) => {
+        if (elapsed !== 0) {
+          // elapsed=0は中断時なのでなにもしない
+          mouseDraggedComplete = false;
+          mergeToMainBuffer();
+        }
       });
     }
   };

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -155,7 +155,9 @@ export const paramsChanged = () => {
   return !isSameParams(lastCalc, currentParams);
 };
 
-export const startCalculation = async (onComplete: () => void) => {
+export const startCalculation = async (
+  onComplete: (elapsed: number) => void,
+) => {
   updateCurrentParams();
 
   const currentBatchId = crypto.randomUUID();

--- a/src/poi-history/poi-history.ts
+++ b/src/poi-history/poi-history.ts
@@ -17,7 +17,7 @@ let initialized = false;
 
 const event = eventmit<string>();
 const POI_HISTORY_CHANGED = "poi-history-changed";
-const MAX_HISTORY = 100;
+const MAX_HISTORY = 25;
 
 /**
  * 末尾に履歴データを追加する

--- a/src/poi-history/poi-history.ts
+++ b/src/poi-history/poi-history.ts
@@ -1,0 +1,82 @@
+import { getCurrentPalette } from "@/camera/palette";
+import { getResizedCanvasImageDataURL } from "@/canvas-reference";
+import { getCurrentParams } from "@/mandelbrot";
+import { createNewPOIData } from "@/store/sync-storage/poi-list";
+import type { POIData } from "@/types";
+import { eventmit } from "eventmit";
+import { useEffect, useState } from "react";
+import { loadHistoriesFromStorage, saveHistoriesToStorage } from "./store";
+
+// poi-historyのデータ保持と読み書きを行う処理
+
+// POIDataに加えthumbnailも一緒に保持する
+export type POIHistory = POIData & { imageDataUrl: string };
+
+const poiHistory: POIHistory[] = [];
+let initialized = false;
+
+const event = eventmit<string>();
+const POI_HISTORY_CHANGED = "poi-history-changed";
+const MAX_HISTORY = 100;
+
+/**
+ * 末尾に履歴データを追加する
+ */
+export const addPOIToHistory = (poi: POIHistory) => {
+  if (!initialized) {
+    throw new Error("POI History not initialized");
+  }
+
+  poiHistory.push(poi);
+  // 常にMAX_HISTORY個以下に保つ
+  if (poiHistory.length > MAX_HISTORY) {
+    poiHistory.splice(0, poiHistory.length - MAX_HISTORY);
+  }
+
+  event.emit(POI_HISTORY_CHANGED);
+  saveHistoriesToStorage(poiHistory);
+};
+
+/**
+ * 今表示しているcanvasの内容と位置を履歴に追加する
+ */
+export const addCurrentLocationToPOIHistory = () => {
+  const poi = createNewPOIData(getCurrentParams(), getCurrentPalette());
+  const imageDataUrl = getResizedCanvasImageDataURL(100);
+
+  addPOIToHistory({ ...poi, imageDataUrl });
+};
+
+/**
+ * poi-historyを供給するhooks
+ */
+export const usePOIHistories = () => {
+  const [value, setValue] = useState(() => poiHistory);
+
+  useEffect(() => {
+    const handler = () => {
+      setValue([...poiHistory]);
+    };
+    event.on(handler);
+
+    return () => {
+      event.off(handler);
+    };
+  }, []);
+
+  return value;
+};
+
+/**
+ * poi-historyの初期化
+ */
+export const initializePOIHistory = () => {
+  // fire and forget
+  return loadHistoriesFromStorage().then((history) => {
+    if (history) {
+      poiHistory.push(...history);
+    }
+    console.debug("POI History initialized from storage", poiHistory);
+    initialized = true;
+  });
+};

--- a/src/poi-history/poi-history.ts
+++ b/src/poi-history/poi-history.ts
@@ -24,7 +24,8 @@ const MAX_HISTORY = 100;
  */
 export const addPOIToHistory = (poi: POIHistory) => {
   if (!initialized) {
-    throw new Error("POI History not initialized");
+    console.error("POI History is not initialized yet");
+    return;
   }
 
   poiHistory.push(poi);

--- a/src/poi-history/store.tsx
+++ b/src/poi-history/store.tsx
@@ -1,0 +1,23 @@
+import { get, set } from "idb-keyval";
+import type { POIHistory } from "./poi-history";
+
+// poi-historyをindexedDBに読み書きする処理
+
+/** indexedDBのキー */
+const POI_HISTORY_KEY = "poi-history";
+
+/**
+ * 履歴データをindexedDBに保存
+ */
+export const saveHistoriesToStorage = (history: POIHistory[]) => {
+  set(POI_HISTORY_KEY, history);
+};
+
+/**
+ * indexedDBから履歴データを読む
+ */
+export const loadHistoriesFromStorage = async (): Promise<
+  POIHistory[] | undefined
+> => {
+  return get(POI_HISTORY_KEY);
+};

--- a/src/store/preview-store.ts
+++ b/src/store/preview-store.ts
@@ -32,7 +32,7 @@ export const useTrackChangePreview = (id: string) => {
     return () => {
       event.off(handler);
     };
-  }, []);
+  }, [id]);
 
   return value;
 };

--- a/src/store/sync-storage/poi-list.ts
+++ b/src/store/sync-storage/poi-list.ts
@@ -14,7 +14,7 @@ export const createNewPOIData = (
 });
 
 export const writePOIListToStorage = (poiList: POIData[]) => {
-  const serialized = JSON.stringify(poiList.map(serializedPOIData));
+  const serialized = JSON.stringify(poiList.map(serializePOIData));
   localStorage.setItem("poiList", serialized);
 };
 
@@ -23,10 +23,10 @@ export const readPOIListFromStorage = (): POIData[] => {
   if (!serialized) return [];
 
   const rawList = JSON.parse(serialized);
-  return rawList.map(deserializedMandelbrotParams);
+  return rawList.map(deserializeMandelbrotParams);
 };
 
-const serializedPOIData = (params: POIData) => {
+export const serializePOIData = (params: POIData) => {
   return {
     id: params.id,
     x: params.x.toString(),
@@ -38,7 +38,7 @@ const serializedPOIData = (params: POIData) => {
   };
 };
 
-const deserializedMandelbrotParams = (params: any): POIData => {
+export const deserializeMandelbrotParams = (params: any): POIData => {
   const id = params.id == null ? crypto.randomUUID() : params.id;
 
   return {
@@ -82,7 +82,7 @@ export const readPOIListFromClipboard = async (): Promise<
 
     const rawList = JSON.parse(serialized);
 
-    const importedPOIList = rawList.map(deserializedMandelbrotParams);
+    const importedPOIList = rawList.map(deserializeMandelbrotParams);
 
     const existsPOIList = readPOIListFromStorage();
     const { result, imported, conflicted } = mergePOIList(

--- a/src/view/right-sidebar/index.tsx
+++ b/src/view/right-sidebar/index.tsx
@@ -1,7 +1,7 @@
-import { POIHistories } from "../footer/poi-histories";
 import { Informations } from "./informations";
 import { Operations } from "./operations";
 import { Parameters } from "./parameters";
+import { POIHistories } from "./poi-histories";
 
 export const RightSidebar = () => {
   return (

--- a/src/view/right-sidebar/index.tsx
+++ b/src/view/right-sidebar/index.tsx
@@ -1,3 +1,4 @@
+import { POIHistories } from "../footer/poi-histories";
 import { Informations } from "./informations";
 import { Operations } from "./operations";
 import { Parameters } from "./parameters";
@@ -8,6 +9,7 @@ export const RightSidebar = () => {
       <Parameters />
       <Informations />
       <Operations />
+      <POIHistories />
     </div>
   );
 };

--- a/src/view/right-sidebar/poi-histories.tsx
+++ b/src/view/right-sidebar/poi-histories.tsx
@@ -1,0 +1,27 @@
+import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
+import { usePOIHistories } from "@/poi-history/poi-history";
+import { useMemo } from "react";
+
+export const POIHistories = () => {
+  const raw = usePOIHistories();
+  const histories = useMemo(() => raw.slice().reverse(), [raw]);
+
+  return (
+    <ScrollArea className="w-full">
+      <div className="r-4 flex flex-nowrap gap-2 px-2 py-4">
+        {histories.map((history) => {
+          return (
+            <div key={history.id} className="min-w-[100px]">
+              <img
+                src={history.imageDataUrl}
+                width="100"
+                className=" rounded-xl"
+              />
+            </div>
+          );
+        })}
+      </div>
+      <ScrollBar orientation="horizontal" />
+    </ScrollArea>
+  );
+};

--- a/src/view/right-sidebar/poi-histories.tsx
+++ b/src/view/right-sidebar/poi-histories.tsx
@@ -1,9 +1,14 @@
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 import { usePOIHistories } from "@/poi-history/poi-history";
 import { useMemo } from "react";
+import { usePOI } from "./use-poi";
 
+/**
+ * 履歴データの表示コンポーネント
+ */
 export const POIHistories = () => {
   const raw = usePOIHistories();
+  const { applyPOI } = usePOI();
   const histories = useMemo(() => raw.slice().reverse(), [raw]);
 
   return (
@@ -12,11 +17,13 @@ export const POIHistories = () => {
         {histories.map((history) => {
           return (
             <div key={history.id} className="min-w-[100px]">
-              <img
-                src={history.imageDataUrl}
-                width="100"
-                className=" rounded-xl"
-              />
+              <button onClick={() => applyPOI(history)}>
+                <img
+                  src={history.imageDataUrl}
+                  width="100"
+                  className="rounded-xl"
+                />
+              </button>
             </div>
           );
         })}


### PR DESCRIPTION
## Summary
- POIListの仕組みを流用して表示した内容の履歴を取るようにした
   - ちょっと前に戻りたいときに便利
- とりあえず25件に制限している
   - thumbnailはせいぜい10kbなので100件とかでも特に困らないと思うけど一応

## Bug
- perturbationでない場合にまだ書き込まれきっていないbufferの内容でthumbnailが作られてしまう
   - この辺のbuffer周りは整理したいのでそのときに直す

## Image
![image](https://github.com/user-attachments/assets/11f8e978-6ceb-4a8c-8138-40d532067bb7)

## 感想
- canvasを800x800固定にしているせいで、画面サイズによるレイアウトの変化に困っているのでresponsiveにしたい