### PR TITLE
canvasの左上にロード中表示を追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,10 @@
     <div id="app-root"></div>
     <div id="main">
       <div id="header"></div>
-      <div id="p5root"></div>
+      <div id="canvas-wrapper">
+        <div id="p5root"></div>
+        <div id="canvas-overlay"></div>
+      </div>
       <div id="sidebar-right"></div>
       <div id="footer"></div>
     </div>

--- a/src/components/loading-spinner.tsx
+++ b/src/components/loading-spinner.tsx
@@ -1,5 +1,7 @@
 import { LoaderCircle } from "lucide-react";
 
 export const LoadingSpinner = () => {
-  return <LoaderCircle className="size-16 animate-spin" />;
+  return (
+    <LoaderCircle className="size-8 animate-spin text-gray-100 drop-shadow-[0_0_3px_rgba(0,0,0,1)]" />
+  );
 };

--- a/src/components/loading-spinner.tsx
+++ b/src/components/loading-spinner.tsx
@@ -1,0 +1,5 @@
+import { LoaderCircle } from "lucide-react";
+
+export const LoadingSpinner = () => {
+  return <LoaderCircle className="size-16 animate-spin" />;
+};

--- a/src/style.css
+++ b/src/style.css
@@ -77,11 +77,22 @@ body {
   grid-area: header;
 }
 
-#p5root {
+#canvas-wrapper {
+  position: relative;
   grid-area: canvas;
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+#p5root {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#canvas-overlay {
+  position: absolute;
 }
 
 #sidebar-right {

--- a/src/view/app-root.tsx
+++ b/src/view/app-root.tsx
@@ -1,5 +1,6 @@
 import { Toaster } from "@/components/ui/toaster";
 import ReactDOM from "react-dom";
+import { CanvasOverlay } from "./canvas-overlay";
 import { Footer } from "./footer";
 import { Header } from "./header";
 import { RightSidebar } from "./right-sidebar";
@@ -13,6 +14,10 @@ export const AppRoot = () => {
         document.getElementById("sidebar-right")!,
       )}
       {ReactDOM.createPortal(<Footer />, document.getElementById("footer")!)}
+      {ReactDOM.createPortal(
+        <CanvasOverlay />,
+        document.getElementById("canvas-overlay")!,
+      )}
       <Toaster />
     </>
   );

--- a/src/view/canvas-overlay/index.tsx
+++ b/src/view/canvas-overlay/index.tsx
@@ -1,0 +1,9 @@
+import { LoadingSpinner } from "@/components/loading-spinner";
+
+export const CanvasOverlay = () => {
+  return (
+    <div className="size-[800px]">
+      <LoadingSpinner />
+    </div>
+  );
+};

--- a/src/view/canvas-overlay/index.tsx
+++ b/src/view/canvas-overlay/index.tsx
@@ -1,9 +1,12 @@
 import { LoadingSpinner } from "@/components/loading-spinner";
+import { useStoreValue } from "@/store/store";
 
 export const CanvasOverlay = () => {
+  const progress = useStoreValue("progress");
+
   return (
-    <div className="size-[800px]">
-      <LoadingSpinner />
+    <div className="size-[800px] p-1">
+      {typeof progress === "string" && <LoadingSpinner />}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- canvasの右上にloading spinnerを表示するようにした
   - Loading中＝描画が開始されてから完了するまでの間

## Image
![image](https://github.com/user-attachments/assets/165e131c-7336-430a-b946-746c88c94120)

## 感想
- ロード中は画面薄暗くするのもしようかなと思ったけどやめた
   - あんまりチカチカするとだるい