### PR TITLE
不要なバックバッファを削除、ついでにバグ修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,9 +25,9 @@
     <div id="app-root"></div>
     <div id="main">
       <div id="header"></div>
-      <div id="canvas-wrapper">
-        <div id="p5root"></div>
+      <div id="canvas-wrapper" style="pointer-events: none">
         <div id="canvas-overlay"></div>
+        <div id="p5root" style="pointer-events: auto"></div>
       </div>
       <div id="sidebar-right"></div>
       <div id="footer"></div>

--- a/src/camera/camera.ts
+++ b/src/camera/camera.ts
@@ -6,7 +6,6 @@ import { renderIterationsToPixel } from "../rendering";
 import { getCurrentPalette, markAsRendered, needsRerender } from "./palette";
 
 let mainBuffer: p5.Graphics;
-let resultBuffer: p5.Graphics;
 
 let width: number;
 let height: number;
@@ -17,7 +16,6 @@ export const getCanvasWidth = () => width;
 
 export const setupCamera = (p: p5, w: number, h: number) => {
   mainBuffer = p.createGraphics(w, h);
-  resultBuffer = p.createGraphics(w, h);
   width = w;
   height = h;
   bufferRect = { x: 0, y: 0, width: w, height: h };
@@ -35,14 +33,6 @@ export const nextBuffer = (_p: p5): p5.Graphics => {
   return mainBuffer;
 };
 
-export const nextResultBuffer = (_p: p5): p5.Graphics => {
-  return resultBuffer;
-};
-
-export const clearResultBuffer = () => {
-  resultBuffer.clear();
-};
-
 export const renderToMainBuffer = (rect: Rect) => {
   const params = getCurrentParams();
 
@@ -53,21 +43,4 @@ export const renderToMainBuffer = (rect: Rect) => {
     getIterationCache(),
     getCurrentPalette(),
   );
-};
-
-export const renderToResultBuffer = (rect: Rect) => {
-  const params = getCurrentParams();
-
-  renderIterationsToPixel(
-    rect,
-    resultBuffer,
-    params.N,
-    getIterationCache(),
-    getCurrentPalette(),
-  );
-};
-
-export const mergeToMainBuffer = () => {
-  mainBuffer.image(resultBuffer, 0, 0);
-  clearResultBuffer();
 };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,7 +2,6 @@ import {
   clearResultBuffer,
   mergeToMainBuffer,
   nextBuffer,
-  nextResultBuffer,
   setupCamera,
 } from "@/camera/camera";
 import {
@@ -283,7 +282,6 @@ const sketch = (p: p5) => {
     }
 
     const mainBuffer = nextBuffer(p);
-    const resultBuffer = nextResultBuffer(p);
 
     p.background(0);
 
@@ -298,20 +296,22 @@ const sketch = (p: p5) => {
       p.image(mainBuffer, 0, 0);
     }
 
-    p.image(resultBuffer, 0, 0);
-
     drawInfo(p);
 
     if (paramsChanged()) {
-      startCalculation((elapsed: number) => {
-        if (elapsed !== 0) {
+      startCalculation(
+        (elapsed: number) => {
           // elapsed=0は中断時なのでなにもしない
+          if (elapsed !== 0) {
+            addCurrentLocationToPOIHistory();
+          }
+        },
+        () => {
+          // onTranslated
+          // cacheの書き換えが終わったら通常位置に戻す
           mouseDraggedComplete = false;
-          mergeToMainBuffer();
-
-          addCurrentLocationToPOIHistory();
-        }
-      });
+        },
+      );
     }
   };
 };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -295,6 +295,9 @@ const sketch = (p: p5) => {
         (elapsed: number) => {
           // elapsed=0は中断時なのでなにもしない
           if (elapsed !== 0) {
+            // bufferに書き込んだあと、一度もrenderingされずに来るケースがある
+            // 再度描画してからthumbnailを保存する
+            p.image(nextBuffer(p), 0, 0);
             addCurrentLocationToPOIHistory();
           }
         },

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,4 @@
-import {
-  clearResultBuffer,
-  mergeToMainBuffer,
-  nextBuffer,
-  setupCamera,
-} from "@/camera/camera";
+import { nextBuffer, setupCamera } from "@/camera/camera";
 import {
   changePaletteFromPresets,
   cycleCurrentPaletteOffset,
@@ -132,8 +127,6 @@ const sketch = (p: p5) => {
     if (isInside(p)) {
       if (getStore("canvasLocked")) return;
 
-      mergeToMainBuffer();
-
       mouseClickStartedInside = true;
       mouseDragged = false;
       mouseClickedOn = { mouseX: p.mouseX, mouseY: p.mouseY };
@@ -146,7 +139,6 @@ const sketch = (p: p5) => {
 
       changeCursor(p, "grabbing");
       mouseDragged = true;
-      clearResultBuffer();
     }
   };
 

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -3,7 +3,7 @@ import {
   clearIterationCache,
   translateRectInIterationCache,
 } from "./aggregator";
-import { renderToResultBuffer } from "./camera/camera";
+import { renderToMainBuffer } from "./camera/camera";
 import { divideRect, Rect } from "./rect";
 import { getStore, updateStore, updateStoreWith } from "./store/store";
 import { MandelbrotParams, OffsetParams } from "./types";
@@ -157,6 +157,7 @@ export const paramsChanged = () => {
 
 export const startCalculation = async (
   onComplete: (elapsed: number) => void,
+  onTranslated: () => void,
 ) => {
   updateCurrentParams();
 
@@ -188,11 +189,13 @@ export const startCalculation = async (
       height: height - Math.abs(offsetY),
     } satisfies Rect;
 
-    // FIXME: キャッシュ側を毎回書き換えるのはどう考えても悪手
+    // FIXME: 画面pixel位置でキャッシュを持っているのでここで移動させている
+    // 複素平面座標で持った方がいいのではないだろうかたぶん
     translateRectInIterationCache(offsetX, offsetY);
+    onTranslated();
 
     // 新しく計算しない部分を先に描画しておく
-    renderToResultBuffer(iterationBufferTransferedRect);
+    renderToMainBuffer(iterationBufferTransferedRect);
 
     // TODO:
     // perturbation時はreference orbitの値を取っておけば移動がかなり高速化できる気がする

--- a/src/worker-pool/callbacks/iteration-worker.ts
+++ b/src/worker-pool/callbacks/iteration-worker.ts
@@ -1,5 +1,5 @@
 import { upsertIterationCache } from "@/aggregator";
-import { renderToResultBuffer } from "@/camera/camera";
+import { renderToMainBuffer } from "@/camera/camera";
 import { CalcIterationJob, IterationIntermediateResult } from "@/types";
 import { completeJob, isBatchCompleted } from "../task-queue";
 import {
@@ -54,7 +54,9 @@ export const onIterationWorkerResult: IterationResultCallback = (
     elapsed: Math.floor(elapsed),
   });
 
-  renderToResultBuffer(rect);
+  batchContext.onChangeProgress();
+
+  renderToMainBuffer(rect);
 
   // バッチ全体が完了していたらonComplete callbackを呼ぶ
   if (isBatchCompleted(job.batchId)) {
@@ -73,11 +75,15 @@ export const onIterationWorkerIntermediateResult = (
   const { iterations, resolution } = result;
   const { rect } = job;
 
+  const batchContext = getBatchContext(job.batchId);
+
   // 停止が間に合わなかったケース。何もしない
-  if (getBatchContext(job.batchId) == null) {
+  if (batchContext == null) {
     return;
   }
 
+  batchContext.onChangeProgress();
+
   upsertIterationCache(rect, new Uint32Array(iterations), resolution);
-  renderToResultBuffer(rect);
+  renderToMainBuffer(rect);
 };

--- a/src/worker-pool/worker-facade.ts
+++ b/src/worker-pool/worker-facade.ts
@@ -36,7 +36,7 @@ export type IterationProgressCallback = (
   job: CalcIterationJob,
 ) => void;
 export type BatchCompleteCallback = (elapsed: number) => void;
-export type BatchProgressChangedCallback = (progressStr: string) => void;
+export type BatchProgressChangedCallback = () => void;
 
 export interface MandelbrotFacadeLike {
   startCalculate(


### PR DESCRIPTION
## Summary
- resultBufferに転写してからmainBufferに、という流れが不要だったので直接mainBufferに書き込むようにした
- ローディング表示をcanvasの上にdivを重ねて実現してたので、pointer-eventsが吸われてしまっていた
   - `pointer-events: none` 指定してcanvas側のcursorが表示されるように修正
- normalモードのthumbnailがぶっ壊れる問題を修正
   - iterationBufferには書き込んでいたがrenderingする前にcanvasの内容を出力してしまっていた