### PR TITLE
画面移動時のチラつきをなくした

### DIFF
--- a/src/camera/camera.ts
+++ b/src/camera/camera.ts
@@ -44,3 +44,7 @@ export const renderToMainBuffer = (rect: Rect) => {
     getCurrentPalette(),
   );
 };
+
+export const clearMainBuffer = () => {
+  mainBuffer.clear();
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -192,7 +192,6 @@ const sketch = (p: p5) => {
 
     changeCursor(p, p.CROSS);
     mouseClickStartedInside = false;
-    mouseDragged = false;
   };
 
   p.mouseWheel = (event: WheelEvent) => {
@@ -289,13 +288,17 @@ const sketch = (p: p5) => {
     }
 
     if (paramsChanged()) {
-      startCalculation((elapsed: number) => {
-        // elapsed=0は中断時なのでなにもしない
-        if (elapsed !== 0) {
-          // 次回のrendering後にPOIHistoryを更新する
-          shouldSavePOIHistoryNextRender = true;
-        }
-      });
+      startCalculation(
+        (elapsed: number) => {
+          // elapsed=0は中断時なのでなにもしない
+          if (elapsed !== 0) {
+            // 次回のrendering後にPOIHistoryを更新する
+            shouldSavePOIHistoryNextRender = true;
+          }
+        },
+        // onTranslated - cacheのtranslateとmainBufferへの書き込みが済んでから描画位置を戻す
+        () => (mouseDragged = false),
+      );
     }
   };
 };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -75,6 +75,8 @@ const currentCursor: "cross" | "grab" = "cross";
 let mouseDragged = false;
 let mouseClickedOn = { mouseX: 0, mouseY: 0 };
 let shouldSavePOIHistoryNextRender = false;
+/** mainBufferの表示位置を0,0から変えているかどうか  */
+let isTranslatingMainBuffer = false;
 
 let elapsed = 0;
 
@@ -138,6 +140,7 @@ const sketch = (p: p5) => {
 
       changeCursor(p, "grabbing");
       mouseDragged = true;
+      isTranslatingMainBuffer = true;
     }
   };
 
@@ -192,6 +195,7 @@ const sketch = (p: p5) => {
 
     changeCursor(p, p.CROSS);
     mouseClickStartedInside = false;
+    mouseDragged = false;
   };
 
   p.mouseWheel = (event: WheelEvent) => {
@@ -272,7 +276,7 @@ const sketch = (p: p5) => {
 
     p.background(0);
 
-    if (mouseDragged) {
+    if (isTranslatingMainBuffer) {
       const { pixelDiffX, pixelDiffY } = getDraggingPixelDiff(p);
       p.image(mainBuffer, pixelDiffX, pixelDiffY);
       drawCrossHair(p);
@@ -297,7 +301,7 @@ const sketch = (p: p5) => {
           }
         },
         // onTranslated - cacheのtranslateとmainBufferへの書き込みが済んでから描画位置を戻す
-        () => (mouseDragged = false),
+        () => (isTranslatingMainBuffer = false),
       );
     }
   };

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -157,7 +157,6 @@ export const paramsChanged = () => {
 
 export const startCalculation = async (
   onComplete: (elapsed: number) => void,
-  onTranslated: () => void,
 ) => {
   updateCurrentParams();
 
@@ -192,7 +191,6 @@ export const startCalculation = async (
     // FIXME: 画面pixel位置でキャッシュを持っているのでここで移動させている
     // 複素平面座標で持った方がいいのではないだろうかたぶん
     translateRectInIterationCache(offsetX, offsetY);
-    onTranslated();
 
     // 新しく計算しない部分を先に描画しておく
     renderToMainBuffer(iterationBufferTransferedRect);

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -3,7 +3,7 @@ import {
   clearIterationCache,
   translateRectInIterationCache,
 } from "./aggregator";
-import { renderToMainBuffer } from "./camera/camera";
+import { clearMainBuffer, renderToMainBuffer } from "./camera/camera";
 import { divideRect, Rect } from "./rect";
 import { getStore, updateStore, updateStoreWith } from "./store/store";
 import { MandelbrotParams, OffsetParams } from "./types";
@@ -157,6 +157,7 @@ export const paramsChanged = () => {
 
 export const startCalculation = async (
   onComplete: (elapsed: number) => void,
+  onTranslated: () => void,
 ) => {
   updateCurrentParams();
 
@@ -192,8 +193,10 @@ export const startCalculation = async (
     // 複素平面座標で持った方がいいのではないだろうかたぶん
     translateRectInIterationCache(offsetX, offsetY);
 
-    // 新しく計算しない部分を先に描画しておく
+    // 新しく計算しない部分を先に描画し、ドラッグ中に描画をずらしていたのを戻す
+    clearMainBuffer();
     renderToMainBuffer(iterationBufferTransferedRect);
+    onTranslated();
 
     // TODO:
     // perturbation時はreference orbitの値を取っておけば移動がかなり高速化できる気がする

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -1,0 +1,19 @@
+// デバッグ時に使う関数
+
+const watchMap = new Map<string, string>();
+
+/**
+ * 値に変化があったときだけログに出力する
+ */
+export const debugWatch = (name: string, str: string, context?: unknown) => {
+  const prev = watchMap.get(name);
+  if (prev !== str) {
+    if (context == null) {
+      console.log(`[changed: ${name}] ${str}`);
+    } else {
+      console.log(`[changed: ${name}] ${str}`, context);
+    }
+    // alert(`[changed: ${name}] ${str} (prev: ${prev})`);
+    watchMap.set(name, str);
+  }
+};


### PR DESCRIPTION
## Summary
- 移動したときに一瞬直前のbuffer内容が出るのを修正した

## なぜ起きていたか
- mouseDraggedがfalseになったあと、cacheをtranslateしてmainBufferに書き込むまでに一度drawされてしまっていた
- mainBufferをtranslateして表示しているか否かとmouseDraggedは別の役割なので別にした
   - そのうえでtranslateとmainBufferへの書き込みが済んでから表示を切り替えるようにした