### PR TITLE
右クリックドラッグで任意倍率の拡縮ができるようにした

### DIFF
--- a/src/camera/camera.ts
+++ b/src/camera/camera.ts
@@ -27,13 +27,13 @@ export const nextBuffer = (_p: p5): p5.Graphics => {
   if (needsRerender()) {
     markAsRendered();
 
-    renderToMainBuffer(bufferRect);
+    renderToMainBuffer();
   }
 
   return mainBuffer;
 };
 
-export const renderToMainBuffer = (rect: Rect) => {
+export const renderToMainBuffer = (rect: Rect = bufferRect) => {
   const params = getCurrentParams();
 
   renderIterationsToPixel(

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -332,19 +332,18 @@ const sketch = (p: p5) => {
         const { mouseX, mouseY } = mouseClickedOn;
         const zoomFactor = calcInteractiveZoomFactor(p);
 
-        // 新しい幅と高さを計算
-        const newWidth = p.width * zoomFactor;
-        const newHeight = p.height * zoomFactor;
-
-        // クリック位置を画面中心に移動させるためのオフセット計算
-        const centerX = p.width / 2;
-        const centerY = p.height / 2;
-
-        const offsetX = centerX - mouseX * zoomFactor;
-        const offsetY = centerY - mouseY * zoomFactor;
+        // クリック位置を画面の中心に置く
+        const offsetX = p.width / 2 - mouseX * zoomFactor;
+        const offsetY = p.height / 2 - mouseY * zoomFactor;
 
         // ズーム適用
-        p.image(mainBuffer, offsetX, offsetY, newWidth, newHeight);
+        p.image(
+          mainBuffer,
+          offsetX,
+          offsetY,
+          p.width * zoomFactor,
+          p.height * zoomFactor,
+        );
       }
     } else {
       p.image(mainBuffer, 0, 0);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -206,9 +206,6 @@ const sketch = (p: p5) => {
           // 右クリックドラッグ(拡縮)確定時
           const zoomFactor = calcInteractiveZoomFactor(p);
 
-          // ズーム適用
-          zoom(1 / zoomFactor);
-
           const { mouseX, mouseY } = calcVars(
             mouseClickedOn.mouseX,
             mouseClickedOn.mouseY,
@@ -217,6 +214,9 @@ const sketch = (p: p5) => {
           );
 
           setCurrentParams({ x: mouseX, y: mouseY });
+
+          // ズーム適用
+          zoom(1 / zoomFactor);
         }
       } else {
         // クリック時

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -344,6 +344,13 @@ const sketch = (p: p5) => {
           p.width * zoomFactor,
           p.height * zoomFactor,
         );
+
+        // 拡大率表示
+        p.fill(255);
+        p.stroke(0);
+        p.strokeWeight(4);
+        p.textSize(14);
+        p.text(`x${zoomFactor.toFixed(2)}`, p.mouseX + 10, p.mouseY);
       }
     } else {
       p.image(mainBuffer, 0, 0);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -105,7 +105,11 @@ const sketch = (p: p5) => {
   p.setup = () => {
     const { width, height } = getCanvasSize();
 
-    p.createCanvas(width, height);
+    const canvas = p.createCanvas(width, height);
+    // canvas上での右クリックを無効化
+    canvas.elt.addEventListener("contextmenu", (e: Event) =>
+      e.preventDefault(),
+    );
     setupCamera(p, width, height);
 
     p.colorMode(p.HSB, 360, 100, 100, 100);
@@ -124,10 +128,11 @@ const sketch = (p: p5) => {
     }
   };
 
-  p.mousePressed = () => {
+  p.mousePressed = (ev: MouseEvent) => {
     if (isInside(p)) {
       if (getStore("canvasLocked")) return;
 
+      console.debug("dragging start: ", ev.buttons);
       mouseClickStartedInside = true;
       mouseDragged = false;
       mouseClickedOn = { mouseX: p.mouseX, mouseY: p.mouseY };
@@ -146,7 +151,6 @@ const sketch = (p: p5) => {
 
   p.mouseReleased = (ev: MouseEvent) => {
     if (!ev) return;
-    if (ev.button !== 0) return;
 
     // canvas内でクリックして、canvas内で離した場合のみクリック時の処理を行う
     // これで外からcanvas内に流れてきた場合の誤クリックを防げる

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -336,9 +336,12 @@ const sketch = (p: p5) => {
         const newWidth = p.width * zoomFactor;
         const newHeight = p.height * zoomFactor;
 
-        // クリック位置を中心にするためのオフセット計算
-        const offsetX = mouseX - (mouseX * newWidth) / p.width;
-        const offsetY = mouseY - (mouseY * newHeight) / p.height;
+        // クリック位置を画面中心に移動させるためのオフセット計算
+        const centerX = p.width / 2;
+        const centerY = p.height / 2;
+
+        const offsetX = centerX - mouseX * zoomFactor;
+        const offsetY = centerY - mouseY * zoomFactor;
 
         // ズーム適用
         p.image(mainBuffer, offsetX, offsetY, newWidth, newHeight);

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -193,10 +193,9 @@ export const startCalculation = async (
     // 複素平面座標で持った方がいいのではないだろうかたぶん
     translateRectInIterationCache(offsetX, offsetY);
 
-    // 新しく計算しない部分を先に描画し、ドラッグ中に描画をずらしていたのを戻す
+    // 新しく計算しない部分を先に描画
     clearMainBuffer();
     renderToMainBuffer(iterationBufferTransferedRect);
-    onTranslated();
 
     // TODO:
     // perturbation時はreference orbitの値を取っておけば移動がかなり高速化できる気がする
@@ -208,6 +207,9 @@ export const startCalculation = async (
     // 移動していない場合は再利用するCacheがないので消す
     clearIterationCache();
   }
+
+  // ドラッグ中に描画をずらしていたのを戻す
+  onTranslated();
 
   const units = calculationRects.map((rect) => ({
     rect,

--- a/src/view/header/instructions.tsx
+++ b/src/view/header/instructions.tsx
@@ -11,8 +11,11 @@ export const Instructions = () => {
         <div>Click</div>
         <div>Zoom at clicked point</div>
 
-        <div>Drag</div>
+        <div>LMB Drag</div>
         <div>Change center</div>
+
+        <div>RMB Drag</div>
+        <div>Interactive zoom and change center</div>
       </div>
 
       <div className="mb-2 border-b text-lg font-bold">Keys</div>


### PR DESCRIPTION
## Summary
- 任意倍率での拡縮ができるようにした
   - この部分をきれいに画面に収めたい、というときにうれしい
- マウスの動かした距離と拡大倍率はsettingsタブのものをrespectする
   - ここがx1.2になってると拡大幅が少なくなるのでx50とかにしておくとよい

## 課題
- cacheの書き換えをしてないので一瞬前回のやつが出る
- ドラッグ中にcanvasの外に出ると動作がおかしくなる
   - pointer lock API使うといちいちオーバーレイが出て鬱陶しい・・・
   - なんかうまいことやれないかな

## Image
![Animation](https://github.com/user-attachments/assets/627fab9b-7163-4ecd-825a-55643e1fb4ab)
