### PR TITLE
iterationBufferのcacheを複素数平面上の座標で持つようにした

### DIFF
--- a/src/aggregator.ts
+++ b/src/aggregator.ts
@@ -1,12 +1,7 @@
 import { type ComplexRect } from "./rect";
 import { IterationBuffer, Resolution } from "./types";
 
-// FIXME: たぶんIterationBufferは複素数平面座標に対するキャッシュを持つべき
-// それならrがどうであれ使い回せるはず
-// 一方でちゃんとピクセル座標と誤差なく対応させられるかわからない
-// BigNumberだし比較重いかも
-
-// FIXME: もっと賢くデータを持つ
+// FIXME: 必要なくなったキャッシュを良い感じのタイミングで破棄できるようにする
 let iterationCache: IterationBuffer[] = [];
 
 export const upsertIterationCache = (
@@ -43,7 +38,7 @@ export const clearIterationCache = (): void => {
 /**
  * マウスXY座標の位置のiteration回数を取得する
  */
-export const getIterationTimeAt = (worldX: number, worldY: number) => {
+export const getIterationTimeAt = (_worldX: number, _worldY: number) => {
   // for (const iteration of iterationCache) {
   //   if (
   //     worldX < iteration.rect.x ||

--- a/src/aggregator.ts
+++ b/src/aggregator.ts
@@ -66,21 +66,3 @@ export const getIterationTimeAt = (worldX: number, worldY: number) => {
   // }
   return -1;
 };
-
-export const translateRectInIterationCache = (
-  offsetX: number,
-  offsetY: number,
-): void => {
-  // iterationCache = iterationCache.map((iteration) => {
-  //   return {
-  //     rect: {
-  //       x: iteration.rect.x - offsetX,
-  //       y: iteration.rect.y - offsetY,
-  //       width: iteration.rect.width,
-  //       height: iteration.rect.height,
-  //     },
-  //     buffer: iteration.buffer,
-  //     resolution: iteration.resolution,
-  //   };
-  // });
-};

--- a/src/aggregator.ts
+++ b/src/aggregator.ts
@@ -1,4 +1,4 @@
-import { Rect } from "./rect";
+import { type ComplexRect } from "./rect";
 import { bufferLocalLogicalIndex } from "./rendering";
 import { IterationBuffer, Resolution } from "./types";
 
@@ -11,7 +11,7 @@ import { IterationBuffer, Resolution } from "./types";
 let iterationCache: IterationBuffer[] = [];
 
 export const upsertIterationCache = (
-  rect: Rect,
+  rect: ComplexRect,
   buffer: Uint32Array,
   resolution: Resolution,
 ): void => {

--- a/src/aggregator.ts
+++ b/src/aggregator.ts
@@ -1,5 +1,4 @@
 import { type ComplexRect } from "./rect";
-import { bufferLocalLogicalIndex } from "./rendering";
 import { IterationBuffer, Resolution } from "./types";
 
 // FIXME: たぶんIterationBufferは複素数平面座標に対するキャッシュを持つべき
@@ -45,26 +44,26 @@ export const clearIterationCache = (): void => {
  * マウスXY座標の位置のiteration回数を取得する
  */
 export const getIterationTimeAt = (worldX: number, worldY: number) => {
-  for (const iteration of iterationCache) {
-    if (
-      worldX < iteration.rect.x ||
-      iteration.rect.x + iteration.rect.width < worldX
-    )
-      continue;
-    if (
-      worldY < iteration.rect.y ||
-      iteration.rect.y + iteration.rect.height < worldY
-    )
-      continue;
-    const idx = bufferLocalLogicalIndex(
-      Math.floor(worldX),
-      Math.floor(worldY),
-      iteration.rect,
-      iteration.resolution,
-    );
+  // for (const iteration of iterationCache) {
+  //   if (
+  //     worldX < iteration.rect.x ||
+  //     iteration.rect.x + iteration.rect.width < worldX
+  //   )
+  //     continue;
+  //   if (
+  //     worldY < iteration.rect.y ||
+  //     iteration.rect.y + iteration.rect.height < worldY
+  //   )
+  //     continue;
+  //   const idx = bufferLocalLogicalIndex(
+  //     Math.floor(worldX),
+  //     Math.floor(worldY),
+  //     iteration.rect,
+  //     iteration.resolution,
+  //   );
 
-    return iteration.buffer[idx];
-  }
+  //   return iteration.buffer[idx];
+  // }
   return -1;
 };
 
@@ -72,16 +71,16 @@ export const translateRectInIterationCache = (
   offsetX: number,
   offsetY: number,
 ): void => {
-  iterationCache = iterationCache.map((iteration) => {
-    return {
-      rect: {
-        x: iteration.rect.x - offsetX,
-        y: iteration.rect.y - offsetY,
-        width: iteration.rect.width,
-        height: iteration.rect.height,
-      },
-      buffer: iteration.buffer,
-      resolution: iteration.resolution,
-    };
-  });
+  // iterationCache = iterationCache.map((iteration) => {
+  //   return {
+  //     rect: {
+  //       x: iteration.rect.x - offsetX,
+  //       y: iteration.rect.y - offsetY,
+  //       width: iteration.rect.width,
+  //       height: iteration.rect.height,
+  //     },
+  //     buffer: iteration.buffer,
+  //     resolution: iteration.resolution,
+  //   };
+  // });
 };

--- a/src/camera/camera.ts
+++ b/src/camera/camera.ts
@@ -1,3 +1,4 @@
+import type { IterationBuffer } from "@/types";
 import p5 from "p5";
 import { getIterationCache } from "../aggregator";
 import { getCurrentParams } from "../mandelbrot";
@@ -34,14 +35,17 @@ export const nextBuffer = (_p: p5): p5.Graphics => {
   return mainBuffer;
 };
 
-export const renderToMainBuffer = (rect: Rect = bufferRect) => {
+export const renderToMainBuffer = (
+  rect: Rect = bufferRect,
+  iterationBuffer?: IterationBuffer,
+) => {
   const params = getCurrentParams();
 
   renderIterationsToPixel(
     rect,
     mainBuffer,
     params,
-    getIterationCache(),
+    iterationBuffer ? [iterationBuffer] : getIterationCache(),
     getCurrentPalette(),
   );
 };

--- a/src/camera/camera.ts
+++ b/src/camera/camera.ts
@@ -13,6 +13,7 @@ let height: number;
 let bufferRect: Rect;
 
 export const getCanvasWidth = () => width;
+export const getCanvasHeight = () => height;
 
 export const setupCamera = (p: p5, w: number, h: number) => {
   mainBuffer = p.createGraphics(w, h);
@@ -39,7 +40,7 @@ export const renderToMainBuffer = (rect: Rect = bufferRect) => {
   renderIterationsToPixel(
     rect,
     mainBuffer,
-    params.N,
+    params,
     getIterationCache(),
     getCurrentPalette(),
   );

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -186,10 +186,6 @@ export const startCalculation = async (
       height: height - Math.abs(offsetY),
     } satisfies Rect;
 
-    // FIXME: 画面pixel位置でキャッシュを持っているのでここで移動させている
-    // 複素平面座標で持った方がいいのではないだろうかたぶん
-    // translateRectInIterationCache(offsetX, offsetY);
-
     // 新しく計算しない部分を先に描画
     clearMainBuffer();
     renderToMainBuffer(iterationBufferTransferedRect);

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -190,10 +190,6 @@ export const startCalculation = async (
     clearMainBuffer();
     renderToMainBuffer(iterationBufferTransferedRect);
 
-    // TODO:
-    // perturbation時はreference orbitの値を取っておけば移動がかなり高速化できる気がする
-    // ただしどのくらいの距離まで有効なのか、有効でなくなったことをどう検知したらいいのかわからん
-
     const expectedDivideCount = Math.max(divideRectCount, 2);
     calculationRects = divideRect(getOffsetRects(), expectedDivideCount);
   } else {

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -193,8 +193,10 @@ export const startCalculation = async (
     const expectedDivideCount = Math.max(divideRectCount, 2);
     calculationRects = divideRect(getOffsetRects(), expectedDivideCount);
   } else {
-    // 移動していない場合は再利用するCacheがないので消す
+    // FIXME: 拡縮時もキャッシュは使えるはず、消すのをどこでやるか考える
     clearIterationCache();
+    // clearMainBuffer();
+    // renderToMainBuffer();
   }
 
   // ドラッグ中に描画をずらしていたのを戻す

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -1,8 +1,5 @@
 import BigNumber from "bignumber.js";
-import {
-  clearIterationCache,
-  translateRectInIterationCache,
-} from "./aggregator";
+import { clearIterationCache } from "./aggregator";
 import { clearMainBuffer, renderToMainBuffer } from "./camera/camera";
 import { divideRect, Rect } from "./rect";
 import { getStore, updateStore, updateStoreWith } from "./store/store";
@@ -191,7 +188,7 @@ export const startCalculation = async (
 
     // FIXME: 画面pixel位置でキャッシュを持っているのでここで移動させている
     // 複素平面座標で持った方がいいのではないだろうかたぶん
-    translateRectInIterationCache(offsetX, offsetY);
+    // translateRectInIterationCache(offsetX, offsetY);
 
     // 新しく計算しない部分を先に描画
     clearMainBuffer();

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -186,6 +186,7 @@ export const startCalculation = async (
       height: height - Math.abs(offsetY),
     } satisfies Rect;
 
+    clearIterationCache();
     // 新しく計算しない部分を先に描画
     clearMainBuffer();
     renderToMainBuffer(iterationBufferTransferedRect);
@@ -193,10 +194,9 @@ export const startCalculation = async (
     const expectedDivideCount = Math.max(divideRectCount, 2);
     calculationRects = divideRect(getOffsetRects(), expectedDivideCount);
   } else {
-    // FIXME: 拡縮時もキャッシュは使えるはず、消すのをどこでやるか考える
     clearIterationCache();
-    // clearMainBuffer();
-    // renderToMainBuffer();
+    clearMainBuffer();
+    renderToMainBuffer();
   }
 
   // ドラッグ中に描画をずらしていたのを戻す

--- a/src/rect.ts
+++ b/src/rect.ts
@@ -9,23 +9,27 @@ export interface Rect {
 }
 
 /** 複素数平面座標の矩形 */
-export type RealRect = {
-  topLeftX: BigNumber;
-  topLeftY: BigNumber;
-  bottomRightX: BigNumber;
-  bottomRightY: BigNumber;
+export type ComplexRect = {
+  x: BigNumber;
+  y: BigNumber;
+  width: BigNumber;
+  height: BigNumber;
 };
 
-export const calculateRealRect = (
+/**
+ * ピクセル座標のRectを複素数平面座標のRectに変換する
+ */
+export const convertToComplexRect = (
   cx: BigNumber,
   cy: BigNumber,
   rect: Rect,
   canvasWidth: number,
   canvasHeight: number,
   r: BigNumber,
-): RealRect => {
-  const topLeftX = cx.plus((rect.x * 2) / canvasWidth - 1.0).times(r);
-  const topLeftY = cy.minus((rect.y * 2) / canvasHeight - 1.0).times(r);
+): ComplexRect => {
+  const x = cx.plus((rect.x * 2) / canvasWidth - 1.0).times(r);
+  const y = cy.minus((rect.y * 2) / canvasHeight - 1.0).times(r);
+
   const bottomRightX = cx
     .plus(((rect.x + rect.width) * 2) / canvasWidth - 1.0)
     .times(r);
@@ -33,11 +37,14 @@ export const calculateRealRect = (
     .minus(((rect.y + rect.height) * 2) / canvasHeight - 1.0)
     .times(r);
 
+  const width = bottomRightX.minus(x);
+  const height = y.minus(bottomRightY);
+
   return {
-    topLeftX,
-    topLeftY,
-    bottomRightX,
-    bottomRightY,
+    x,
+    y,
+    width,
+    height,
   };
 };
 

--- a/src/rect.ts
+++ b/src/rect.ts
@@ -48,6 +48,48 @@ export const convertToComplexRect = (
   };
 };
 
+/**
+ * 複素数平面座標のRectをピクセル座標のRectに変換する
+ */
+export const convertToPixelRect = (
+  cx: BigNumber,
+  cy: BigNumber,
+  complexRect: ComplexRect,
+  canvasWidth: number,
+  canvasHeight: number,
+  r: BigNumber,
+): Rect => {
+  // 左上のピクセル座標を計算
+  const x = complexRect.x
+    .div(r)
+    .minus(cx)
+    .plus(1.0)
+    .times(canvasWidth / 2)
+    .toNumber();
+  const y = cy
+    .minus(complexRect.y.div(r))
+    .plus(1.0)
+    .times(canvasHeight / 2)
+    .toNumber();
+
+  // 幅と高さをピクセル単位で計算
+  const width = complexRect.width
+    .div(r)
+    .times(canvasWidth / 2)
+    .toNumber();
+  const height = complexRect.height
+    .div(r)
+    .times(canvasHeight / 2)
+    .toNumber();
+
+  return {
+    x: Math.round(x),
+    y: Math.round(y),
+    width: Math.round(width),
+    height: Math.round(height),
+  };
+};
+
 export const calculateDivideArea = (
   divideCount: number,
 ): { longSideCount: number; shortSideCount: number } => {

--- a/src/rect.ts
+++ b/src/rect.ts
@@ -135,6 +135,7 @@ export function convertToPixelRect(
   canvasHeight: number,
   r: BigNumber,
 ): Rect {
+  console.log("e?");
   // 左上（x, y）をピクセルへ
   const topLeft = complexToPixel(
     complexRect.x,

--- a/src/rendering.ts
+++ b/src/rendering.ts
@@ -77,6 +77,7 @@ export const renderIterationsToPixel = (
   graphics.loadPixels();
   const density = graphics.pixelDensity();
 
+  // console.log("what", iterationsResult.length);
   for (const iteration of iterationsResult) {
     const { rect, buffer, resolution } = iteration;
 
@@ -101,6 +102,10 @@ export const renderIterationsToPixel = (
       pixelRect.x + pixelRect.width,
       worldRect.x + worldRect.width,
     );
+
+    if (startY >= endY && startX >= endX) {
+      // console.log("majide?");
+    }
 
     for (let worldY = startY; worldY < endY; worldY++) {
       for (let worldX = startX; worldX < endX; worldX++) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from "bignumber.js";
-import { Rect } from "./rect";
+import { Rect, type ComplexRect } from "./rect";
 import {
   BatchCompleteCallback,
   BatchProgressChangedCallback,
@@ -100,7 +100,7 @@ export const mandelbrotWorkerTypes = ["normal", "perturbation"] as const;
 export type MandelbrotWorkerType = (typeof mandelbrotWorkerTypes)[number];
 
 export interface IterationBuffer {
-  rect: Rect;
+  rect: ComplexRect;
   buffer: Uint32Array;
   resolution: Resolution;
 }

--- a/src/worker-pool/callbacks/iteration-worker.ts
+++ b/src/worker-pool/callbacks/iteration-worker.ts
@@ -1,5 +1,6 @@
 import { upsertIterationCache } from "@/aggregator";
 import { renderToMainBuffer } from "@/camera/camera";
+import { convertToComplexRect } from "@/rect";
 import { CalcIterationJob, IterationIntermediateResult } from "@/types";
 import { completeJob, isBatchCompleted } from "../task-queue";
 import {
@@ -38,7 +39,11 @@ export const onIterationWorkerResult: IterationResultCallback = (
   }
 
   const iterationsResult = new Uint32Array(iterations);
-  upsertIterationCache(rect, iterationsResult, {
+  const { x, y, r } = batchContext.mandelbrotParams;
+  const { pixelHeight, pixelWidth } = batchContext;
+
+  const cRect = convertToComplexRect(x, y, rect, pixelWidth, pixelHeight, r);
+  upsertIterationCache(cRect, iterationsResult, {
     width: rect.width,
     height: rect.height,
   });
@@ -84,6 +89,11 @@ export const onIterationWorkerIntermediateResult = (
 
   batchContext.onChangeProgress();
 
-  upsertIterationCache(rect, new Uint32Array(iterations), resolution);
+  const { x, y, r } = batchContext.mandelbrotParams;
+  const { pixelHeight, pixelWidth } = batchContext;
+
+  const cRect = convertToComplexRect(x, y, rect, pixelWidth, pixelHeight, r);
+  upsertIterationCache(cRect, new Uint32Array(iterations), resolution);
+
   renderToMainBuffer(rect);
 };

--- a/src/worker-pool/callbacks/iteration-worker.ts
+++ b/src/worker-pool/callbacks/iteration-worker.ts
@@ -43,7 +43,7 @@ export const onIterationWorkerResult: IterationResultCallback = (
   const { pixelHeight, pixelWidth } = batchContext;
 
   const cRect = convertToComplexRect(x, y, rect, pixelWidth, pixelHeight, r);
-  upsertIterationCache(cRect, iterationsResult, {
+  const iterBuf = upsertIterationCache(cRect, iterationsResult, {
     width: rect.width,
     height: rect.height,
   });
@@ -61,7 +61,8 @@ export const onIterationWorkerResult: IterationResultCallback = (
 
   batchContext.onChangeProgress();
 
-  renderToMainBuffer(rect);
+  // 必要な情報だけ渡して描画
+  renderToMainBuffer(rect, iterBuf);
 
   // バッチ全体が完了していたらonComplete callbackを呼ぶ
   if (isBatchCompleted(job.batchId)) {
@@ -93,7 +94,12 @@ export const onIterationWorkerIntermediateResult = (
   const { pixelHeight, pixelWidth } = batchContext;
 
   const cRect = convertToComplexRect(x, y, rect, pixelWidth, pixelHeight, r);
-  upsertIterationCache(cRect, new Uint32Array(iterations), resolution);
+  const iterBuf = upsertIterationCache(
+    cRect,
+    new Uint32Array(iterations),
+    resolution,
+  );
 
-  renderToMainBuffer(rect);
+  // 必要な情報だけ渡して描画
+  renderToMainBuffer(rect, iterBuf);
 };


### PR DESCRIPTION
## Summary
- 描画時のpixel座標ベースでキャッシュをもっていたが、画面移動時に全キャッシュを移動する必要がありいけてなかった
- 複素数平面上の座標で持つようにして、移動する必要なくした
   - が、変換ロジックがいっぱい呼ばれてめっちゃ重かったのでやめた

## 感想
- そもそも配列で持って全チェックしてるのがひどいのでこれをもうちょいマシにすればよい気もする
- でもたぶんpixelベースで持ってて変換した方が軽い...