### PR TITLE
zoom時の挙動をなめらかにした

### DIFF
--- a/src/aggregator.ts
+++ b/src/aggregator.ts
@@ -2,12 +2,7 @@ import { Rect } from "./rect";
 import { bufferLocalLogicalIndex } from "./rendering";
 import { IterationBuffer, Resolution } from "./types";
 
-// FIXME: たぶんIterationBufferは複素数平面座標に対するキャッシュを持つべき
-// それならrがどうであれ使い回せるはず
-// 一方でちゃんとピクセル座標と誤差なく対応させられるかわからない
-// BigNumberだし比較重いかも
-
-// FIXME: もっと賢くデータを持つ
+// FIXME: 配列全部舐める必要があるのよくないので良い感じにデータを持つようにする
 let iterationCache: IterationBuffer[] = [];
 
 export const upsertIterationCache = (

--- a/src/aggregator.ts
+++ b/src/aggregator.ts
@@ -9,7 +9,9 @@ export const upsertIterationCache = (
   rect: Rect,
   buffer: Uint32Array,
   resolution: Resolution,
-): void => {
+): IterationBuffer => {
+  const item = { rect, buffer, resolution };
+
   const idx = iterationCache.findIndex(
     (i) => i.rect.x === rect.x && i.rect.y === rect.y,
   );
@@ -21,11 +23,13 @@ export const upsertIterationCache = (
       resolution.width * resolution.height
     ) {
       // 解像度が大きい方を採用
-      iterationCache[idx] = { rect, buffer, resolution };
+      iterationCache[idx] = item;
     }
   } else {
-    iterationCache.push({ rect, buffer, resolution });
+    iterationCache.push(item);
   }
+
+  return item;
 };
 
 export const getIterationCache = (): IterationBuffer[] => {

--- a/src/aggregator.ts
+++ b/src/aggregator.ts
@@ -1,3 +1,4 @@
+import { getCanvasSize } from "./mandelbrot";
 import { Rect } from "./rect";
 import { bufferLocalLogicalIndex } from "./rendering";
 import { IterationBuffer, Resolution } from "./types";
@@ -42,12 +43,11 @@ export const getIterationCache = (): IterationBuffer[] => {
  * 2. 小さすぎて描画に使えない
  * 3. でかすぎて描画に使えるピクセルが少ない
  */
-export const removeUnusedIterationCache = (
-  canvasWidth: number,
-  canvasHeight: number,
-): void => {
+export const removeUnusedIterationCache = (): void => {
   const minSize = 10; // 小さすぎる判定
   const maxArea = 10_000_000; // 大きすぎる判定
+
+  const { width: canvasWidth, height: canvasHeight } = getCanvasSize();
 
   const beforeCount = iterationCache.length;
 
@@ -78,9 +78,17 @@ export const removeUnusedIterationCache = (
   });
 
   const afterCount = iterationCache.length;
-  console.log(
+  console.debug(
     `${beforeCount - afterCount} iteration cache removed. Remaining: ${afterCount}`,
   );
+};
+
+/**
+ * iterationキャッシュを全部クリアする
+ */
+export const clearIterationCache = (): void => {
+  iterationCache = [];
+  console.debug("Iteration cache cleared");
 };
 
 /**

--- a/src/aggregator.ts
+++ b/src/aggregator.ts
@@ -136,14 +136,19 @@ export const translateRectInIterationCache = (
   });
 };
 
+export const setIterationCache = (cache: IterationBuffer[]): void => {
+  iterationCache = cache;
+};
+
 export const scaleIterationCacheAroundPoint = (
   centerX: number,
   centerY: number,
   scale: number,
   canvasWidth: number,
   canvasHeight: number,
-): void => {
-  iterationCache = iterationCache.map((iteration) => {
+  iterationCache: IterationBuffer[] = getIterationCache(),
+) => {
+  return iterationCache.map((iteration) => {
     const scaledRect = scaleRectAroundMouse(
       iteration.rect,
       centerX,

--- a/src/aggregator.ts
+++ b/src/aggregator.ts
@@ -90,35 +90,53 @@ export const scaleIterationCacheAroundPoint = (
   centerX: number,
   centerY: number,
   scale: number,
+  canvasWidth: number,
+  canvasHeight: number,
 ): void => {
-  console.log("scale!", { centerX, centerY, scale });
-
   iterationCache = iterationCache.map((iteration) => {
-    const { x, y, width, height } = iteration.rect;
-
-    console.log("before", { x, y, width, height });
-
     // iteration.rectの中心で拡大縮小した場合を考える
+    const scaledRect = scaleRectAroundMouse(
+      iteration.rect,
+      centerX,
+      centerY,
+      scale,
+    );
 
-    // (x, y) を (centerX, centerY) 基準に平行移動（差分を取り）→ scale 倍 → 中心へ戻す
-    const newX = centerX + (x - centerX) * scale;
-    const newY = centerY + (y - centerY) * scale;
-
-    // 幅・高さはそのまま倍率をかけるだけ
-    const newWidth = width * scale;
-    const newHeight = height * scale;
-
-    console.log("after", { newX, newY, newWidth, newHeight });
+    scaledRect.x -= centerX - canvasWidth / 2;
+    scaledRect.y -= centerY - canvasHeight / 2;
 
     return {
-      rect: {
-        x: newX,
-        y: newY,
-        width: newWidth,
-        height: newHeight,
-      },
+      rect: scaledRect,
       buffer: iteration.buffer,
       resolution: iteration.resolution,
     };
   });
 };
+
+// マウス座標 (mouseX, mouseY) と rect 座標 (x, y, width, height) があるとします。
+// rect 内部のローカル座標にマウス位置を変換してから拡大縮小し、再度グローバル座標に戻す例です。
+function scaleRectAroundMouse(
+  rect: Rect,
+  mouseX: number,
+  mouseY: number,
+  scale: number,
+) {
+  // マウス座標を rect 原点基準に変換（ローカル座標系へ）
+  const localMouseX = mouseX - rect.x;
+  const localMouseY = mouseY - rect.y;
+
+  // 幅・高さをスケール
+  const newWidth = rect.width * scale;
+  const newHeight = rect.height * scale;
+
+  // rect.x, y を「マウス座標を中心に」スケールした分だけずらす
+  const newX = rect.x + localMouseX - localMouseX * scale;
+  const newY = rect.y + localMouseY - localMouseY * scale;
+
+  return {
+    x: newX,
+    y: newY,
+    width: newWidth,
+    height: newHeight,
+  };
+}

--- a/src/aggregator.ts
+++ b/src/aggregator.ts
@@ -36,8 +36,51 @@ export const getIterationCache = (): IterationBuffer[] => {
   return iterationCache;
 };
 
-export const clearIterationCache = (): void => {
-  iterationCache = [];
+/**
+ * 以下の条件でもはや描画に使用できないiterationキャッシュを削除する
+ * 1. 完全に画面外にいる
+ * 2. 小さすぎて描画に使えない
+ * 3. でかすぎて描画に使えるピクセルが少ない
+ */
+export const removeUnusedIterationCache = (
+  canvasWidth: number,
+  canvasHeight: number,
+): void => {
+  const minSize = 10; // 小さすぎる判定
+  const maxArea = 10_000_000; // 大きすぎる判定
+
+  const beforeCount = iterationCache.length;
+
+  iterationCache = iterationCache.filter((iterCache) => {
+    const { x, y, width, height } = iterCache.rect;
+
+    // 1. 完全に画面外にいる
+    if (
+      x + width < 0 ||
+      y + height < 0 ||
+      x > canvasWidth ||
+      y > canvasHeight
+    ) {
+      return false;
+    }
+
+    // 2. 小さすぎる
+    if (width < minSize || height < minSize) {
+      return false;
+    }
+
+    // 3. でかすぎる
+    if (width * height > maxArea) {
+      return false;
+    }
+
+    return true;
+  });
+
+  const afterCount = iterationCache.length;
+  console.log(
+    `${beforeCount - afterCount} iteration cache removed. Remaining: ${afterCount}`,
+  );
 };
 
 /**

--- a/src/aggregator.ts
+++ b/src/aggregator.ts
@@ -144,7 +144,6 @@ export const scaleIterationCacheAroundPoint = (
   canvasHeight: number,
 ): void => {
   iterationCache = iterationCache.map((iteration) => {
-    // iteration.rectの中心で拡大縮小した場合を考える
     const scaledRect = scaleRectAroundMouse(
       iteration.rect,
       centerX,

--- a/src/aggregator.ts
+++ b/src/aggregator.ts
@@ -85,3 +85,40 @@ export const translateRectInIterationCache = (
     };
   });
 };
+
+export const scaleIterationCacheAroundPoint = (
+  centerX: number,
+  centerY: number,
+  scale: number,
+): void => {
+  console.log("scale!", { centerX, centerY, scale });
+
+  iterationCache = iterationCache.map((iteration) => {
+    const { x, y, width, height } = iteration.rect;
+
+    console.log("before", { x, y, width, height });
+
+    // iteration.rectの中心で拡大縮小した場合を考える
+
+    // (x, y) を (centerX, centerY) 基準に平行移動（差分を取り）→ scale 倍 → 中心へ戻す
+    const newX = centerX + (x - centerX) * scale;
+    const newY = centerY + (y - centerY) * scale;
+
+    // 幅・高さはそのまま倍率をかけるだけ
+    const newWidth = width * scale;
+    const newHeight = height * scale;
+
+    console.log("after", { newX, newY, newWidth, newHeight });
+
+    return {
+      rect: {
+        x: newX,
+        y: newY,
+        width: newWidth,
+        height: newHeight,
+      },
+      buffer: iteration.buffer,
+      resolution: iteration.resolution,
+    };
+  });
+};

--- a/src/aggregator/aggregator.test.ts
+++ b/src/aggregator/aggregator.test.ts
@@ -1,0 +1,163 @@
+import type { IterationBuffer } from "@/types";
+import { describe, expect, it } from "vitest";
+import { scaleIterationCacheAroundPoint } from "./aggregator";
+
+describe("scaleIterationCacheAroundPoint", () => {
+  it("原点で1.0倍しても変化しない", () => {
+    const itrs: IterationBuffer[] = [
+      {
+        rect: { x: 0, y: 0, width: 100, height: 100 },
+        buffer: new Uint32Array(1),
+        resolution: { width: 100, height: 100 },
+      },
+    ];
+
+    const result = scaleIterationCacheAroundPoint(0, 0, 1.0, 100, 100, itrs);
+
+    expect(result[0].rect).toEqual({ x: 0, y: 0, width: 100, height: 100 });
+  });
+
+  it("原点で2.0倍", () => {
+    const itrs: IterationBuffer[] = [
+      {
+        rect: { x: 0, y: 0, width: 100, height: 100 },
+        buffer: new Uint32Array(1),
+        resolution: { width: 100, height: 100 },
+      },
+    ];
+
+    const result = scaleIterationCacheAroundPoint(0, 0, 2.0, 100, 100, itrs);
+
+    expect(result[0].rect).toEqual({ x: 0, y: 0, width: 200, height: 200 });
+  });
+
+  it("右端で2.0倍", () => {
+    const itrs: IterationBuffer[] = [
+      {
+        rect: { x: 0, y: 0, width: 100, height: 100 },
+        buffer: new Uint32Array(1),
+        resolution: { width: 100, height: 100 },
+      },
+    ];
+
+    const result = scaleIterationCacheAroundPoint(100, 0, 2.0, 100, 100, itrs);
+
+    expect(result[0].rect).toEqual({ x: -100, y: 0, width: 200, height: 200 });
+  });
+
+  it("終点で2.0倍", () => {
+    const itrs: IterationBuffer[] = [
+      {
+        rect: { x: 0, y: 0, width: 100, height: 100 },
+        buffer: new Uint32Array(1),
+        resolution: { width: 100, height: 100 },
+      },
+    ];
+
+    const result = scaleIterationCacheAroundPoint(
+      100,
+      100,
+      2.0,
+      100,
+      100,
+      itrs,
+    );
+
+    expect(result[0].rect).toEqual({
+      x: -100,
+      y: -100,
+      width: 200,
+      height: 200,
+    });
+  });
+
+  it("rectの位置をずらしたパターン", () => {
+    const itrs: IterationBuffer[] = [
+      {
+        rect: { x: 50, y: 0, width: 50, height: 50 },
+        buffer: new Uint32Array(1),
+        resolution: { width: 100, height: 100 },
+      },
+    ];
+
+    const result = scaleIterationCacheAroundPoint(100, 50, 2.0, 100, 100, itrs);
+
+    expect(result[0].rect).toEqual({
+      x: 0,
+      y: -50,
+      width: 100,
+      height: 100,
+    });
+  });
+
+  it("rectの外の点を中心に動かすパターン", () => {
+    const itrs: IterationBuffer[] = [
+      {
+        rect: { x: 50, y: 50, width: 50, height: 50 },
+        buffer: new Uint32Array(1),
+        resolution: { width: 100, height: 100 },
+      },
+    ];
+
+    const result = scaleIterationCacheAroundPoint(0, 0, 2.0, 100, 100, itrs);
+
+    expect(result[0].rect).toEqual({
+      x: 100,
+      y: 100,
+      width: 100,
+      height: 100,
+    });
+  });
+
+  it("rectの外の点を中心に動かすパターン", () => {
+    const itrs: IterationBuffer[] = [
+      {
+        rect: { x: 0, y: 0, width: 50, height: 50 },
+        buffer: new Uint32Array(1),
+        resolution: { width: 50, height: 50 },
+      },
+      {
+        rect: { x: 50, y: 0, width: 50, height: 50 },
+        buffer: new Uint32Array(1),
+        resolution: { width: 50, height: 50 },
+      },
+      {
+        rect: { x: 0, y: 50, width: 50, height: 50 },
+        buffer: new Uint32Array(1),
+        resolution: { width: 50, height: 50 },
+      },
+      {
+        rect: { x: 50, y: 50, width: 50, height: 50 },
+        buffer: new Uint32Array(1),
+        resolution: { width: 50, height: 50 },
+      },
+    ];
+
+    const result = scaleIterationCacheAroundPoint(50, 50, 2.0, 100, 100, itrs);
+
+    expect(result[0].rect).toEqual({
+      x: -50,
+      y: -50,
+      width: 100,
+      height: 100,
+    });
+    expect(result[1].rect).toEqual({
+      x: 50,
+      y: -50,
+      width: 100,
+      height: 100,
+    });
+    expect(result[2].rect).toEqual({
+      x: -50,
+      y: 50,
+      width: 100,
+      height: 100,
+    });
+    expect(result[3].rect).toEqual({
+      x: 50,
+      y: 50,
+      width: 100,
+      height: 100,
+    });
+  });
+});

--- a/src/aggregator/aggregator.ts
+++ b/src/aggregator/aggregator.ts
@@ -1,7 +1,7 @@
-import { getCanvasSize } from "./mandelbrot";
-import { Rect } from "./rect";
-import { bufferLocalLogicalIndex } from "./rendering";
-import { IterationBuffer, Resolution } from "./types";
+import { getCanvasSize } from "../mandelbrot";
+import { Rect } from "../rect";
+import { bufferLocalLogicalIndex } from "../rendering";
+import { IterationBuffer, Resolution } from "../types";
 
 // FIXME: 配列全部舐める必要があるのよくないので良い感じにデータを持つようにする
 let iterationCache: IterationBuffer[] = [];

--- a/src/aggregator/aggregator.ts
+++ b/src/aggregator/aggregator.ts
@@ -180,8 +180,8 @@ function scaleRectAroundMouse(
   const newY = centerY + localY * scale;
 
   return {
-    x: newX,
-    y: newY,
+    x: Math.round(newX),
+    y: Math.round(newY),
     width: newWidth,
     height: newHeight,
   };

--- a/src/aggregator/aggregator.ts
+++ b/src/aggregator/aggregator.ts
@@ -44,10 +44,16 @@ export const getIterationCache = (): IterationBuffer[] => {
  * 3. でかすぎて描画に使えるピクセルが少ない
  */
 export const removeUnusedIterationCache = (): void => {
-  const minSize = 10; // 小さすぎる判定
-  const maxArea = 10_000_000; // 大きすぎる判定
-
   const { width: canvasWidth, height: canvasHeight } = getCanvasSize();
+
+  // 10pixel以下のcacheは消す
+  const minSizePixel = 10;
+  // rect内の1pixelがcanvas上で何pixelに相当するかで上限を設ける
+  // ここでは3pixelより荒いときに消す
+  // そんなに超拡大してたらほぼ画面外判定の方で消えるので、これは荒くてもよい
+  const maxResolutionPerPixel = Math.floor(
+    Math.min(canvasWidth, canvasHeight) / 3,
+  );
 
   const beforeCount = iterationCache.length;
 
@@ -64,13 +70,16 @@ export const removeUnusedIterationCache = (): void => {
       return false;
     }
 
-    // 2. 小さすぎる
-    if (width < minSize || height < minSize) {
+    // 2. 細かすぎる
+    if (width < minSizePixel || height < minSizePixel) {
       return false;
     }
 
-    // 3. でかすぎる
-    if (width * height > maxArea) {
+    // 3. 荒すぎる
+    if (
+      maxResolutionPerPixel < width / iterCache.resolution.width ||
+      maxResolutionPerPixel < height / iterCache.resolution.height
+    ) {
       return false;
     }
 

--- a/src/aggregator/aggregator.ts
+++ b/src/aggregator/aggregator.ts
@@ -156,6 +156,10 @@ export const scaleIterationCacheAroundPoint = (
       scale,
     );
 
+    // クリック位置が画面中央に来るように位置調整
+    scaledRect.x = Math.round(scaledRect.x - (centerX - canvasWidth / 2));
+    scaledRect.y = Math.round(scaledRect.y - (centerY - canvasHeight / 2));
+
     return {
       rect: scaledRect,
       buffer: iteration.buffer,

--- a/src/aggregator/aggregator.ts
+++ b/src/aggregator/aggregator.ts
@@ -140,6 +140,9 @@ export const setIterationCache = (cache: IterationBuffer[]): void => {
   iterationCache = cache;
 };
 
+/**
+ * iterationCacheを指定した点を中心にscale倍し、その点が中央に来るようにtranslateする
+ */
 export const scaleIterationCacheAroundPoint = (
   centerX: number,
   centerY: number,
@@ -149,7 +152,7 @@ export const scaleIterationCacheAroundPoint = (
   iterationCache: IterationBuffer[] = getIterationCache(),
 ) => {
   return iterationCache.map((iteration) => {
-    const scaledRect = scaleRectAroundMouse(
+    const scaledRect = scaleRectAroundPoint(
       iteration.rect,
       centerX,
       centerY,
@@ -168,7 +171,10 @@ export const scaleIterationCacheAroundPoint = (
   });
 };
 
-function scaleRectAroundMouse(
+/**
+ * Rectを指定した点を中心にscale倍する
+ */
+function scaleRectAroundPoint(
   rect: Rect,
   centerX: number,
   centerY: number,

--- a/src/aggregator/aggregator.ts
+++ b/src/aggregator/aggregator.ts
@@ -156,9 +156,6 @@ export const scaleIterationCacheAroundPoint = (
       scale,
     );
 
-    scaledRect.x -= centerX - canvasWidth / 2;
-    scaledRect.y -= centerY - canvasHeight / 2;
-
     return {
       rect: scaledRect,
       buffer: iteration.buffer,
@@ -167,25 +164,20 @@ export const scaleIterationCacheAroundPoint = (
   });
 };
 
-// マウス座標 (mouseX, mouseY) と rect 座標 (x, y, width, height) があるとします。
-// rect 内部のローカル座標にマウス位置を変換してから拡大縮小し、再度グローバル座標に戻す例です。
 function scaleRectAroundMouse(
   rect: Rect,
-  mouseX: number,
-  mouseY: number,
+  centerX: number,
+  centerY: number,
   scale: number,
 ) {
-  // マウス座標を rect 原点基準に変換（ローカル座標系へ）
-  const localMouseX = mouseX - rect.x;
-  const localMouseY = mouseY - rect.y;
+  const localX = rect.x - centerX;
+  const localY = rect.y - centerY;
 
-  // 幅・高さをスケール
   const newWidth = rect.width * scale;
   const newHeight = rect.height * scale;
 
-  // rect.x, y を「マウス座標を中心に」スケールした分だけずらす
-  const newX = rect.x + localMouseX - localMouseX * scale;
-  const newY = rect.y + localMouseY - localMouseY * scale;
+  const newX = centerX + localX * scale;
+  const newY = centerY + localY * scale;
 
   return {
     x: newX,

--- a/src/aggregator/aggregator.ts
+++ b/src/aggregator/aggregator.ts
@@ -1,6 +1,6 @@
 import { getCanvasSize } from "../mandelbrot";
 import { Rect } from "../rect";
-import { bufferLocalLogicalIndex } from "../rendering";
+import { bufferLocalLogicalIndex } from "../rendering/rendering";
 import { IterationBuffer, Resolution } from "../types";
 
 // FIXME: 配列全部舐める必要があるのよくないので良い感じにデータを持つようにする

--- a/src/camera/camera.ts
+++ b/src/camera/camera.ts
@@ -3,7 +3,7 @@ import p5 from "p5";
 import { getIterationCache } from "../aggregator/aggregator";
 import { getCurrentParams } from "../mandelbrot";
 import { Rect } from "../rect";
-import { renderIterationsToPixel } from "../rendering";
+import { renderIterationsToPixel } from "../rendering/rendering";
 import { getCurrentPalette, markAsRendered, needsRerender } from "./palette";
 
 let mainBuffer: p5.Graphics;

--- a/src/camera/camera.ts
+++ b/src/camera/camera.ts
@@ -1,3 +1,4 @@
+import type { IterationBuffer } from "@/types";
 import p5 from "p5";
 import { getIterationCache } from "../aggregator";
 import { getCurrentParams } from "../mandelbrot";
@@ -33,14 +34,17 @@ export const nextBuffer = (_p: p5): p5.Graphics => {
   return mainBuffer;
 };
 
-export const renderToMainBuffer = (rect: Rect = bufferRect) => {
+export const renderToMainBuffer = (
+  rect: Rect = bufferRect,
+  iterBuffer?: IterationBuffer[],
+) => {
   const params = getCurrentParams();
 
   renderIterationsToPixel(
     rect,
     mainBuffer,
     params.N,
-    getIterationCache(),
+    iterBuffer ?? getIterationCache(),
     getCurrentPalette(),
   );
 };

--- a/src/camera/camera.ts
+++ b/src/camera/camera.ts
@@ -1,6 +1,6 @@
 import type { IterationBuffer } from "@/types";
 import p5 from "p5";
-import { getIterationCache } from "../aggregator";
+import { getIterationCache } from "../aggregator/aggregator";
 import { getCurrentParams } from "../mandelbrot";
 import { Rect } from "../rect";
 import { renderIterationsToPixel } from "../rendering";

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,7 +7,7 @@ import {
 import p5 from "p5";
 import React from "react";
 import ReactDOMClient from "react-dom/client";
-import { getIterationTimeAt } from "./aggregator";
+import { getIterationTimeAt } from "./aggregator/aggregator";
 import { setP5 } from "./canvas-reference";
 import { extractMandelbrotParams } from "./lib/params";
 import {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -30,7 +30,7 @@ import {
   addCurrentLocationToPOIHistory,
   initializePOIHistory,
 } from "./poi-history/poi-history";
-import { drawCrossHair } from "./rendering";
+import { drawCrossHair } from "./rendering/rendering";
 import { createStore, getStore, updateStore } from "./store/store";
 import { readPOIListFromStorage } from "./store/sync-storage/poi-list";
 import {
@@ -38,6 +38,7 @@ import {
   readSettingsFromStorage,
 } from "./store/sync-storage/settings";
 import "./style.css";
+import { checkpoint } from "./utils/debug";
 import { AppRoot } from "./view/app-root";
 import { prepareWorkerPool } from "./worker-pool/pool-instance";
 import { getProgressData } from "./worker-pool/worker-pool";
@@ -375,7 +376,7 @@ const sketch = (p: p5) => {
     } else {
       p.image(mainBuffer, 0, 0);
     }
-
+    checkpoint();
     drawInfo(p);
 
     if (shouldSavePOIHistoryNextRender) {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -21,6 +21,7 @@ import {
   setCurrentParams,
   setDeepIterationCount,
   setOffsetParams,
+  setScaleParams,
   startCalculation,
   togglePinReference,
   zoom,
@@ -217,6 +218,13 @@ const sketch = (p: p5) => {
 
           // ズーム適用
           zoom(1 / zoomFactor);
+
+          const { mouseX: mx, mouseY: my } = mouseClickedOn;
+          setScaleParams({
+            scaleAtX: mx,
+            scaleAtY: my,
+            scale: zoomFactor,
+          });
         }
       } else {
         // クリック時

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -38,7 +38,6 @@ import {
   readSettingsFromStorage,
 } from "./store/sync-storage/settings";
 import "./style.css";
-import { checkpoint } from "./utils/debug";
 import { AppRoot } from "./view/app-root";
 import { prepareWorkerPool } from "./worker-pool/pool-instance";
 import { getProgressData } from "./worker-pool/worker-pool";
@@ -376,7 +375,6 @@ const sketch = (p: p5) => {
     } else {
       p.image(mainBuffer, 0, 0);
     }
-    checkpoint();
     drawInfo(p);
 
     if (shouldSavePOIHistoryNextRender) {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -244,6 +244,12 @@ const sketch = (p: p5) => {
         } else {
           zoom(1.0 / rate);
         }
+
+        setScaleParams({
+          scaleAtX: p.mouseX,
+          scaleAtY: p.mouseY,
+          scale: 1 / rate,
+        });
       }
     }
 
@@ -267,6 +273,12 @@ const sketch = (p: p5) => {
       } else {
         zoom(1.0 / rate);
       }
+
+      setScaleParams({
+        scaleAtX: p.width / 2,
+        scaleAtY: p.height / 2,
+        scale: 1 / rate,
+      });
     }
   };
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -248,7 +248,7 @@ const sketch = (p: p5) => {
         setScaleParams({
           scaleAtX: p.mouseX,
           scaleAtY: p.mouseY,
-          scale: 1 / rate,
+          scale: rate,
         });
       }
     }
@@ -277,7 +277,7 @@ const sketch = (p: p5) => {
       setScaleParams({
         scaleAtX: p.width / 2,
         scaleAtY: p.height / 2,
-        scale: 1 / rate,
+        scale: rate,
       });
     }
   };

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -1,6 +1,6 @@
 import BigNumber from "bignumber.js";
 import {
-  clearIterationCache,
+  scaleIterationCacheAroundPoint,
   translateRectInIterationCache,
 } from "./aggregator";
 import { clearMainBuffer, renderToMainBuffer } from "./camera/camera";
@@ -130,6 +130,14 @@ export const setOffsetParams = (params: Partial<OffsetParams>) => {
   offsetParams = { ...offsetParams, ...params };
 };
 
+let scaleParams = { scaleAtX: 0, scaleAtY: 0, scale: 1 };
+export const setScaleParams = (params: Partial<typeof scaleParams>) => {
+  scaleParams = { ...scaleParams, ...params };
+};
+export const resetScaleParams = () =>
+  setScaleParams({ scaleAtX: 0, scaleAtY: 0, scale: 1 });
+export const getScaleParams = () => scaleParams;
+
 export const resetIterationCount = () => setCurrentParams({ N: DEFAULT_N });
 export const setDeepIterationCount = () =>
   setCurrentParams({ N: DEFAULT_N * 20 });
@@ -205,7 +213,11 @@ export const startCalculation = async (
     calculationRects = divideRect(getOffsetRects(), expectedDivideCount);
   } else {
     // 移動していない場合は再利用するCacheがないので消す
-    clearIterationCache();
+    const { scaleAtX, scaleAtY, scale } = getScaleParams();
+    scaleIterationCacheAroundPoint(scaleAtX, scaleAtY, scale);
+    clearMainBuffer();
+    renderToMainBuffer();
+    resetScaleParams();
   }
 
   // ドラッグ中に描画をずらしていたのを戻す

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -220,7 +220,6 @@ export const startCalculation = async (
   } else {
     // 拡縮の場合は倍率を指定してキャッシュを書き換える
     const { scaleAtX, scaleAtY, scale } = getScaleParams();
-    console.log({ scaleAtX, scaleAtY, scale });
 
     const scaled = scaleIterationCacheAroundPoint(
       scaleAtX,

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -214,7 +214,7 @@ export const startCalculation = async (
   } else {
     // 移動していない場合は再利用するCacheがないので消す
     const { scaleAtX, scaleAtY, scale } = getScaleParams();
-    scaleIterationCacheAroundPoint(scaleAtX, scaleAtY, scale);
+    scaleIterationCacheAroundPoint(scaleAtX, scaleAtY, scale, width, height);
     clearMainBuffer();
     renderToMainBuffer();
     resetScaleParams();

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -2,6 +2,7 @@ import BigNumber from "bignumber.js";
 import {
   removeUnusedIterationCache,
   scaleIterationCacheAroundPoint,
+  setIterationCache,
   translateRectInIterationCache,
 } from "./aggregator";
 import { clearMainBuffer, renderToMainBuffer } from "./camera/camera";
@@ -212,7 +213,14 @@ export const startCalculation = async (
     // 拡縮の場合は倍率を指定してキャッシュを書き換える
     const { scaleAtX, scaleAtY, scale } = getScaleParams();
 
-    scaleIterationCacheAroundPoint(scaleAtX, scaleAtY, scale, width, height);
+    const scaled = scaleIterationCacheAroundPoint(
+      scaleAtX,
+      scaleAtY,
+      scale,
+      width,
+      height,
+    );
+    setIterationCache(scaled);
     removeUnusedIterationCache();
 
     clearMainBuffer();

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -197,8 +197,7 @@ export const startCalculation = async (
       height: height - Math.abs(offsetY),
     } satisfies Rect;
 
-    // FIXME: 画面pixel位置でキャッシュを持っているのでここで移動させている
-    // 複素平面座標で持った方がいいのではないだろうかたぶん
+    // 画面pixel位置でキャッシュを持っているのでここで移動させている
     translateRectInIterationCache(offsetX, offsetY);
 
     // 新しく計算しない部分を先に描画
@@ -212,9 +211,10 @@ export const startCalculation = async (
     const expectedDivideCount = Math.max(divideRectCount, 2);
     calculationRects = divideRect(getOffsetRects(), expectedDivideCount);
   } else {
-    // 移動していない場合は再利用するCacheがないので消す
+    // 拡縮の場合は倍率を指定してキャッシュを書き換える
     const { scaleAtX, scaleAtY, scale } = getScaleParams();
     scaleIterationCacheAroundPoint(scaleAtX, scaleAtY, scale, width, height);
+
     clearMainBuffer();
     renderToMainBuffer();
     resetScaleParams();

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -206,15 +206,12 @@ export const startCalculation = async (
     clearMainBuffer();
     renderToMainBuffer(iterationBufferTransferedRect);
 
-    // TODO:
-    // perturbation時はreference orbitの値を取っておけば移動がかなり高速化できる気がする
-    // ただしどのくらいの距離まで有効なのか、有効でなくなったことをどう検知したらいいのかわからん
-
     const expectedDivideCount = Math.max(divideRectCount, 2);
     calculationRects = divideRect(getOffsetRects(), expectedDivideCount);
   } else {
     // 拡縮の場合は倍率を指定してキャッシュを書き換える
     const { scaleAtX, scaleAtY, scale } = getScaleParams();
+
     scaleIterationCacheAroundPoint(scaleAtX, scaleAtY, scale, width, height);
     removeUnusedIterationCache();
 

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -223,7 +223,7 @@ export const startCalculation = async (
 
   // ドラッグ中に描画をずらしていたのを戻す
   onTranslated();
-  removeUnusedIterationCache(width, height);
+  removeUnusedIterationCache();
 
   const units = calculationRects.map((rect) => ({
     rect,

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -132,12 +132,20 @@ export const setOffsetParams = (params: Partial<OffsetParams>) => {
   offsetParams = { ...offsetParams, ...params };
 };
 
-let scaleParams = { scaleAtX: 0, scaleAtY: 0, scale: 1 };
+let scaleParams = {
+  scaleAtX: Math.round(width / 2),
+  scaleAtY: Math.round(height / 2),
+  scale: 1,
+};
 export const setScaleParams = (params: Partial<typeof scaleParams>) => {
   scaleParams = { ...scaleParams, ...params };
 };
 export const resetScaleParams = () =>
-  setScaleParams({ scaleAtX: 0, scaleAtY: 0, scale: 1 });
+  setScaleParams({
+    scaleAtX: Math.round(width / 2),
+    scaleAtY: Math.round(height / 2),
+    scale: 1,
+  });
 export const getScaleParams = () => scaleParams;
 
 export const resetIterationCount = () => setCurrentParams({ N: DEFAULT_N });
@@ -212,6 +220,7 @@ export const startCalculation = async (
   } else {
     // 拡縮の場合は倍率を指定してキャッシュを書き換える
     const { scaleAtX, scaleAtY, scale } = getScaleParams();
+    console.log({ scaleAtX, scaleAtY, scale });
 
     const scaled = scaleIterationCacheAroundPoint(
       scaleAtX,

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -195,10 +195,6 @@ export const startCalculation = async (
     const offsetX = offsetParams.x;
     const offsetY = offsetParams.y;
 
-    // FIXME: 拡大待ち中や移動が終わる前に再度移動すると表示が壊れる
-    // 拡大開始したときに既にCacheが消えてるからそりゃそうだ
-    // なんとかせい
-
     // 移動した分の再描画範囲を計算
     const iterationBufferTransferedRect = {
       x: offsetX >= 0 ? 0 : Math.abs(offsetX),

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -1,6 +1,5 @@
 import BigNumber from "bignumber.js";
 import {
-  getIterationCache,
   removeUnusedIterationCache,
   scaleIterationCacheAroundPoint,
   setIterationCache,
@@ -223,10 +222,6 @@ export const startCalculation = async (
     );
     setIterationCache(scaled);
     removeUnusedIterationCache();
-
-    getIterationCache().forEach((iteration) => {
-      console.log("scaled", iteration.rect, iteration.resolution);
-    });
 
     clearMainBuffer();
     renderToMainBuffer();

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -1,5 +1,6 @@
 import BigNumber from "bignumber.js";
 import {
+  getIterationCache,
   removeUnusedIterationCache,
   scaleIterationCacheAroundPoint,
   setIterationCache,
@@ -9,6 +10,7 @@ import { clearMainBuffer, renderToMainBuffer } from "./camera/camera";
 import { divideRect, Rect } from "./rect";
 import { getStore, updateStore, updateStoreWith } from "./store/store";
 import { MandelbrotParams, OffsetParams } from "./types";
+import { nextStop } from "./utils/debug";
 import { getWorkerCount, prepareWorkerPool } from "./worker-pool/pool-instance";
 import {
   cancelBatch,
@@ -222,6 +224,11 @@ export const startCalculation = async (
     );
     setIterationCache(scaled);
     removeUnusedIterationCache();
+
+    getIterationCache().forEach((iteration) => {
+      console.log("scaled", iteration.rect, iteration.resolution);
+    });
+    nextStop(2);
 
     clearMainBuffer();
     renderToMainBuffer();

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -4,7 +4,7 @@ import {
   scaleIterationCacheAroundPoint,
   setIterationCache,
   translateRectInIterationCache,
-} from "./aggregator";
+} from "./aggregator/aggregator";
 import { clearMainBuffer, renderToMainBuffer } from "./camera/camera";
 import { divideRect, Rect } from "./rect";
 import { getStore, updateStore, updateStoreWith } from "./store/store";

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -1,5 +1,6 @@
 import BigNumber from "bignumber.js";
 import {
+  removeUnusedIterationCache,
   scaleIterationCacheAroundPoint,
   translateRectInIterationCache,
 } from "./aggregator";
@@ -222,6 +223,7 @@ export const startCalculation = async (
 
   // ドラッグ中に描画をずらしていたのを戻す
   onTranslated();
+  removeUnusedIterationCache(width, height);
 
   const units = calculationRects.map((rect) => ({
     rect,

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -10,7 +10,6 @@ import { clearMainBuffer, renderToMainBuffer } from "./camera/camera";
 import { divideRect, Rect } from "./rect";
 import { getStore, updateStore, updateStoreWith } from "./store/store";
 import { MandelbrotParams, OffsetParams } from "./types";
-import { nextStop } from "./utils/debug";
 import { getWorkerCount, prepareWorkerPool } from "./worker-pool/pool-instance";
 import {
   cancelBatch,
@@ -228,7 +227,6 @@ export const startCalculation = async (
     getIterationCache().forEach((iteration) => {
       console.log("scaled", iteration.rect, iteration.resolution);
     });
-    nextStop(2);
 
     clearMainBuffer();
     renderToMainBuffer();

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -200,6 +200,7 @@ export const startCalculation = async (
 
     // 画面pixel位置でキャッシュを持っているのでここで移動させている
     translateRectInIterationCache(offsetX, offsetY);
+    removeUnusedIterationCache();
 
     // 新しく計算しない部分を先に描画
     clearMainBuffer();
@@ -215,15 +216,16 @@ export const startCalculation = async (
     // 拡縮の場合は倍率を指定してキャッシュを書き換える
     const { scaleAtX, scaleAtY, scale } = getScaleParams();
     scaleIterationCacheAroundPoint(scaleAtX, scaleAtY, scale, width, height);
+    removeUnusedIterationCache();
 
     clearMainBuffer();
     renderToMainBuffer();
+
     resetScaleParams();
   }
 
   // ドラッグ中に描画をずらしていたのを戻す
   onTranslated();
-  removeUnusedIterationCache();
 
   const units = calculationRects.map((rect) => ({
     rect,

--- a/src/rendering.ts
+++ b/src/rendering.ts
@@ -17,8 +17,9 @@ export const fillColor = (
 ) => {
   for (let i = 0; i < density; i++) {
     for (let j = 0; j < density; j++) {
-      const pixelIndex =
-        4 * ((y * density + j) * canvasWidth * density + (x * density + i));
+      const pixelIndex = Math.floor(
+        4 * ((y * density + j) * canvasWidth * density + (x * density + i)),
+      );
 
       // iterationが-1のときはglitchが起きているので白で塗りつぶす
       if (iteration === GLITCHED_POINT_ITERATION) {

--- a/src/rendering/rendering.test.ts
+++ b/src/rendering/rendering.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { bufferLocalLogicalIndex } from "./rendering";
+
+describe("bufferLocalLogicalIndex", () => {
+  it("resolutionが1の場合、どこを指定しても0", () => {
+    const result = bufferLocalLogicalIndex(
+      25,
+      25,
+      { x: 0, y: 0, width: 50, height: 50 },
+      { width: 1, height: 1 },
+    );
+    expect(result).toBe(0);
+  });
+
+  it("resolutionよりrectが大きいケース", () => {
+    const result = bufferLocalLogicalIndex(
+      3,
+      3,
+      { x: 0, y: 0, width: 4, height: 4 },
+      { width: 2, height: 2 },
+    );
+    expect(result).toBe(3);
+  });
+
+  it("resolutionよりrectが小さいケース", () => {
+    const result = bufferLocalLogicalIndex(
+      50,
+      50,
+      { x: 50, y: 50, width: 50, height: 50 },
+      { width: 2, height: 2 },
+    );
+    expect(result).toBe(0);
+
+    const result2 = bufferLocalLogicalIndex(
+      99,
+      99,
+      { x: 50, y: 50, width: 50, height: 50 },
+      { width: 2, height: 2 },
+    );
+    expect(result2).toBe(3);
+  });
+
+  it("rectが画面をはみ出すケース", () => {
+    const result = bufferLocalLogicalIndex(
+      99,
+      99,
+      { x: -100, y: -100, width: 200, height: 200 },
+      { width: 1, height: 1 },
+    );
+    expect(result).toBe(0);
+  });
+});

--- a/src/rendering/rendering.test.ts
+++ b/src/rendering/rendering.test.ts
@@ -22,7 +22,7 @@ describe("bufferLocalLogicalIndex", () => {
     expect(result).toBe(3);
   });
 
-  it("resolutionよりrectが小さいケース", () => {
+  it("左上と右下の値が正しく取れる", () => {
     const result = bufferLocalLogicalIndex(
       50,
       50,

--- a/src/rendering/rendering.ts
+++ b/src/rendering/rendering.ts
@@ -46,6 +46,11 @@ export const fillColor = (
   }
 };
 
+/**
+ * rect内のローカル座標系(resolution)でのindexを取得する
+ *
+ * worldX,Yはrectの中に収まっている前提
+ */
 export const bufferLocalLogicalIndex = (
   worldX: number,
   worldY: number,

--- a/src/rendering/rendering.ts
+++ b/src/rendering/rendering.ts
@@ -76,7 +76,10 @@ export const renderIterationsToPixel = (
   graphics.loadPixels();
   const density = graphics.pixelDensity();
 
-  for (const iteration of iterationsResult) {
+  const i = iterationsResult;
+  const a = i.length >= 4 ? iterationsResult : i;
+
+  for (const iteration of a) {
     const { rect, buffer, resolution } = iteration;
 
     // worldRectとiterationのrectが一致する箇所だけ描画する
@@ -84,6 +87,8 @@ export const renderIterationsToPixel = (
     const startX = Math.max(rect.x, worldRect.x);
     const endY = Math.min(rect.y + rect.height, worldRect.y + worldRect.height);
     const endX = Math.min(rect.x + rect.width, worldRect.x + worldRect.width);
+
+    console.log("start", startX, startY, "end", endX, endY);
 
     for (let worldY = startY; worldY < endY; worldY++) {
       for (let worldX = startX; worldX < endX; worldX++) {

--- a/src/rendering/rendering.ts
+++ b/src/rendering/rendering.ts
@@ -1,9 +1,9 @@
 import { Palette } from "@/color";
 import p5 from "p5";
-import { getCanvasWidth } from "./camera/camera";
-import { GLITCHED_POINT_ITERATION } from "./mandelbrot";
-import { Rect } from "./rect";
-import { IterationBuffer, Resolution } from "./types";
+import { getCanvasWidth } from "../camera/camera";
+import { GLITCHED_POINT_ITERATION } from "../mandelbrot";
+import { Rect } from "../rect";
+import { IterationBuffer, Resolution } from "../types";
 
 export const fillColor = (
   x: number,

--- a/src/rendering/rendering.ts
+++ b/src/rendering/rendering.ts
@@ -76,10 +76,7 @@ export const renderIterationsToPixel = (
   graphics.loadPixels();
   const density = graphics.pixelDensity();
 
-  const i = iterationsResult;
-  const a = i.length >= 4 ? iterationsResult : i;
-
-  for (const iteration of a) {
+  for (const iteration of iterationsResult) {
     const { rect, buffer, resolution } = iteration;
 
     // worldRectとiterationのrectが一致する箇所だけ描画する
@@ -87,8 +84,6 @@ export const renderIterationsToPixel = (
     const startX = Math.max(rect.x, worldRect.x);
     const endY = Math.min(rect.y + rect.height, worldRect.y + worldRect.height);
     const endX = Math.min(rect.x + rect.width, worldRect.x + worldRect.width);
-
-    console.log("start", startX, startY, "end", endX, endY);
 
     for (let worldY = startY; worldY < endY; worldY++) {
       for (let worldX = startX; worldX < endX; worldX++) {

--- a/src/rendering/rendering.ts
+++ b/src/rendering/rendering.ts
@@ -5,6 +5,11 @@ import { GLITCHED_POINT_ITERATION } from "../mandelbrot";
 import { Rect } from "../rect";
 import { IterationBuffer, Resolution } from "../types";
 
+/**
+ * 指定した座標をpaletteとiterationの値に応じて塗りつぶす
+ *
+ * retina対応
+ */
 export const fillColor = (
   x: number,
   y: number,
@@ -84,7 +89,7 @@ export const renderIterationsToPixel = (
   for (const iteration of iterationsResult) {
     const { rect, buffer, resolution } = iteration;
 
-    // worldRectとiterationのrectが一致する箇所だけ描画する
+    // worldRectとiterationのrectが重なっている部分だけ描画する
     const startY = Math.max(rect.y, worldRect.y);
     const startX = Math.max(rect.x, worldRect.x);
     const endY = Math.min(rect.y + rect.height, worldRect.y + worldRect.height);

--- a/src/store/sync-storage/settings.ts
+++ b/src/store/sync-storage/settings.ts
@@ -7,7 +7,8 @@ export type Settings = {
   animationCycleStep?: number;
 };
 
-export const DEFAULT_WORKER_COUNT = navigator.hardwareConcurrency;
+export const DEFAULT_WORKER_COUNT =
+  process.env.NODE_ENV === "test" ? 1 : navigator.hardwareConcurrency;
 
 const defaultSettings = {
   zoomRate: 2.0,

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -3,15 +3,15 @@
 const watchMap = new Map<string, string>();
 
 /**
- * 値に変化があったときだけログに出力する
+ * デバッグ用：値に変化があったときだけログに出力する
  */
 export const debugWatch = (name: string, str: string, context?: unknown) => {
   const prev = watchMap.get(name);
   if (prev !== str) {
     if (context == null) {
-      console.log(`[changed: ${name}] ${str}`);
+      console.debug(`[changed: ${name}] ${str}`);
     } else {
-      console.log(`[changed: ${name}] ${str}`, context);
+      console.debug(`[changed: ${name}] ${str}`, context);
     }
     // alert(`[changed: ${name}] ${str} (prev: ${prev})`);
     watchMap.set(name, str);

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -1,5 +1,7 @@
 // デバッグ時に使う関数
 
+import { getIterationCache } from "@/aggregator/aggregator";
+
 const watchMap = new Map<string, string>();
 
 /**
@@ -35,4 +37,18 @@ export const logInterval = (
     console.debug(`[${name}]`, value);
     logMap.set(name, now);
   }
+};
+
+let willStop = -1;
+export const checkpoint = () => {
+  if (willStop > 0) {
+    willStop--;
+  } else if (willStop === 0) {
+    const iter = getIterationCache();
+    debugger;
+    willStop = -1;
+  }
+};
+export const nextStop = (count: number) => {
+  willStop = count;
 };

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -17,3 +17,22 @@ export const debugWatch = (name: string, str: string, context?: unknown) => {
     watchMap.set(name, str);
   }
 };
+
+const logMap = new Map<string, number>();
+
+/**
+ * デバッグ用：指定した間隔でログを出力する
+ */
+export const logInterval = (
+  name: string,
+  value: unknown,
+  interval: number = 1000,
+) => {
+  const prev = logMap.get(name);
+  const now = Date.now();
+
+  if (prev == null || now - prev > interval) {
+    console.debug(`[${name}]`, value);
+    logMap.set(name, now);
+  }
+};

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -1,7 +1,5 @@
 // デバッグ時に使う関数
 
-import { getIterationCache } from "@/aggregator/aggregator";
-
 const watchMap = new Map<string, string>();
 
 /**
@@ -39,16 +37,16 @@ export const logInterval = (
   }
 };
 
-let willStop = -1;
-export const checkpoint = () => {
-  if (willStop > 0) {
-    willStop--;
-  } else if (willStop === 0) {
-    const iter = getIterationCache();
-    debugger;
-    willStop = -1;
-  }
-};
-export const nextStop = (count: number) => {
-  willStop = count;
-};
+// let willStop = -1;
+// export const checkpoint = () => {
+//   if (willStop > 0) {
+//     willStop--;
+//   } else if (willStop === 0) {
+//     const iter = getIterationCache();
+//     debugger;
+//     willStop = -1;
+//   }
+// };
+// export const nextStop = (count: number) => {
+//   willStop = count;
+// };

--- a/src/view/right-sidebar/use-poi.tsx
+++ b/src/view/right-sidebar/use-poi.tsx
@@ -1,4 +1,4 @@
-import { clearIterationCache } from "@/aggregator";
+import { clearIterationCache } from "@/aggregator/aggregator";
 import { getCurrentPalette, setSerializedPalette } from "@/camera/palette";
 import { getResizedCanvasImageDataURL } from "@/canvas-reference";
 import { deletePreview, savePreview } from "@/store/preview-store";

--- a/src/view/right-sidebar/use-poi.tsx
+++ b/src/view/right-sidebar/use-poi.tsx
@@ -1,3 +1,4 @@
+import { clearIterationCache } from "@/aggregator";
 import { getCurrentPalette, setSerializedPalette } from "@/camera/palette";
 import { getResizedCanvasImageDataURL } from "@/canvas-reference";
 import { deletePreview, savePreview } from "@/store/preview-store";
@@ -56,6 +57,7 @@ export const usePOI = () => {
 
   const applyPOI = useCallback((poi: POIData) => {
     setCurrentParams(cloneParams(poi));
+    clearIterationCache();
     setSerializedPalette(poi.serializedPalette);
   }, []);
 

--- a/src/worker-pool/callbacks/iteration-worker.ts
+++ b/src/worker-pool/callbacks/iteration-worker.ts
@@ -1,4 +1,7 @@
-import { getIterationCache, upsertIterationCache } from "@/aggregator";
+import {
+  getIterationCache,
+  upsertIterationCache,
+} from "@/aggregator/aggregator";
 import { renderToMainBuffer } from "@/camera/camera";
 import { CalcIterationJob, IterationIntermediateResult } from "@/types";
 import { completeJob, isBatchCompleted } from "../task-queue";

--- a/src/worker-pool/callbacks/iteration-worker.ts
+++ b/src/worker-pool/callbacks/iteration-worker.ts
@@ -38,7 +38,7 @@ export const onIterationWorkerResult: IterationResultCallback = (
   }
 
   const iterationsResult = new Uint32Array(iterations);
-  upsertIterationCache(rect, iterationsResult, {
+  const iterBuffer = upsertIterationCache(rect, iterationsResult, {
     width: rect.width,
     height: rect.height,
   });
@@ -56,7 +56,7 @@ export const onIterationWorkerResult: IterationResultCallback = (
 
   batchContext.onChangeProgress();
 
-  renderToMainBuffer(rect);
+  renderToMainBuffer(rect, [iterBuffer]);
 
   // バッチ全体が完了していたらonComplete callbackを呼ぶ
   if (isBatchCompleted(job.batchId)) {
@@ -84,6 +84,10 @@ export const onIterationWorkerIntermediateResult = (
 
   batchContext.onChangeProgress();
 
-  upsertIterationCache(rect, new Uint32Array(iterations), resolution);
-  renderToMainBuffer(rect);
+  const iterBuffer = upsertIterationCache(
+    rect,
+    new Uint32Array(iterations),
+    resolution,
+  );
+  renderToMainBuffer(rect, [iterBuffer]);
 };

--- a/src/worker-pool/callbacks/iteration-worker.ts
+++ b/src/worker-pool/callbacks/iteration-worker.ts
@@ -1,4 +1,4 @@
-import { upsertIterationCache } from "@/aggregator";
+import { getIterationCache, upsertIterationCache } from "@/aggregator";
 import { renderToMainBuffer } from "@/camera/camera";
 import { CalcIterationJob, IterationIntermediateResult } from "@/types";
 import { completeJob, isBatchCompleted } from "../task-queue";
@@ -63,6 +63,8 @@ export const onIterationWorkerResult: IterationResultCallback = (
     const finishedAt = performance.now();
     batchContext.finishedAt = finishedAt;
     const elapsed = finishedAt - batchContext.startedAt;
+
+    console.log("Iteration Buffer length: ", getIterationCache().length);
 
     batchContext.onComplete(elapsed);
   }

--- a/src/worker-pool/worker-pool.ts
+++ b/src/worker-pool/worker-pool.ts
@@ -10,6 +10,7 @@ import {
   ResultSpans,
   mandelbrotWorkerTypes,
 } from "@/types";
+import { debugWatch } from "@/utils/debug";
 import {
   calcNormalizedWorkerIndex,
   findFreeWorkerIndex,
@@ -29,7 +30,6 @@ import {
   getRunningJobsInBatch,
   getWaitingJobs,
   hasRunningJob,
-  hasWaitingJob,
   markDoneJob,
   popWaitingExecutableJob,
   removeBatchFromRunningJobs,
@@ -184,6 +184,7 @@ export function registerBatch(
 }
 
 export function tickWorkerPool() {
+  let jobStarted = false;
   const refPool = getWorkerPool("calc-ref-orbit");
   if (
     (refPool.length > 0 && findFreeWorkerIndex("calc-ref-orbit") === -1) ||
@@ -212,6 +213,7 @@ export function tickWorkerPool() {
       break;
     }
 
+    jobStarted = true;
     start(workerIdx, job);
   }
 
@@ -235,14 +237,16 @@ export function tickWorkerPool() {
       break;
     }
 
+    jobStarted = true;
     start(workerIdx, job);
 
     deleteCompletedDoneJobs();
   }
 
-  if (hasWaitingJob() || !hasRunningJob()) {
-    console.debug(
-      `Job status: running: ${countRunningJobs()}, waiting: ${countWaitingJobs()}`,
+  if (jobStarted || !hasRunningJob()) {
+    debugWatch(
+      "jobStatus",
+      `running: ${countRunningJobs()}, waiting: ${countWaitingJobs()}`,
     );
   }
 }


### PR DESCRIPTION
## Summary
- 左クリック拡縮時・右クリックドラッグのインタラクティブ拡縮時、プレビュー後描画待ちから描画結果にスムーズにつながるようにした
   - 下記画像参照
   - めっちゃスムーズにつながるようになったし、palette animationも止まらないので最強
- 一部の描画完了時にすべてのiterationCacheを見ていたのを修正
   - 今完了した部分のiterationCacheのみ描画するようにしたのでたぶん少し軽くなった

## メモ
- iterationCacheを複素数座標で持つのはやめた。比較がBigNumberの比較で重い
   - worker数を増やすとiterationCacheのエントリ数も増えるので比較コストがバカにならない

## Image
https://github.com/user-attachments/assets/307e55f0-f79e-424a-9aa0-03d17f43980c

palette animation有効な場合

https://github.com/user-attachments/assets/77be6f23-f810-4bb6-91d1-87805f007f2a
