### PR TITLE
canvasを領域内いっぱいに広げて表示するようにした

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "culori": "4.0.1",
     "d3-color": "3.1.0",
     "d3-scale-chromatic": "3.1.0",
+    "es-toolkit": "1.31.0",
     "eventmit": "2.0.4",
     "idb-keyval": "6.2.1",
     "lodash.throttle": "4.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       d3-scale-chromatic:
         specifier: 3.1.0
         version: 3.1.0
+      es-toolkit:
+        specifier: 1.31.0
+        version: 1.31.0
       eventmit:
         specifier: 2.0.4
         version: 2.0.4
@@ -1709,6 +1712,9 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.31.0:
+    resolution: {integrity: sha512-vwS0lv/tzjM2/t4aZZRAgN9I9TP0MSkWuvt6By+hEXfG/uLs8yg2S1/ayRXH/x3pinbLgVJYT+eppueg3cM6tg==}
 
   esbuild@0.20.2:
     resolution: {integrity: sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==}
@@ -4603,6 +4609,8 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  es-toolkit@1.31.0: {}
 
   esbuild@0.20.2:
     optionalDependencies:

--- a/src/camera/camera.ts
+++ b/src/camera/camera.ts
@@ -1,15 +1,16 @@
-import { getCurrentParams } from "@/mandelbrot-state/mandelbrot-state";
+import {
+  getCurrentParams,
+  requireNextRender,
+} from "@/mandelbrot-state/mandelbrot-state";
 import type { IterationBuffer } from "@/types";
 import p5 from "p5";
-import { getIterationCache } from "../iteration-buffer/iteration-buffer";
+import {
+  clearIterationCache,
+  getIterationCache,
+} from "../iteration-buffer/iteration-buffer";
 import { Rect } from "../math/rect";
 import { renderIterationsToPixel } from "../rendering/rendering";
-import {
-  getCurrentPalette,
-  markAsRendered,
-  markNeedsRerender,
-  needsRerender,
-} from "./palette";
+import { getCurrentPalette, markAsRendered, needsRerender } from "./palette";
 
 let mainBuffer: p5.Graphics;
 
@@ -59,12 +60,18 @@ export const resizeCamera = (p: p5, w: number, h: number) => {
   height = h;
   bufferRect = { x: 0, y: 0, width: w, height: h };
 
-  mainBuffer.resizeCanvas(w, h);
+  // const offsetX = Math.round((w - from.width) / 2);
+  // const offsetY = Math.round((h - from.height) / 2);
 
+  mainBuffer.resizeCanvas(w, h);
   clearMainBuffer();
+
+  // translateRectInIterationCache(-offsetX, -offsetY);
+  // removeUnusedIterationCache();
+  clearIterationCache();
   renderToMainBuffer();
 
-  markNeedsRerender();
+  requireNextRender();
 };
 
 export const nextBuffer = (_p: p5): p5.Graphics => {

--- a/src/camera/camera.ts
+++ b/src/camera/camera.ts
@@ -26,7 +26,16 @@ let bufferRect: Rect;
 /**
  * FIXME: responsiveにするときに任意の値で初期化できるようにする
  */
-export const initializeCanvasSize = (w: number = 800, h: number = 800) => {
+export const initializeCanvasSize = () => {
+  const elm = document.getElementById("canvas-wrapper");
+  let w = 800;
+  let h = 800;
+
+  if (elm) {
+    w = elm.clientWidth;
+    h = elm.clientHeight;
+  }
+
   width = w;
   height = h;
 

--- a/src/camera/camera.ts
+++ b/src/camera/camera.ts
@@ -1,4 +1,5 @@
 import { getCurrentParams } from "@/mandelbrot-state/mandelbrot-state";
+import { getStore } from "@/store/store";
 import type { IterationBuffer } from "@/types";
 import p5 from "p5";
 import {
@@ -61,11 +62,22 @@ export const setupCamera = (p: p5, w: number, h: number) => {
  * - mainBufferのリサイズ
  * - cacheの位置変更（できれば）
  */
-export const resizeCamera = (p: p5, w: number, h: number) => {
+export const resizeCamera = (
+  p: p5,
+  requestWidth: number,
+  requestHeight: number,
+) => {
   const from = getCanvasSize();
   console.debug(
-    `Resize canvas to x=${w} y=${h}, from x=${from.width} y=${from.height}`,
+    `Request resize canvas to w=${requestWidth} h=${requestHeight}, from w=${from.width} h=${from.height}`,
   );
+
+  const maxSize = getStore("maxCanvasSize");
+
+  const w = maxSize === -1 ? requestWidth : Math.min(requestWidth, maxSize);
+  const h = maxSize === -1 ? requestHeight : Math.min(requestHeight, maxSize);
+
+  console.debug(`Resize to: w=${w}, h=${h} (maxCanvasSize=${maxSize})`);
 
   p.resizeCanvas(w, h);
 

--- a/src/camera/camera.ts
+++ b/src/camera/camera.ts
@@ -4,7 +4,12 @@ import p5 from "p5";
 import { getIterationCache } from "../iteration-buffer/iteration-buffer";
 import { Rect } from "../math/rect";
 import { renderIterationsToPixel } from "../rendering/rendering";
-import { getCurrentPalette, markAsRendered, needsRerender } from "./palette";
+import {
+  getCurrentPalette,
+  markAsRendered,
+  markNeedsRerender,
+  needsRerender,
+} from "./palette";
 
 let mainBuffer: p5.Graphics;
 
@@ -32,6 +37,34 @@ export const setupCamera = (p: p5, w: number, h: number) => {
   bufferRect = { x: 0, y: 0, width: w, height: h };
 
   console.log("Camera setup done", { width, height });
+};
+
+/**
+ * 画面サイズが変わったときに呼ぶ
+ *
+ * やること
+ * - canvasのリサイズ
+ * - mainBufferのリサイズ
+ * - cacheの位置変更（できれば）
+ */
+export const resizeCamera = (p: p5, w: number, h: number) => {
+  const from = getCanvasSize();
+  console.log(
+    `Resize canvas to x=${w} y=${h}, from x=${from.width} y=${from.height}`,
+  );
+
+  p.resizeCanvas(w, h);
+
+  width = w;
+  height = h;
+  bufferRect = { x: 0, y: 0, width: w, height: h };
+
+  mainBuffer.resizeCanvas(w, h);
+
+  clearMainBuffer();
+  renderToMainBuffer();
+
+  markNeedsRerender();
 };
 
 export const nextBuffer = (_p: p5): p5.Graphics => {

--- a/src/camera/palette.ts
+++ b/src/camera/palette.ts
@@ -24,7 +24,7 @@ let renderNext = true;
 /**
  * 次に再renderするようマークする
  */
-const markNeedsRerender = () => {
+export const markNeedsRerender = () => {
   renderNext = true;
 };
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,4 @@
+import { debounce } from "es-toolkit";
 import p5 from "p5";
 import React from "react";
 import ReactDOMClient from "react-dom/client";
@@ -8,6 +9,7 @@ import {
   p5Draw,
   p5MouseReleased,
   p5Setup,
+  resizeTo,
   zoomTo,
 } from "./p5-adapter/p5-adapter";
 import { isInside } from "./p5-adapter/utils";
@@ -70,6 +72,11 @@ const sketch = (p: p5) => {
 
   p.draw = () => {
     p5Draw(p);
+  };
+
+  const debouncedResizeFunc = debounce(() => resizeTo(p), 500);
+  p.windowResized = () => {
+    debouncedResizeFunc();
   };
 };
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -74,7 +74,7 @@ const sketch = (p: p5) => {
     p5Draw(p);
   };
 
-  const debouncedResizeFunc = debounce(() => resizeTo(p), 500);
+  const debouncedResizeFunc = debounce(() => resizeTo(p), 250);
   p.windowResized = () => {
     debouncedResizeFunc();
   };

--- a/src/mandelbrot-state/mandelbrot-state.ts
+++ b/src/mandelbrot-state/mandelbrot-state.ts
@@ -52,6 +52,9 @@ export const markAsRenderedWithCurrentParams = () => {
 export const needsRenderForCurrentParams = () => {
   return !isSameParams(lastCalc, currentParams);
 };
+export const requireNextRender = () => {
+  lastCalc = { ...currentParams, N: 0 };
+};
 const isSameParams = (a: MandelbrotParams, b: MandelbrotParams) =>
   a.x === b.x && a.y === b.y && a.r === b.r && a.N === b.N && a.mode === b.mode;
 

--- a/src/p5-adapter/p5-adapter.ts
+++ b/src/p5-adapter/p5-adapter.ts
@@ -281,7 +281,7 @@ export const zoomTo = (isZoomOut: boolean) => {
 };
 
 /** wrapper elementの高さを取得してcameraのサイズを変える */
-export const resizeTo = (p: p5) => {
+export const resizeTo = (p: p5 = UNSAFE_p5Instance) => {
   const elm = document.getElementById("canvas-wrapper");
 
   if (elm) {

--- a/src/p5-adapter/p5-adapter.ts
+++ b/src/p5-adapter/p5-adapter.ts
@@ -2,6 +2,7 @@ import {
   getCanvasSize,
   initializeCanvasSize,
   nextBuffer,
+  resizeCamera,
   setupCamera,
 } from "@/camera/camera";
 import {
@@ -277,6 +278,15 @@ export const zoomTo = (isZoomOut: boolean) => {
     scaleAtY: height / 2,
     scale: rate,
   });
+};
+
+/** wrapper elementの高さを取得してcameraのサイズを変える */
+export const resizeTo = (p: p5) => {
+  const elm = document.getElementById("canvas-wrapper");
+
+  if (elm) {
+    resizeCamera(p, elm.clientWidth, elm.clientHeight);
+  }
 };
 
 // ================================================================================================

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -21,6 +21,8 @@ type Store = {
   workerCount: number;
   animationTime: number;
   refOrbitWorkerCount: number;
+  /** -1なら無制限。値があればcanvasの縦横幅はこの値以上にならない */
+  maxCanvasSize: number;
   canvasLocked: boolean;
   shouldReuseRefOrbit: boolean;
   paletteLength: number;
@@ -46,6 +48,7 @@ const store: Store = {
   workerCount: 2,
   animationTime: 0,
   refOrbitWorkerCount: 1, // 仮
+  maxCanvasSize: -1,
   // UI state
   canvasLocked: false,
   // mandelbrot state

--- a/src/store/sync-storage/settings.ts
+++ b/src/store/sync-storage/settings.ts
@@ -5,6 +5,7 @@ export type Settings = {
   workerCount: number;
   animationTime: number;
   animationCycleStep?: number;
+  maxCanvasSize?: number;
 };
 
 export const DEFAULT_WORKER_COUNT =
@@ -15,6 +16,7 @@ const defaultSettings = {
   workerCount: DEFAULT_WORKER_COUNT,
   animationTime: 0,
   animationCycleStep: 1,
+  maxCanvasSize: -1,
 } satisfies Settings;
 
 export const isSettingField = (key: string): key is keyof Settings =>

--- a/src/view/canvas-overlay/index.tsx
+++ b/src/view/canvas-overlay/index.tsx
@@ -5,7 +5,7 @@ export const CanvasOverlay = () => {
   const progress = useStoreValue("progress");
 
   return (
-    <div className="size-[800px] p-1">
+    <div className="p-1">
       {typeof progress === "string" && <LoadingSpinner />}
     </div>
   );

--- a/src/view/right-sidebar/settings.tsx
+++ b/src/view/right-sidebar/settings.tsx
@@ -1,4 +1,5 @@
 import { ValueSlider } from "@/components/slider-wrapper";
+import { resizeTo } from "@/p5-adapter/p5-adapter";
 import { Button } from "@/shadcn/components/ui/button";
 import { useToast } from "@/shadcn/hooks/use-toast";
 import { readPOIListFromClipboard } from "@/store/sync-storage/poi-list";
@@ -30,6 +31,7 @@ export const Settings = () => {
 
   const zoomRate = useStoreValue("zoomRate");
   const workerCount = useStoreValue("workerCount");
+  const maxCanvasSize = useStoreValue("maxCanvasSize");
 
   const zoomRateValues = ["1.2", "1.5", "2.0", "4.0", "6.0", "10", "50", "100"];
   const workerCountValues = createWorkerCountValues();
@@ -62,6 +64,15 @@ export const Settings = () => {
     "43",
     "47",
   ];
+  const maxCanvasSizeValues = [
+    "-1",
+    "128",
+    "256",
+    "512",
+    "800",
+    "1024",
+    "2048",
+  ];
 
   const [zoomRatePreview, setZoomRatePreview] = useState(zoomRate);
   const [workerCountPreview, setWorkerCountPreview] = useState(workerCount);
@@ -71,6 +82,8 @@ export const Settings = () => {
   const [animationCycleStep, setAnimationCycleStep] = useState(() =>
     getStore("animationCycleStep"),
   );
+  const [maxCanvasSizePreview, setMaxCanvasSizePreview] =
+    useState(maxCanvasSize);
 
   return (
     <div className="flex max-w-80 flex-col gap-6">
@@ -125,6 +138,21 @@ export const Settings = () => {
           valueConverter={(value) => parseInt(value)}
           onValueChange={(value) => setAnimationCycleStep(value)}
           onValueCommit={(value) => updateStore("animationCycleStep", value)}
+        />
+      </div>
+      <div>
+        <div className="mb-1 ml-2">Max Canvas Size: {maxCanvasSizePreview}</div>
+        <ValueSlider<number>
+          values={maxCanvasSizeValues}
+          defaultValue={maxCanvasSize}
+          valueConverter={(value) => parseInt(value)}
+          onValueChange={(value) => {
+            setMaxCanvasSizePreview(value);
+          }}
+          onValueCommit={(value) => {
+            updateStore("maxCanvasSize", value);
+            resizeTo();
+          }}
         />
       </div>
       <div>


### PR DESCRIPTION
## Summary
- 800x800固定だったが、画面が小さい環境で微妙に画面におさまりきらなかったりしたのでやった
   - - これでレイアウトがちょっと楽になりそう
- resize直後はcacheを使いまわして新たに計算はしない
   - 領域広がるときにめっちゃ荒いcacheが使われたりするがまあいいだろう
- settingsで最大サイズを指定できるようにした
   - 4Kディスプレイとかめっちゃ重くなりそうなので

## Future
- 画面サイズと解像度を別に指定できたらそれは素敵なことですね

## Bug
- WQHDのディスプレイからFHDのディスプレイに移すとheightがそのままになってしまう

## Image
https://github.com/user-attachments/assets/d60d57c8-0f59-49ed-8fd2-fec70a4e4f29

