### PR TITLE
右クリックドラッグ中にcanvasの外にはみ出たときにcontextmenuを表示しないようにした

### DIFF
--- a/src/camera/camera.ts
+++ b/src/camera/camera.ts
@@ -25,20 +25,22 @@ let height: number;
 let bufferRect: Rect;
 
 /**
- * FIXME: responsiveにするときに任意の値で初期化できるようにする
+ * canvasのサイズをcontainerのサイズと最大サイズ設定見て初期化する
  */
 export const initializeCanvasSize = () => {
   const elm = document.getElementById("canvas-wrapper");
   let w = 800;
   let h = 800;
 
+  const maxCanvasSize = getStore("maxCanvasSize");
+
   if (elm) {
     w = elm.clientWidth;
     h = elm.clientHeight;
   }
 
-  width = w;
-  height = h;
+  width = Math.min(w, maxCanvasSize);
+  height = Math.min(h, maxCanvasSize);
 
   return { width, height };
 };

--- a/src/p5-adapter/p5-adapter.ts
+++ b/src/p5-adapter/p5-adapter.ts
@@ -102,9 +102,7 @@ const calcInteractiveScaleFactor = (
 
 /** カーソルの変更 */
 const changeCursor = (p: p5, cursor: string) => {
-  if (isInside(p)) {
-    p.cursor(cursor);
-  }
+  p.cursor(cursor);
 };
 
 /** canvasの状態をstoreに反映する */

--- a/src/p5-adapter/p5-adapter.ts
+++ b/src/p5-adapter/p5-adapter.ts
@@ -59,6 +59,8 @@ let draggingMode: "move" | "zoom" | undefined = undefined;
 let elapsed = 0;
 /** canvas内でマウスクリックが開始されたかどうか */
 let mouseClickStartedInside = false;
+/** 次回のcontextmenu表示を妨害する。右クリックドラッグではみ出たときに使う */
+let willBlockNextContextMenu = false;
 /** p5のインスタンス。基本的には直に使わない */
 let UNSAFE_p5Instance: p5;
 
@@ -307,6 +309,14 @@ export const p5Setup = (p: p5) => {
   p.colorMode(p.HSB, 360, 100, 100, 100);
   p.cursor(p.CROSS);
 
+  window.oncontextmenu = () => {
+    if (willBlockNextContextMenu) {
+      willBlockNextContextMenu = false;
+      return false;
+    }
+    return true;
+  };
+
   initializePOIHistory();
 
   const initialParams = extractMandelbrotParams();
@@ -339,6 +349,7 @@ export const p5MouseReleased = (p: p5, ev: MouseEvent) => {
         x: mouseClickedOn.mouseX,
         y: mouseClickedOn.mouseY,
       });
+      willBlockNextContextMenu = true;
     }
   } else {
     // クリック時

--- a/src/rendering/rendering.ts
+++ b/src/rendering/rendering.ts
@@ -1,4 +1,5 @@
 import { Palette } from "@/color";
+import { clamp } from "@/math/util";
 import p5 from "p5";
 import { getCanvasSize } from "../camera/camera";
 import { Rect } from "../math/rect";
@@ -160,5 +161,22 @@ export const drawScaleRate = (p: p5, scaleFactor: number) => {
   p.strokeWeight(4);
   p.textSize(14);
 
-  p.text(`x${scaleFactor.toFixed(2)}`, p.mouseX + 10, p.mouseY);
+  const { text, size } = scaleRateText(scaleFactor);
+
+  const x = clamp(p.mouseX, 0, p.width - size);
+  const y = clamp(p.mouseY, 0, p.height - 25);
+
+  p.text(`${text}`, x + 10, y + 20);
+};
+
+const scaleRateText = (scaleFactor: number) => {
+  if (scaleFactor < 10) {
+    return { text: `x${scaleFactor.toFixed(2)}`, size: 60 };
+  } else if (scaleFactor < 100) {
+    return { text: `x${scaleFactor.toFixed(1)}`, size: 60 };
+  } else {
+    // 100~
+    const text = `x${Math.round(scaleFactor)}`;
+    return { text, size: text.length * 10 + 8 };
+  }
 };

--- a/src/store/sync-storage/settings.ts
+++ b/src/store/sync-storage/settings.ts
@@ -4,8 +4,8 @@ export type Settings = {
   zoomRate: number;
   workerCount: number;
   animationTime: number;
-  animationCycleStep?: number;
-  maxCanvasSize?: number;
+  animationCycleStep: number;
+  maxCanvasSize: number;
 };
 
 export const DEFAULT_WORKER_COUNT =
@@ -28,6 +28,7 @@ export const writeSettingsToStorage = () => {
     workerCount: getStore("workerCount"),
     animationTime: getStore("animationTime"),
     animationCycleStep: getStore("animationCycleStep"),
+    maxCanvasSize: getStore("maxCanvasSize"),
   } satisfies Settings;
 
   const serialized = JSON.stringify(settings);


### PR DESCRIPTION
## Summary
- 表題の通り
- あとついでにcanvas外に行ったときも倍率表示はcanvasの中に収まるようにした

## 感想
- 最初 `document.addEventListener("contextmenu", () => false)` してもcontextmenu消えないんだが！？って時間を溶かしました...

## ついでに
- #71 
   - でlocalStorageに保存できてなかったのを修正した

## Image
https://github.com/user-attachments/assets/97145559-5221-4599-9a94-479d9f7a3967

