### PR TITLE
POICard周りの表示や挙動の細かい修正

### DIFF
--- a/src/view/right-sidebar/poi-card-preview.tsx
+++ b/src/view/right-sidebar/poi-card-preview.tsx
@@ -1,12 +1,13 @@
 import { loadPreview, useTrackChangePreview } from "@/store/preview-store";
 import { POIData } from "@/types";
+import React from "react";
 import usePromise from "react-promise-suspense";
 
 type Props = {
   poi: POIData;
 };
 
-export const POICardPreview = ({ poi }: Props) => {
+export const POICardPreview = React.memo(({ poi }: Props) => {
   const data = usePromise(loadPreview, [poi.id], 1000);
 
   useTrackChangePreview(poi.id);
@@ -19,4 +20,5 @@ export const POICardPreview = ({ poi }: Props) => {
     );
 
   return <img src={data} />;
-};
+});
+POICardPreview.displayName = "POICardPreview";

--- a/src/view/right-sidebar/poi-card.tsx
+++ b/src/view/right-sidebar/poi-card.tsx
@@ -29,7 +29,7 @@ export const POICard = ({
   const canRegenerate = useIsInSamePlace(poi);
 
   return (
-    <Card className="w-64 p-2">
+    <Card className="p-2">
       <div className="flex">
         <div className="">
           <Suspense fallback={"loading..."}>
@@ -38,21 +38,16 @@ export const POICard = ({
         </div>
         <div className="ml-2 flex grow flex-col">
           <div className="flex justify-between">
-            <div>r</div>
-            <div>{r.toPrecision(5)}</div>
+            <div className="mr-2">r</div>
+            <div>{r.toPrecision(3)}</div>
           </div>
           <div className="flex justify-between">
             <div>N</div>
             <div>{N.toFixed(0)}</div>
           </div>
 
-          <div className="mt-2 flex justify-between">
-            <SimpleTooltip content="Apply params">
-              <Button variant="default" size="icon" onClick={onApply}>
-                <IconArrowBigLeftLine />
-              </Button>
-            </SimpleTooltip>
-            {canRegenerate && (
+          <div className="mt-2 flex justify-between gap-2">
+            {canRegenerate ? (
               <SimpleTooltip content="Regenerate thumbnail">
                 <Button
                   variant="secondary"
@@ -60,6 +55,12 @@ export const POICard = ({
                   onClick={onRegenerateThumbnail}
                 >
                   <IconRefresh />
+                </Button>
+              </SimpleTooltip>
+            ) : (
+              <SimpleTooltip content="Apply params">
+                <Button variant="default" size="icon" onClick={onApply}>
+                  <IconArrowBigLeftLine />
                 </Button>
               </SimpleTooltip>
             )}

--- a/src/view/right-sidebar/poi-card.tsx
+++ b/src/view/right-sidebar/poi-card.tsx
@@ -42,7 +42,7 @@ export const POICard = ({
             <div>{r.toPrecision(3)}</div>
           </div>
           <div className="flex justify-between">
-            <div>N</div>
+            <div className="mr-2">N</div>
             <div>{N.toFixed(0)}</div>
           </div>
 

--- a/src/view/right-sidebar/use-poi.tsx
+++ b/src/view/right-sidebar/use-poi.tsx
@@ -47,6 +47,8 @@ export const usePOI = () => {
 
   const deletePOIAt = useCallback(
     (index: number) => {
+      if (!confirm("Are you sure you want to delete this POI?")) return;
+
       const del = poiList[index];
       const newPOIList = poiList.filter((_, i) => i !== index);
       writePOIListToStorage(newPOIList);


### PR DESCRIPTION
## Summary
- thumbnailを毎回IndexedDBからロードしてきていたのでReact.memoで防いだ
- 表示の横幅をすこし減らした
   - regenerate thumbnailボタンはapplyの代わりに出すようにした
      - regenerateできるときは同じ位置にいるときなので、applyしたいことはない
   - rの桁数も減らした
      - rからは深さしか判断できないしe以降さえわかればよい
- 消すときにwindow.confirmするようにした
   - どれを消そうとしてるのか分からないし、消しても戻せるタイプのUIの方がよいと思うが応急処置ということで

## Image
|before|after|
|----|----|
|[![Image from Gyazo](https://i.gyazo.com/4669ff22b7cb19291bd7725842b3676c.png)](https://gyazo.com/4669ff22b7cb19291bd7725842b3676c)|[![Image from Gyazo](https://i.gyazo.com/868054cd94f5913f8759d7ed4b433f02.png)](https://gyazo.com/868054cd94f5913f8759d7ed4b433f02)|