### PR TITLE
リサイズ時に操作できる範囲がリサイズ前のものに固定されてしまっていたのを修正

### DIFF
--- a/src/rendering/renderer.ts
+++ b/src/rendering/renderer.ts
@@ -89,12 +89,19 @@ export function resizeCanvas(
   requestWidth: number,
   requestHeight: number,
 ): void {
-  runRendererFunction(
-    p5Renderer.resizeCanvas,
-    webGPURenderer.resizeCanvas,
-    requestWidth,
-    requestHeight,
-  );
+  const rendererType = getRenderer();
+
+  switch (rendererType) {
+    case "p5js": {
+      p5Renderer.resizeCanvas(requestWidth, requestHeight);
+    }
+    case "webgpu": {
+      // 手抜きして従来のp5rendererをそのままUI描画用canvasに使っているので両方リサイズする必要がある
+      // FIXME: UI描画用canvasを分離する
+      webGPURenderer.resizeCanvas(requestWidth, requestHeight);
+      p5Renderer.resizeCanvas(requestWidth, requestHeight);
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
ズームやDnDのためにp5jsの便利関数を使っているので、
WebGPUの場合でもUI描画はp5jsのものを使っていた
rendererがWebGPUのときにこのUI描画用canvasをリサイズしていなかったのが原因

## TODO
UI描画用のcanvasは元々のp5jsの描画用canvasをそのまま使いまわしているため、
不必要なBuffer確保等が行われている
直す（そのうち）