### PR TITLE
IterationCacheのdebug viewを作成

### DIFF
--- a/src/iteration-buffer/iteration-buffer.ts
+++ b/src/iteration-buffer/iteration-buffer.ts
@@ -7,6 +7,9 @@ import { IterationBuffer } from "../types";
 // FIXME: 配列全部舐める必要があるのよくないので良い感じにデータを持つようにする
 let iterationCache: IterationBuffer[] = [];
 
+// Subscription system for iteration cache updates
+let subscribers: Set<() => void> = new Set();
+
 export const upsertIterationCache = (
   rect: Rect,
   buffer: Uint32Array,
@@ -37,6 +40,19 @@ export const upsertIterationCache = (
 
 export const getIterationCache = (): IterationBuffer[] => {
   return iterationCache;
+};
+
+// Subscription functions for cache updates
+export const subscribeToIterationCacheUpdates = (callback: () => void) => {
+  subscribers.add(callback);
+  return () => {
+    subscribers.delete(callback);
+  };
+};
+
+// Explicit notification function to be called after rendering is complete
+export const notifyIterationCacheUpdate = () => {
+  subscribers.forEach(callback => callback());
 };
 
 /**

--- a/src/iteration-buffer/use-iteration-cache.ts
+++ b/src/iteration-buffer/use-iteration-cache.ts
@@ -1,0 +1,15 @@
+import { useSyncExternalStore } from "react";
+import { getIterationCache, subscribeToIterationCacheUpdates } from "./iteration-buffer";
+import type { IterationBuffer } from "../types";
+
+/**
+ * iteration cacheの変更を自動で検知するReactフック
+ * useSyncExternalStoreを使用してパフォーマンス最適化
+ */
+export const useIterationCache = (): IterationBuffer[] => {
+  return useSyncExternalStore(
+    subscribeToIterationCacheUpdates,
+    getIterationCache,
+    getIterationCache // SSR用のgetServerSnapshot
+  );
+};

--- a/src/iteration-buffer/use-iteration-cache.ts
+++ b/src/iteration-buffer/use-iteration-cache.ts
@@ -1,6 +1,9 @@
 import { useSyncExternalStore } from "react";
-import { getIterationCache, subscribeToIterationCacheUpdates } from "./iteration-buffer";
 import type { IterationBuffer } from "../types";
+import {
+  getIterationCacheSnapshot,
+  subscribeToIterationCacheUpdates,
+} from "./iteration-buffer";
 
 /**
  * iteration cacheの変更を自動で検知するReactフック
@@ -9,7 +12,6 @@ import type { IterationBuffer } from "../types";
 export const useIterationCache = (): IterationBuffer[] => {
   return useSyncExternalStore(
     subscribeToIterationCacheUpdates,
-    getIterationCache,
-    getIterationCache // SSR用のgetServerSnapshot
+    getIterationCacheSnapshot,
   );
 };

--- a/src/shadcn/components/ui/switch.tsx
+++ b/src/shadcn/components/ui/switch.tsx
@@ -1,0 +1,29 @@
+import { Switch as SwitchPrimitive } from "radix-ui"
+import * as React from "react"
+
+import { cn } from "@/shadcn/utils"
+
+function Switch({
+  className,
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root>) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      className={cn(
+        "peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className={cn(
+          "bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0"
+        )}
+      />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -8,6 +8,7 @@ import {
 } from "./sync-storage/settings";
 
 type Store = {
+  // mandelbrot params
   centerX: BigNumber;
   centerY: BigNumber;
   mouseX: BigNumber;
@@ -16,21 +17,40 @@ type Store = {
   N: number;
   iteration: number | string;
   mode: "normal" | "perturbation";
+
+  // POI List
   poi: POIData[];
+
+  // Settings
   zoomRate: number;
   workerCount: number;
   animationTime: number;
   refOrbitWorkerCount: number;
-  /** -1なら無制限。値があればcanvasの縦横幅はこの値以上にならない */
+  /**
+   * 最大キャンバスサイズ
+   *
+   * -1なら無制限
+   * 値があればcanvasの縦横幅はこの値以上にならない
+   */
   maxCanvasSize: number;
+
+  // UI state
   canvasLocked: boolean;
+
+  // mandelbrot state
   shouldReuseRefOrbit: boolean;
+
+  // palette settings
   paletteLength: number;
   paletteOffset: number;
   animationCycleStep: number;
+
+  // state
   progress: string | ResultSpans;
-  /** 現在使用中のレンダラー */
+  /** 現在使用中のrenderer */
   rendererType: "webgpu" | "p5js";
+  /** Debug Mode中か否か */
+  isDebugMode: boolean;
 };
 
 const store: Store = {
@@ -61,8 +81,8 @@ const store: Store = {
   animationCycleStep: 1,
   // state
   progress: "",
-  // renderer
   rendererType: "p5js",
+  isDebugMode: false,
 };
 
 const event = eventmit<string>();

--- a/src/style.css
+++ b/src/style.css
@@ -123,6 +123,8 @@ body {
 
   display: flex;
   flex-direction: column;
+  height: 88dvh;
+  overflow-y: auto;
 }
 
 #footer {

--- a/src/view/header/index.tsx
+++ b/src/view/header/index.tsx
@@ -5,6 +5,9 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/shadcn/components/ui/dialog";
+import { Label } from "@/shadcn/components/ui/label";
+import { Switch } from "@/shadcn/components/ui/switch";
+import { updateStoreWith, useStoreValue } from "@/store/store";
 import { IconHelp } from "@tabler/icons-react";
 import { useModalState } from "../modal/use-modal-state";
 import { Actions } from "./actions";
@@ -12,6 +15,9 @@ import { Instructions } from "./instructions";
 
 export const Header = () => {
   const [opened, { open, toggle }] = useModalState();
+  const isDebugMode = useStoreValue("isDebugMode");
+
+  const toggleDebugMode = () => updateStoreWith("isDebugMode", (v) => !v);
 
   return (
     <>
@@ -26,13 +32,21 @@ export const Header = () => {
       <div className="grid grid-cols-2">
         <Actions />
         <div className="col-end-7 flex items-center gap-1">
+          <div className="flex items-center space-x-2 px-2">
+            <Switch
+              id="debug-mode"
+              checked={isDebugMode}
+              onCheckedChange={() => toggleDebugMode()}
+            />
+            <Label htmlFor="debug-mode">Debug Mode</Label>
+          </div>
           <Button variant="outline" size="icon-sm" asChild>
             <a
               href="https://github.com/k-chop/p5mandelbrot"
               target="_blank"
               rel="noreferrer"
             >
-              <img src="github-mark-white.svg" />
+              <img src="github-mark-white.svg" className="p-1" />
             </a>
           </Button>
           <Button variant="outline" size="icon-sm" onClick={open}>

--- a/src/view/right-sidebar/debug-mode/debug-mode.tsx
+++ b/src/view/right-sidebar/debug-mode/debug-mode.tsx
@@ -1,3 +1,24 @@
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@/shadcn/components/ui/tabs";
+import { IterationCacheViewer } from "./iteration-cache-viewer";
+
 export const DebugMode = () => {
-  return <div>hello</div>;
+  return (
+    <Tabs defaultValue="iteration-cache">
+      <TabsList>
+        <TabsTrigger value="iteration-cache">Iteration Cache</TabsTrigger>
+        <TabsTrigger value="worker-stats">Worker Stats</TabsTrigger>
+      </TabsList>
+      <TabsContent value="iteration-cache">
+        <IterationCacheViewer />
+      </TabsContent>
+      <TabsContent value="worker-stats">
+        <div>hello</div>
+      </TabsContent>
+    </Tabs>
+  );
 };

--- a/src/view/right-sidebar/debug-mode/debug-mode.tsx
+++ b/src/view/right-sidebar/debug-mode/debug-mode.tsx
@@ -1,0 +1,3 @@
+export const DebugMode = () => {
+  return <div>hello</div>;
+};

--- a/src/view/right-sidebar/debug-mode/iteration-cache-viewer.tsx
+++ b/src/view/right-sidebar/debug-mode/iteration-cache-viewer.tsx
@@ -142,35 +142,30 @@ export const IterationCacheViewer = () => {
     const boundsWidth = bounds.maxX - bounds.minX;
     const boundsHeight = bounds.maxY - bounds.minY;
 
-    // アスペクト比を保持した有効描画領域の計算
+    // アスペクト比を保持した動的SVGサイズの計算
     const boundsAspect = boundsWidth / boundsHeight;
-    const minimapAspect = MINIMAP_WIDTH / MINIMAP_HEIGHT;
     
-    let effectiveWidth: number, effectiveHeight: number, offsetX: number, offsetY: number;
+    let effectiveWidth: number, effectiveHeight: number;
     
-    if (boundsAspect > minimapAspect) {
-      // boundsが横長 → 幅を基準にする
+    if (boundsAspect > 1) {
+      // boundsが横長 → 最大幅を基準にする
       effectiveWidth = MINIMAP_WIDTH;
       effectiveHeight = MINIMAP_WIDTH / boundsAspect;
-      offsetX = 0;
-      offsetY = (MINIMAP_HEIGHT - effectiveHeight) / 2;
     } else {
-      // boundsが縦長 → 高さを基準にする
+      // boundsが縦長 → 最大高さを基準にする
       effectiveWidth = MINIMAP_HEIGHT * boundsAspect;
       effectiveHeight = MINIMAP_HEIGHT;
-      offsetX = (MINIMAP_WIDTH - effectiveWidth) / 2;
-      offsetY = 0;
     }
 
-    // 座標をSVG座標系に正規化する関数（アスペクト比保持）
+    // 座標をSVG座標系に正規化する関数（シンプル版）
     const normalizeToSVG = (rect: {
       x: number;
       y: number;
       width: number;
       height: number;
     }) => {
-      const x = ((rect.x - bounds.minX) / boundsWidth) * effectiveWidth + offsetX;
-      const y = ((rect.y - bounds.minY) / boundsHeight) * effectiveHeight + offsetY;
+      const x = ((rect.x - bounds.minX) / boundsWidth) * effectiveWidth;
+      const y = ((rect.y - bounds.minY) / boundsHeight) * effectiveHeight;
       const width = (rect.width / boundsWidth) * effectiveWidth;
       const height = (rect.height / boundsHeight) * effectiveHeight;
       return { x, y, width, height };
@@ -188,8 +183,8 @@ export const IterationCacheViewer = () => {
       <div className="space-y-2">
         <div className="relative">
           <svg
-            width={MINIMAP_WIDTH}
-            height={MINIMAP_HEIGHT}
+            width={effectiveWidth}
+            height={effectiveHeight}
             className="rounded border"
             style={{ backgroundColor: "#f8fafc" }}
           >
@@ -209,28 +204,11 @@ export const IterationCacheViewer = () => {
                 />
               </pattern>
             </defs>
-            {/* 全体の背景（無地） */}
-            <rect width={MINIMAP_WIDTH} height={MINIMAP_HEIGHT} fill="#f8fafc" />
-            
-            {/* 有効領域のみにグリッド背景 */}
+            {/* 背景グリッド */}
             <rect
-              x={offsetX}
-              y={offsetY}
               width={effectiveWidth}
               height={effectiveHeight}
               fill={`url(#grid-${scaleIndex})`}
-            />
-            
-            {/* 有効領域の境界線 */}
-            <rect
-              x={offsetX}
-              y={offsetY}
-              width={effectiveWidth}
-              height={effectiveHeight}
-              fill="none"
-              stroke="#cbd5e1"
-              strokeWidth={1}
-              className="pointer-events-none"
             />
 
             {/* キャッシュrectを描画 */}

--- a/src/view/right-sidebar/debug-mode/iteration-cache-viewer.tsx
+++ b/src/view/right-sidebar/debug-mode/iteration-cache-viewer.tsx
@@ -142,17 +142,37 @@ export const IterationCacheViewer = () => {
     const boundsWidth = bounds.maxX - bounds.minX;
     const boundsHeight = bounds.maxY - bounds.minY;
 
-    // 座標をSVG座標系に正規化する関数（bounds基準）
+    // アスペクト比を保持した有効描画領域の計算
+    const boundsAspect = boundsWidth / boundsHeight;
+    const minimapAspect = MINIMAP_WIDTH / MINIMAP_HEIGHT;
+    
+    let effectiveWidth: number, effectiveHeight: number, offsetX: number, offsetY: number;
+    
+    if (boundsAspect > minimapAspect) {
+      // boundsが横長 → 幅を基準にする
+      effectiveWidth = MINIMAP_WIDTH;
+      effectiveHeight = MINIMAP_WIDTH / boundsAspect;
+      offsetX = 0;
+      offsetY = (MINIMAP_HEIGHT - effectiveHeight) / 2;
+    } else {
+      // boundsが縦長 → 高さを基準にする
+      effectiveWidth = MINIMAP_HEIGHT * boundsAspect;
+      effectiveHeight = MINIMAP_HEIGHT;
+      offsetX = (MINIMAP_WIDTH - effectiveWidth) / 2;
+      offsetY = 0;
+    }
+
+    // 座標をSVG座標系に正規化する関数（アスペクト比保持）
     const normalizeToSVG = (rect: {
       x: number;
       y: number;
       width: number;
       height: number;
     }) => {
-      const x = ((rect.x - bounds.minX) / boundsWidth) * MINIMAP_WIDTH;
-      const y = ((rect.y - bounds.minY) / boundsHeight) * MINIMAP_HEIGHT;
-      const width = (rect.width / boundsWidth) * MINIMAP_WIDTH;
-      const height = (rect.height / boundsHeight) * MINIMAP_HEIGHT;
+      const x = ((rect.x - bounds.minX) / boundsWidth) * effectiveWidth + offsetX;
+      const y = ((rect.y - bounds.minY) / boundsHeight) * effectiveHeight + offsetY;
+      const width = (rect.width / boundsWidth) * effectiveWidth;
+      const height = (rect.height / boundsHeight) * effectiveHeight;
       return { x, y, width, height };
     };
 
@@ -189,10 +209,28 @@ export const IterationCacheViewer = () => {
                 />
               </pattern>
             </defs>
+            {/* 全体の背景（無地） */}
+            <rect width={MINIMAP_WIDTH} height={MINIMAP_HEIGHT} fill="#f8fafc" />
+            
+            {/* 有効領域のみにグリッド背景 */}
             <rect
-              width={MINIMAP_WIDTH}
-              height={MINIMAP_HEIGHT}
+              x={offsetX}
+              y={offsetY}
+              width={effectiveWidth}
+              height={effectiveHeight}
               fill={`url(#grid-${scaleIndex})`}
+            />
+            
+            {/* 有効領域の境界線 */}
+            <rect
+              x={offsetX}
+              y={offsetY}
+              width={effectiveWidth}
+              height={effectiveHeight}
+              fill="none"
+              stroke="#cbd5e1"
+              strokeWidth={1}
+              className="pointer-events-none"
             />
 
             {/* キャッシュrectを描画 */}

--- a/src/view/right-sidebar/debug-mode/iteration-cache-viewer.tsx
+++ b/src/view/right-sidebar/debug-mode/iteration-cache-viewer.tsx
@@ -105,29 +105,36 @@ export const IterationCacheViewer = () => {
 
     // 全キャッシュrectとキャンバスを包含するbounds計算
     const calculateBounds = () => {
-      const allRects = sizeGroups.flatMap(group => group.items.map(item => item.rect));
-      
+      const allRects = sizeGroups.flatMap((group) =>
+        group.items.map((item) => item.rect),
+      );
+
       if (allRects.length === 0) {
-        return { minX: 0, minY: 0, maxX: canvasSize.width, maxY: canvasSize.height };
+        return {
+          minX: 0,
+          minY: 0,
+          maxX: canvasSize.width,
+          maxY: canvasSize.height,
+        };
       }
-      
+
       const minX = Math.min(
-        ...allRects.map(rect => rect.x),
-        0  // キャンバス表示領域を含める
+        ...allRects.map((rect) => rect.x),
+        0, // キャンバス表示領域を含める
       );
       const minY = Math.min(
-        ...allRects.map(rect => rect.y),
-        0  // キャンバス表示領域を含める
+        ...allRects.map((rect) => rect.y),
+        0, // キャンバス表示領域を含める
       );
       const maxX = Math.max(
-        ...allRects.map(rect => rect.x + rect.width),
-        canvasSize.width  // キャンバス表示領域を含める
+        ...allRects.map((rect) => rect.x + rect.width),
+        canvasSize.width, // キャンバス表示領域を含める
       );
       const maxY = Math.max(
-        ...allRects.map(rect => rect.y + rect.height),
-        canvasSize.height  // キャンバス表示領域を含める
+        ...allRects.map((rect) => rect.y + rect.height),
+        canvasSize.height, // キャンバス表示領域を含める
       );
-      
+
       return { minX, minY, maxX, maxY };
     };
 
@@ -148,13 +155,13 @@ export const IterationCacheViewer = () => {
       const height = (rect.height / boundsHeight) * MINIMAP_HEIGHT;
       return { x, y, width, height };
     };
-    
+
     // キャンバス表示領域のSVG座標
     const canvasViewRect = normalizeToSVG({
       x: 0,
       y: 0,
       width: canvasSize.width,
-      height: canvasSize.height
+      height: canvasSize.height,
     });
 
     return (
@@ -212,7 +219,7 @@ export const IterationCacheViewer = () => {
                 );
               });
             })}
-            
+
             {/* キャンバス表示領域（赤枠） */}
             <rect
               x={canvasViewRect.x}
@@ -229,7 +236,7 @@ export const IterationCacheViewer = () => {
 
           {/* ホバー時のツールチップ */}
           {hoveredRect && (
-            <div className="absolute top-0 left-full z-10 ml-2 rounded bg-black px-2 py-1 text-xs text-white shadow-lg">
+            <div className="absolute top-full left-0 z-20 mt-2 rounded bg-black px-3 py-2 text-xs whitespace-nowrap text-white shadow-lg">
               <div>
                 Position: ({hoveredRect.cache.rect.x.toFixed(1)},{" "}
                 {hoveredRect.cache.rect.y.toFixed(1)})
@@ -243,6 +250,8 @@ export const IterationCacheViewer = () => {
                 {hoveredRect.cache.resolution.height}
               </div>
               {hoveredRect.cache.isSuperSampled && <div>Super Sampled</div>}
+              {/* ツールチップの矢印 */}
+              <div className="absolute bottom-full left-4 h-0 w-0 border-r-4 border-b-4 border-l-4 border-transparent border-b-black" />
             </div>
           )}
         </div>
@@ -253,13 +262,13 @@ export const IterationCacheViewer = () => {
           <div className="flex items-center gap-1">
             <div
               className="h-3 w-3 border-2 border-dashed"
-              style={{ borderColor: '#ef4444' }}
+              style={{ borderColor: "#ef4444" }}
             />
             <span className="font-medium text-red-600">
               Canvas View ({canvasSize.width}×{canvasSize.height})
             </span>
           </div>
-          
+
           {/* サイズグループ凡例 */}
           {sizeGroups.map((sizeGroup, sizeIndex) => {
             const color =

--- a/src/view/right-sidebar/debug-mode/iteration-cache-viewer.tsx
+++ b/src/view/right-sidebar/debug-mode/iteration-cache-viewer.tsx
@@ -29,15 +29,17 @@ export const IterationCacheViewer = () => {
     for (const cache of cacheData) {
       const rectSize = { width: cache.rect.width, height: cache.rect.height };
       const resolution = cache.resolution;
-      const scale = (rectSize.width * rectSize.height) / (resolution.width * resolution.height);
+      const scale =
+        (rectSize.width * rectSize.height) /
+        (resolution.width * resolution.height);
       const sizeKey = `${rectSize.width}x${rectSize.height}-${resolution.width}x${resolution.height}`;
-      
+
       if (!scaleGroups.has(scale)) {
         scaleGroups.set(scale, new Map<string, SizeGroup>());
       }
-      
+
       const sizeGroupsForScale = scaleGroups.get(scale)!;
-      
+
       if (!sizeGroupsForScale.has(sizeKey)) {
         sizeGroupsForScale.set(sizeKey, {
           rectSize,
@@ -46,7 +48,7 @@ export const IterationCacheViewer = () => {
           hasSuperSampled: false,
         });
       }
-      
+
       const sizeGroup = sizeGroupsForScale.get(sizeKey)!;
       sizeGroup.items.push(cache);
       if (cache.isSuperSampled) {
@@ -67,11 +69,12 @@ export const IterationCacheViewer = () => {
       .sort((a, b) => b.scale - a.scale); // scaleが大きい順（解像度が荒い順）
   };
 
-
   return (
     <div className="space-y-4 p-4">
       <div className="flex items-center justify-between">
-        <h3 className="text-lg font-semibold">Iteration Cache</h3>
+        <h3 className="text-lg font-semibold">
+          Iteration Cache (count: {cacheData.length})
+        </h3>
         <Button onClick={loadCache} variant="outline" size="sm">
           リロード
         </Button>
@@ -82,10 +85,6 @@ export const IterationCacheViewer = () => {
           const scaleGroups = groupCacheData(cacheData);
           return (
             <>
-              <div className="text-muted-foreground text-sm">
-                Cache Groups ({scaleGroups.length}個のスケールグループ)
-              </div>
-
               {scaleGroups.length === 0 ? (
                 <div className="text-muted-foreground text-sm italic">
                   リロードボタンを押してキャッシュを表示
@@ -97,7 +96,7 @@ export const IterationCacheViewer = () => {
                       <div className="text-base font-semibold">
                         Scale: {scaleGroup.scale.toFixed(2)}
                       </div>
-                      
+
                       <div className="space-y-2 pl-4">
                         {scaleGroup.sizeGroups.map((sizeGroup, sizeIndex) => (
                           <div
@@ -106,7 +105,11 @@ export const IterationCacheViewer = () => {
                           >
                             <div className="flex items-center gap-2">
                               <span className="font-medium">
-                                {sizeGroup.rectSize.width.toFixed(1)}×{sizeGroup.rectSize.height.toFixed(1)} @ {sizeGroup.resolution.width}×{sizeGroup.resolution.height} - {sizeGroup.items.length}個
+                                {sizeGroup.rectSize.width.toFixed(1)}×
+                                {sizeGroup.rectSize.height.toFixed(1)} @{" "}
+                                {sizeGroup.resolution.width}×
+                                {sizeGroup.resolution.height} -{" "}
+                                {sizeGroup.items.length}個
                               </span>
                               {sizeGroup.hasSuperSampled && (
                                 <span className="rounded bg-blue-100 px-2 py-1 text-xs text-blue-800">
@@ -117,8 +120,12 @@ export const IterationCacheViewer = () => {
 
                             <div className="mt-3 space-y-1 pl-4">
                               {sizeGroup.items.map((cache, itemIndex) => (
-                                <div key={itemIndex} className="text-muted-foreground text-xs">
-                                  • ({cache.rect.x.toFixed(1)}, {cache.rect.y.toFixed(1)})
+                                <div
+                                  key={itemIndex}
+                                  className="text-muted-foreground text-xs"
+                                >
+                                  • ({cache.rect.x.toFixed(1)},{" "}
+                                  {cache.rect.y.toFixed(1)})
                                 </div>
                               ))}
                             </div>

--- a/src/view/right-sidebar/debug-mode/iteration-cache-viewer.tsx
+++ b/src/view/right-sidebar/debug-mode/iteration-cache-viewer.tsx
@@ -1,0 +1,92 @@
+import { getIterationCache } from "@/iteration-buffer/iteration-buffer";
+import { Button } from "@/shadcn/components/ui/button";
+import type { IterationBuffer } from "@/types";
+import { useState } from "react";
+
+export const IterationCacheViewer = () => {
+  const [cacheData, setCacheData] = useState<IterationBuffer[]>([]);
+
+  // FIXME: こんなん表示しても意味ないのであとで修正する
+
+  const loadCache = () => {
+    const cache = getIterationCache();
+    setCacheData(cache);
+  };
+
+  const formatBytes = (bytes: number) => {
+    if (bytes === 0) return "0 B";
+    const k = 1024;
+    const sizes = ["B", "KB", "MB", "GB"];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return `${parseFloat((bytes / Math.pow(k, i)).toFixed(2))} ${sizes[i]}`;
+  };
+
+  const formatRect = (rect: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  }) => {
+    return `(${rect.x.toFixed(1)}, ${rect.y.toFixed(1)}) ${rect.width.toFixed(1)}×${rect.height.toFixed(1)}`;
+  };
+
+  return (
+    <div className="space-y-4 p-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-semibold">Iteration Cache</h3>
+        <Button onClick={loadCache} variant="outline" size="sm">
+          リロード
+        </Button>
+      </div>
+
+      <div className="space-y-2">
+        <div className="text-muted-foreground text-sm">
+          キャッシュ数: {cacheData.length}
+        </div>
+
+        {cacheData.length === 0 ? (
+          <div className="text-muted-foreground text-sm italic">
+            リロードボタンを押してキャッシュを表示
+          </div>
+        ) : (
+          <div className="max-h-96 space-y-2 overflow-y-auto">
+            {cacheData.map((cache, index) => (
+              <div
+                key={index}
+                className="space-y-2 rounded-lg border p-3 text-sm"
+              >
+                <div className="flex items-start justify-between">
+                  <div className="font-medium">Cache #{index + 1}</div>
+                  {cache.isSuperSampled && (
+                    <span className="rounded bg-blue-100 px-2 py-1 text-xs text-blue-800">
+                      Super Sampled
+                    </span>
+                  )}
+                </div>
+
+                <div className="text-muted-foreground grid grid-cols-1 gap-1 text-xs">
+                  <div>
+                    <span className="font-medium">位置:</span>{" "}
+                    {formatRect(cache.rect)}
+                  </div>
+                  <div>
+                    <span className="font-medium">解像度:</span>{" "}
+                    {cache.resolution.width}×{cache.resolution.height}
+                  </div>
+                  <div>
+                    <span className="font-medium">バッファサイズ:</span>{" "}
+                    {formatBytes(cache.buffer.byteLength)}
+                  </div>
+                  <div>
+                    <span className="font-medium">ピクセル数:</span>{" "}
+                    {cache.buffer.length.toLocaleString()}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/view/right-sidebar/debug-mode/iteration-cache-viewer.tsx
+++ b/src/view/right-sidebar/debug-mode/iteration-cache-viewer.tsx
@@ -1,6 +1,5 @@
-import { getIterationCache } from "@/iteration-buffer/iteration-buffer";
+import { useIterationCache } from "@/iteration-buffer/use-iteration-cache";
 import { getCanvasSize } from "@/rendering/renderer";
-import { Button } from "@/shadcn/components/ui/button";
 import type { IterationBuffer } from "@/types";
 import { useState } from "react";
 
@@ -33,11 +32,7 @@ const SIZE_GROUP_COLORS = [
 ];
 
 export const IterationCacheViewer = () => {
-  const [cacheData, setCacheData] = useState<IterationBuffer[]>([]);
-  const loadCache = () => {
-    const cache = getIterationCache();
-    setCacheData(cache);
-  };
+  const cacheData = useIterationCache();
 
   const groupCacheData = (cacheData: IterationBuffer[]): ScaleGroup[] => {
     // 1段階目: scaleでグループ化
@@ -313,9 +308,6 @@ export const IterationCacheViewer = () => {
         <h3 className="text-lg font-semibold">
           Iteration Cache (count: {cacheData.length})
         </h3>
-        <Button onClick={loadCache} variant="outline" size="sm">
-          リロード
-        </Button>
       </div>
 
       <div className="space-y-4">
@@ -325,7 +317,7 @@ export const IterationCacheViewer = () => {
             <>
               {scaleGroups.length === 0 ? (
                 <div className="text-muted-foreground text-sm italic">
-                  リロードボタンを押してキャッシュを表示
+                  キャッシュデータはありません
                 </div>
               ) : (
                 <div className="space-y-4">

--- a/src/view/right-sidebar/debug-mode/iteration-cache-viewer.tsx
+++ b/src/view/right-sidebar/debug-mode/iteration-cache-viewer.tsx
@@ -42,9 +42,7 @@ export const IterationCacheViewer = () => {
     for (const cache of cacheData) {
       const rectSize = { width: cache.rect.width, height: cache.rect.height };
       const resolution = cache.resolution;
-      const scale =
-        (rectSize.width * rectSize.height) /
-        (resolution.width * resolution.height);
+      const scale = rectSize.width / resolution.width;
       const sizeKey = `${rectSize.width}x${rectSize.height}-${resolution.width}x${resolution.height}`;
 
       if (!scaleGroups.has(scale)) {

--- a/src/view/right-sidebar/debug-mode/iteration-cache-viewer.tsx
+++ b/src/view/right-sidebar/debug-mode/iteration-cache-viewer.tsx
@@ -49,7 +49,7 @@ export const IterationCacheViewer = () => {
             リロードボタンを押してキャッシュを表示
           </div>
         ) : (
-          <div className="max-h-96 space-y-2 overflow-y-auto">
+          <div className="space-y-2">
             {cacheData.map((cache, index) => (
               <div
                 key={index}

--- a/src/view/right-sidebar/debug-mode/iteration-cache-viewer.tsx
+++ b/src/view/right-sidebar/debug-mode/iteration-cache-viewer.tsx
@@ -33,6 +33,7 @@ const SIZE_GROUP_COLORS = [
 
 export const IterationCacheViewer = () => {
   const cacheData = useIterationCache();
+  const [detailVisibilityMap, setDetailVisibilityMap] = useState<Record<string, boolean>>({});
 
   const groupCacheData = (cacheData: IterationBuffer[]): ScaleGroup[] => {
     // 1段階目: scaleでグループ化
@@ -334,50 +335,65 @@ export const IterationCacheViewer = () => {
                           scaleIndex={scaleIndex}
                         />
 
-                        {/* 詳細リスト */}
-                        {scaleGroup.sizeGroups.map((sizeGroup, sizeIndex) => (
-                          <div
-                            key={sizeIndex}
-                            className="rounded-lg border p-3 text-sm"
-                          >
-                            <div className="flex items-center gap-2">
-                              <div
-                                className="h-3 w-3 border"
-                                style={{
-                                  backgroundColor:
-                                    SIZE_GROUP_COLORS[
-                                      sizeIndex % SIZE_GROUP_COLORS.length
-                                    ],
-                                  opacity: 0.6,
-                                }}
-                              />
-                              <span className="font-medium">
-                                {sizeGroup.rectSize.width.toFixed(1)}×
-                                {sizeGroup.rectSize.height.toFixed(1)} @{" "}
-                                {sizeGroup.resolution.width}×
-                                {sizeGroup.resolution.height} -{" "}
-                                {sizeGroup.items.length}個
-                              </span>
-                              {sizeGroup.hasSuperSampled && (
-                                <span className="rounded bg-blue-100 px-2 py-1 text-xs text-blue-800">
-                                  Super Sampled
+                        {/* サイズ情報リスト（常に表示） */}
+                        {scaleGroup.sizeGroups.map((sizeGroup, sizeIndex) => {
+                          const detailKey = `${scaleIndex}-${sizeIndex}`;
+                          return (
+                            <div
+                              key={sizeIndex}
+                              className="rounded-lg border p-3 text-sm"
+                            >
+                              <button
+                                onClick={() => setDetailVisibilityMap(prev => ({
+                                  ...prev,
+                                  [detailKey]: !prev[detailKey]
+                                }))}
+                                className="flex w-full items-center gap-2 text-left"
+                              >
+                                <span className="text-xs text-blue-600">
+                                  {detailVisibilityMap[detailKey] ? "▼" : "▶"}
                                 </span>
+                                <div
+                                  className="h-3 w-3 border"
+                                  style={{
+                                    backgroundColor:
+                                      SIZE_GROUP_COLORS[
+                                        sizeIndex % SIZE_GROUP_COLORS.length
+                                      ],
+                                    opacity: 0.6,
+                                  }}
+                                />
+                                <span className="font-medium">
+                                  {sizeGroup.rectSize.width.toFixed(1)}×
+                                  {sizeGroup.rectSize.height.toFixed(1)} @{" "}
+                                  {sizeGroup.resolution.width}×
+                                  {sizeGroup.resolution.height} -{" "}
+                                  {sizeGroup.items.length}個
+                                </span>
+                                {sizeGroup.hasSuperSampled && (
+                                  <span className="rounded bg-blue-100 px-2 py-1 text-xs text-blue-800">
+                                    Super Sampled
+                                  </span>
+                                )}
+                              </button>
+
+                              {/* 座標リスト */}
+                              {detailVisibilityMap[detailKey] && (
+                                <div className="mt-3 space-y-1 pl-4">
+                                  {sizeGroup.items.map((cache, itemIndex) => (
+                                    <div
+                                      key={itemIndex}
+                                      className="text-muted-foreground text-xs"
+                                    >
+                                      • ({cache.rect.x.toFixed(1)},{" "}
+                                      {cache.rect.y.toFixed(1)})
+                                    </div>
+                                  ))}
+                                </div>
                               )}
                             </div>
-
-                            <div className="mt-3 space-y-1 pl-4">
-                              {sizeGroup.items.map((cache, itemIndex) => (
-                                <div
-                                  key={itemIndex}
-                                  className="text-muted-foreground text-xs"
-                                >
-                                  • ({cache.rect.x.toFixed(1)},{" "}
-                                  {cache.rect.y.toFixed(1)})
-                                </div>
-                              ))}
-                            </div>
-                          </div>
-                        ))}
+                          );
+                        })}
                       </div>
                     </div>
                   ))}

--- a/src/view/right-sidebar/debug-mode/iteration-cache-viewer.tsx
+++ b/src/view/right-sidebar/debug-mode/iteration-cache-viewer.tsx
@@ -3,32 +3,70 @@ import { Button } from "@/shadcn/components/ui/button";
 import type { IterationBuffer } from "@/types";
 import { useState } from "react";
 
+interface SizeGroup {
+  rectSize: { width: number; height: number };
+  resolution: { width: number; height: number };
+  items: IterationBuffer[];
+  hasSuperSampled: boolean;
+}
+
+interface ScaleGroup {
+  scale: number;
+  sizeGroups: SizeGroup[];
+}
+
 export const IterationCacheViewer = () => {
   const [cacheData, setCacheData] = useState<IterationBuffer[]>([]);
-
-  // FIXME: こんなん表示しても意味ないのであとで修正する
-
   const loadCache = () => {
     const cache = getIterationCache();
     setCacheData(cache);
   };
 
-  const formatBytes = (bytes: number) => {
-    if (bytes === 0) return "0 B";
-    const k = 1024;
-    const sizes = ["B", "KB", "MB", "GB"];
-    const i = Math.floor(Math.log(bytes) / Math.log(k));
-    return `${parseFloat((bytes / Math.pow(k, i)).toFixed(2))} ${sizes[i]}`;
+  const groupCacheData = (cacheData: IterationBuffer[]): ScaleGroup[] => {
+    // 1段階目: scaleでグループ化
+    const scaleGroups = new Map<number, Map<string, SizeGroup>>();
+
+    for (const cache of cacheData) {
+      const rectSize = { width: cache.rect.width, height: cache.rect.height };
+      const resolution = cache.resolution;
+      const scale = (rectSize.width * rectSize.height) / (resolution.width * resolution.height);
+      const sizeKey = `${rectSize.width}x${rectSize.height}-${resolution.width}x${resolution.height}`;
+      
+      if (!scaleGroups.has(scale)) {
+        scaleGroups.set(scale, new Map<string, SizeGroup>());
+      }
+      
+      const sizeGroupsForScale = scaleGroups.get(scale)!;
+      
+      if (!sizeGroupsForScale.has(sizeKey)) {
+        sizeGroupsForScale.set(sizeKey, {
+          rectSize,
+          resolution,
+          items: [],
+          hasSuperSampled: false,
+        });
+      }
+      
+      const sizeGroup = sizeGroupsForScale.get(sizeKey)!;
+      sizeGroup.items.push(cache);
+      if (cache.isSuperSampled) {
+        sizeGroup.hasSuperSampled = true;
+      }
+    }
+
+    // 結果をScaleGroup[]に変換してソート
+    return Array.from(scaleGroups.entries())
+      .map(([scale, sizeGroupsMap]) => ({
+        scale,
+        sizeGroups: Array.from(sizeGroupsMap.values()).sort((a, b) => {
+          const aRectArea = a.rectSize.width * a.rectSize.height;
+          const bRectArea = b.rectSize.width * b.rectSize.height;
+          return bRectArea - aRectArea; // rectサイズが大きい順
+        }),
+      }))
+      .sort((a, b) => b.scale - a.scale); // scaleが大きい順（解像度が荒い順）
   };
 
-  const formatRect = (rect: {
-    x: number;
-    y: number;
-    width: number;
-    height: number;
-  }) => {
-    return `(${rect.x.toFixed(1)}, ${rect.y.toFixed(1)}) ${rect.width.toFixed(1)}×${rect.height.toFixed(1)}`;
-  };
 
   return (
     <div className="space-y-4 p-4">
@@ -39,53 +77,61 @@ export const IterationCacheViewer = () => {
         </Button>
       </div>
 
-      <div className="space-y-2">
-        <div className="text-muted-foreground text-sm">
-          キャッシュ数: {cacheData.length}
-        </div>
-
-        {cacheData.length === 0 ? (
-          <div className="text-muted-foreground text-sm italic">
-            リロードボタンを押してキャッシュを表示
-          </div>
-        ) : (
-          <div className="space-y-2">
-            {cacheData.map((cache, index) => (
-              <div
-                key={index}
-                className="space-y-2 rounded-lg border p-3 text-sm"
-              >
-                <div className="flex items-start justify-between">
-                  <div className="font-medium">Cache #{index + 1}</div>
-                  {cache.isSuperSampled && (
-                    <span className="rounded bg-blue-100 px-2 py-1 text-xs text-blue-800">
-                      Super Sampled
-                    </span>
-                  )}
-                </div>
-
-                <div className="text-muted-foreground grid grid-cols-1 gap-1 text-xs">
-                  <div>
-                    <span className="font-medium">位置:</span>{" "}
-                    {formatRect(cache.rect)}
-                  </div>
-                  <div>
-                    <span className="font-medium">解像度:</span>{" "}
-                    {cache.resolution.width}×{cache.resolution.height}
-                  </div>
-                  <div>
-                    <span className="font-medium">バッファサイズ:</span>{" "}
-                    {formatBytes(cache.buffer.byteLength)}
-                  </div>
-                  <div>
-                    <span className="font-medium">ピクセル数:</span>{" "}
-                    {cache.buffer.length.toLocaleString()}
-                  </div>
-                </div>
+      <div className="space-y-4">
+        {(() => {
+          const scaleGroups = groupCacheData(cacheData);
+          return (
+            <>
+              <div className="text-muted-foreground text-sm">
+                Cache Groups ({scaleGroups.length}個のスケールグループ)
               </div>
-            ))}
-          </div>
-        )}
+
+              {scaleGroups.length === 0 ? (
+                <div className="text-muted-foreground text-sm italic">
+                  リロードボタンを押してキャッシュを表示
+                </div>
+              ) : (
+                <div className="space-y-4">
+                  {scaleGroups.map((scaleGroup, scaleIndex) => (
+                    <div key={scaleIndex} className="space-y-2">
+                      <div className="text-base font-semibold">
+                        Scale: {scaleGroup.scale.toFixed(2)}
+                      </div>
+                      
+                      <div className="space-y-2 pl-4">
+                        {scaleGroup.sizeGroups.map((sizeGroup, sizeIndex) => (
+                          <div
+                            key={sizeIndex}
+                            className="rounded-lg border p-3 text-sm"
+                          >
+                            <div className="flex items-center gap-2">
+                              <span className="font-medium">
+                                {sizeGroup.rectSize.width.toFixed(1)}×{sizeGroup.rectSize.height.toFixed(1)} @ {sizeGroup.resolution.width}×{sizeGroup.resolution.height} - {sizeGroup.items.length}個
+                              </span>
+                              {sizeGroup.hasSuperSampled && (
+                                <span className="rounded bg-blue-100 px-2 py-1 text-xs text-blue-800">
+                                  Super Sampled
+                                </span>
+                              )}
+                            </div>
+
+                            <div className="mt-3 space-y-1 pl-4">
+                              {sizeGroup.items.map((cache, itemIndex) => (
+                                <div key={itemIndex} className="text-muted-foreground text-xs">
+                                  • ({cache.rect.x.toFixed(1)}, {cache.rect.y.toFixed(1)})
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </>
+          );
+        })()}
       </div>
     </div>
   );

--- a/src/view/right-sidebar/index.tsx
+++ b/src/view/right-sidebar/index.tsx
@@ -1,15 +1,25 @@
+import { useStoreValue } from "@/store/store";
+import { DebugMode } from "./debug-mode/debug-mode";
 import { Informations } from "./informations";
 import { Operations } from "./operations";
 import { Parameters } from "./parameters";
 import { POIHistories } from "./poi-histories";
 
 export const RightSidebar = () => {
+  const isDebugMode = useStoreValue("isDebugMode");
+
   return (
     <div className="flex h-full flex-col gap-2">
-      <Parameters />
-      <Informations />
-      <Operations />
-      <POIHistories />
+      {isDebugMode ? (
+        <DebugMode />
+      ) : (
+        <>
+          <Parameters />
+          <Informations />
+          <Operations />
+          <POIHistories />
+        </>
+      )}
     </div>
   );
 };

--- a/src/worker-pool/callbacks/iteration-worker.ts
+++ b/src/worker-pool/callbacks/iteration-worker.ts
@@ -1,7 +1,7 @@
 import {
   getIterationCache,
-  upsertIterationCache,
   notifyIterationCacheUpdate,
+  upsertIterationCache,
 } from "@/iteration-buffer/iteration-buffer";
 import { addIterationBuffer } from "@/rendering/renderer";
 import { CalcIterationJob, IterationIntermediateResult } from "@/types";
@@ -106,7 +106,4 @@ export const onIterationWorkerIntermediateResult = (
     resolution,
   );
   addIterationBuffer(rect, [iterBuffer]);
-
-  // UIに変更を通知
-  notifyIterationCacheUpdate();
 };

--- a/src/worker-pool/callbacks/iteration-worker.ts
+++ b/src/worker-pool/callbacks/iteration-worker.ts
@@ -1,6 +1,7 @@
 import {
   getIterationCache,
   upsertIterationCache,
+  notifyIterationCacheUpdate,
 } from "@/iteration-buffer/iteration-buffer";
 import { addIterationBuffer } from "@/rendering/renderer";
 import { CalcIterationJob, IterationIntermediateResult } from "@/types";
@@ -68,6 +69,9 @@ export const onIterationWorkerResult: IterationResultCallback = (
 
   addIterationBuffer(rect, [iterBuffer]);
 
+  // UIに変更を通知
+  notifyIterationCacheUpdate();
+
   // バッチ全体が完了していたらonComplete callbackを呼ぶ
   if (isBatchCompleted(job.batchId)) {
     const finishedAt = performance.now();
@@ -102,4 +106,7 @@ export const onIterationWorkerIntermediateResult = (
     resolution,
   );
   addIterationBuffer(rect, [iterBuffer]);
+
+  // UIに変更を通知
+  notifyIterationCacheUpdate();
 };


### PR DESCRIPTION
## Summary
worker別に計算したiterationを持っておくiterationCacheのデバッグ情報を表示するビューを作成した
canvasで実装する必要があると思っていたが、SVGでやれば？というアイデアと実際の実装はclaude codeが一瞬でやってくれた。神

## スクリーンショット
[![Image from Gyazo](https://i.gyazo.com/ac1f01016574de55bc6db60b15301c68.png)](https://gyazo.com/ac1f01016574de55bc6db60b15301c68)

## 効果
たまに描画がおかしくなることがあって原因が全然わかってなかったが、
その部分のiterationCacheがぽっかり抜けているというのが視覚的に分かってよかった
あとズームはともかく移動時は重複だったりかなり無駄な持ち方するので、どっかのタイミングで統合するのをやらなきゃなという気持ちになっている