### PR TITLE
workerPoolのtickが過剰だったのを修正

### DIFF
--- a/src/worker-pool/pool-instance.ts
+++ b/src/worker-pool/pool-instance.ts
@@ -16,7 +16,11 @@ import {
   MandelbrotFacadeLike,
   RefOrbitWorker,
 } from "./worker-facade";
-import { clearBatchContext, tickWorkerPool } from "./worker-pool";
+import {
+  clearBatchContext,
+  tickWorkerPool,
+  tickWorkerPoolThrottled,
+} from "./worker-pool";
 import { clearWorkerReference } from "./worker-reference";
 
 type WorkerPool = MandelbrotFacadeLike[];
@@ -152,7 +156,8 @@ function fillIterationWorkerPool(
 
     workerFacade.onResult((...args) => {
       onIterationWorkerResult(...args);
-      tickWorkerPool();
+      // iterationWorkerの完了は殺到する可能性があるのでthrottledの方を呼ぶ
+      tickWorkerPoolThrottled();
     });
     workerFacade.onIntermediateResult(onIterationWorkerIntermediateResult);
     workerFacade.onProgress(onIterationWorkerProgress);

--- a/src/worker-pool/worker-pool.ts
+++ b/src/worker-pool/worker-pool.ts
@@ -192,11 +192,17 @@ export function registerBatch(
 export function tickWorkerPool() {
   let jobStarted = false;
   const refPool = getWorkerPool("calc-ref-orbit");
+  const waitingRefJobs = getWaitingJobs("calc-ref-orbit");
+  const waitingIterJobs = getWaitingJobs("calc-iteration");
+
   if (
-    (refPool.length > 0 && findFreeWorkerIndex("calc-ref-orbit") === -1) ||
-    findFreeWorkerIndex("calc-iteration") === -1
+    (refPool.length > 0 &&
+      waitingRefJobs.length !== 0 &&
+      findFreeWorkerIndex("calc-ref-orbit") === -1) ||
+    (waitingIterJobs.length !== 0 &&
+      findFreeWorkerIndex("calc-iteration") === -1)
   ) {
-    // まだ準備ができていないworkerがいる場合は待つ
+    // 処理すべきjobが残っていて、まだ準備ができていないworkerがいる場合は100ms待つ
     setTimeout(tickWorkerPool, 100);
     return;
   }

--- a/src/worker-pool/worker-pool.ts
+++ b/src/worker-pool/worker-pool.ts
@@ -15,6 +15,7 @@ import {
   ResultSpans,
   mandelbrotWorkerTypes,
 } from "@/types";
+import { throttle } from "es-toolkit";
 import {
   calcNormalizedWorkerIndex,
   findFreeWorkerIndex,
@@ -256,6 +257,7 @@ export function tickWorkerPool() {
     });
   }
 }
+export const tickWorkerPoolThrottled = throttle(tickWorkerPool, 100);
 
 /**
  * 指定したworkerを使ってjobを開始する


### PR DESCRIPTION
## Summary
今までは空いてるworkerがないかどうかしか見ていなかった
その結果もう処理待ちのjobがないのに100ms待って再tick、とかしてたので無駄だったので修正

あとはworker完了後にtickする処理が入ってたが、workerが32個いるときに32回tickされていたのでthrottleするようにした
