### PR TITLE
右上のパラメータ表示UIを削除してcanvas内に情報表示

### DIFF
--- a/src/p5-adapter/p5-adapter.ts
+++ b/src/p5-adapter/p5-adapter.ts
@@ -33,7 +33,7 @@ import {
   setWebGPUInitialized,
   setWebGPUInitializing,
 } from "@/rendering/common";
-import { drawCrossHair, drawScaleRate } from "@/rendering/p5-renderer";
+import { drawUICrossHair, drawUIScaleRate } from "@/rendering/p5-renderer";
 import {
   getCanvasSize,
   initRenderer,
@@ -576,10 +576,10 @@ export const p5Draw = (p: p5) => {
 
   switch (draggingMode) {
     case "move":
-      drawCrossHair(p);
+      drawUICrossHair(p);
       break;
     case "zoom":
-      drawScaleRate(p, scaleFactor);
+      drawUIScaleRate(p, scaleFactor);
       break;
   }
 

--- a/src/p5-adapter/p5-adapter.ts
+++ b/src/p5-adapter/p5-adapter.ts
@@ -33,7 +33,11 @@ import {
   setWebGPUInitialized,
   setWebGPUInitializing,
 } from "@/rendering/common";
-import { drawUICrossHair, drawUIScaleRate } from "@/rendering/p5-renderer";
+import {
+  drawUICrossHair,
+  drawUICurrentParams,
+  drawUIScaleRate,
+} from "@/rendering/p5-renderer";
 import {
   getCanvasSize,
   initRenderer,
@@ -584,6 +588,8 @@ export const p5Draw = (p: p5) => {
   }
 
   syncStoreValues(p);
+
+  drawUICurrentParams(p, getCurrentParams());
 
   if (shouldSavePOIHistoryNextRender) {
     shouldSavePOIHistoryNextRender = false;

--- a/src/rendering/p5-renderer.ts
+++ b/src/rendering/p5-renderer.ts
@@ -187,6 +187,7 @@ export const drawUIScaleRate = (p: p5, scaleFactor: number) => {
 };
 
 export const drawUICurrentParams = (p: p5, params: MandelbrotParams) => {
+  p.textAlign(p.LEFT, p.BASELINE);
   p.fill(255);
   p.stroke(0);
   p.strokeWeight(3);
@@ -195,12 +196,14 @@ export const drawUICurrentParams = (p: p5, params: MandelbrotParams) => {
   p.text(`r: ${params.r.toPrecision(10)}\nN: ${params.N}`, 4, 14);
 
   const isNotEnoughPrecision =
-    params.mode === "normal" && params.r.isLessThan(1e-13);
+    params.mode === "normal" && params.r.isLessThan(3.5e-14);
   if (isNotEnoughPrecision) {
+    p.textSize(16);
+    p.textAlign(p.CENTER, p.CENTER);
     p.text(
       `Not enough precision.\nSwitch to perturbation mode by [m] key!`,
-      4,
-      p.height - 25,
+      p.width / 2,
+      p.height / 2,
     );
   }
 };

--- a/src/rendering/p5-renderer.ts
+++ b/src/rendering/p5-renderer.ts
@@ -148,7 +148,7 @@ export const resizeCanvas: Renderer["resizeCanvas"] = (
 /**
  * ドラッグ中のクロスヘア描画
  */
-export const drawCrossHair = (p: p5) => {
+export const drawUICrossHair = (p: p5) => {
   const length = 10;
 
   const centerX = Math.floor(p.width / 2);
@@ -172,7 +172,7 @@ export const drawCrossHair = (p: p5) => {
  *
  * interactive zoom中に表示する
  */
-export const drawScaleRate = (p: p5, scaleFactor: number) => {
+export const drawUIScaleRate = (p: p5, scaleFactor: number) => {
   p.fill(255);
   p.stroke(0);
   p.strokeWeight(4);

--- a/src/rendering/p5-renderer.ts
+++ b/src/rendering/p5-renderer.ts
@@ -193,6 +193,16 @@ export const drawUICurrentParams = (p: p5, params: MandelbrotParams) => {
   p.textSize(14);
 
   p.text(`r: ${params.r.toPrecision(10)}\nN: ${params.N}`, 4, 14);
+
+  const isNotEnoughPrecision =
+    params.mode === "normal" && params.r.isLessThan(1e-13);
+  if (isNotEnoughPrecision) {
+    p.text(
+      `Not enough precision.\nSwitch to perturbation mode by [m] key!`,
+      4,
+      p.height - 25,
+    );
+  }
 };
 
 /**

--- a/src/rendering/p5-renderer.ts
+++ b/src/rendering/p5-renderer.ts
@@ -16,7 +16,7 @@ import { clamp } from "@/math/util";
 import { getStore } from "@/store/store";
 import p5 from "p5";
 import { Rect } from "../math/rect";
-import { IterationBuffer } from "../types";
+import { IterationBuffer, type MandelbrotParams } from "../types";
 import type { Renderer } from "./renderer";
 
 export interface Resolution {
@@ -184,6 +184,15 @@ export const drawUIScaleRate = (p: p5, scaleFactor: number) => {
   const y = clamp(p.mouseY, 0, p.height - 25);
 
   p.text(`${text}`, x + 10, y + 20);
+};
+
+export const drawUICurrentParams = (p: p5, params: MandelbrotParams) => {
+  p.fill(255);
+  p.stroke(0);
+  p.strokeWeight(3);
+  p.textSize(14);
+
+  p.text(`r: ${params.r.toPrecision(10)}\nN: ${params.N}`, 4, 14);
 };
 
 /**

--- a/src/view/right-sidebar/index.tsx
+++ b/src/view/right-sidebar/index.tsx
@@ -2,7 +2,6 @@ import { useStoreValue } from "@/store/store";
 import { DebugMode } from "./debug-mode/debug-mode";
 import { Informations } from "./informations";
 import { Operations } from "./operations";
-import { Parameters } from "./parameters";
 import { POIHistories } from "./poi-histories";
 
 export const RightSidebar = () => {
@@ -14,7 +13,7 @@ export const RightSidebar = () => {
         <DebugMode />
       ) : (
         <>
-          <Parameters />
+          {/* <Parameters /> */}
           <Informations />
           <Operations />
           <POIHistories />


### PR DESCRIPTION
## Summary
縦幅を取る割にあんまり重要な情報を表示していなかったので取り去った

N, rは現在どのへんか知りたいのでcanvasへ
邪魔じゃないように小さく表示しているが、表示・非表示を切り替えられるようにしてもうちょっと良い感じの表示にする

mouseXYは不要
centerXYは共有時には欲しい気がするが、現状ではとりあえず不要。
mandelbrot setのどの辺にいるか、みたいなのはミニマップ的なのを実装したいかも

iteration at cursorはバグっていたので削除
ctrl押している間のみcanvas内に表示、というような実装で復活するかも

## スクリーンショット
[![Image from Gyazo](https://i.gyazo.com/5ff121cb042dc1d48b755be07132f474.png)](https://gyazo.com/5ff121cb042dc1d48b755be07132f474)