### PR TITLE
小さい拡大率で繰り返し拡縮するとiterationCacheが溜まりまくってしまう問題を修正

### DIFF
--- a/src/iteration-buffer/iteration-buffer.ts
+++ b/src/iteration-buffer/iteration-buffer.ts
@@ -80,6 +80,8 @@ export const notifyIterationCacheUpdate = debounce(() => {
 
 /**
  * 以下の条件でもはや描画に使用できないiterationキャッシュを削除する
+ *
+ * 0. 現状存在する最も解像度が高いcache以外
  * 1. 完全に画面外にいる
  * 2. 小さすぎて描画に使えない
  * 3. でかすぎて描画に使えるピクセルが少ない
@@ -97,6 +99,16 @@ export const removeUnusedIterationCache = (): void => {
   );
 
   const beforeCount = iterationCache.length;
+
+  // 現状存在する最大解像度以外のcacheは消す
+  const maxRes = iterationCache.reduce((prev, iterCache) => {
+    const res = iterCache.resolution.width / iterCache.rect.width;
+    return res > prev ? res : prev;
+  }, Number.MIN_VALUE);
+  iterationCache = iterationCache.filter((iterCache) => {
+    const res = iterCache.resolution.width / iterCache.rect.width;
+    return Math.abs(res - maxRes) < Number.EPSILON;
+  });
 
   iterationCache = iterationCache.filter((iterCache) => {
     const { x, y, width, height } = iterCache.rect;


### PR DESCRIPTION
## Summary
removeUnusedIterationCacheで消す条件が甘かったので、
x1.2とかで拡縮を繰り返しているとめっちゃiterationCacheが溜まっていた
そしてWebGPUでは(手抜きで)解像度違いのcacheの描画を1フレーム遅らせる処理が入っている
これが合わさって描画がぶっ壊れていた

そもそも基本的に最大解像度のものだけあれば良いので、最大解像度以外のcacheは消すようにした
おそらく描画途中で次に行ったりしたときがカバーし切れないが、おおむねこれで問題ないはず
ちゃんと領域をカバーしているかどうかのチェックは意外と大変っぽいので早々に諦めた