### PR TITLE
スーパーサンプリングを別ビューで実装し直して復活

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ rust_client/target/*
 
 # Claude agent files
 CLAUDE.md
+tmp

--- a/index.html
+++ b/index.html
@@ -32,5 +32,6 @@
       <div id="sidebar-right"></div>
       <div id="footer"></div>
     </div>
+    <div id="supersampling-overlay"></div>
   </body>
 </html>

--- a/src/iteration-buffer/iteration-buffer.ts
+++ b/src/iteration-buffer/iteration-buffer.ts
@@ -22,6 +22,9 @@ export const upsertIterationCache = (
 
   const idx = iterationCache.findIndex((i) => i.rect.x === rect.x && i.rect.y === rect.y);
 
+  // supersampledな場合は別経路の描画なのでiterationCacheには積まない
+  if (isSuperSampled) return item
+  
   if (idx !== -1) {
     const old = iterationCache[idx];
     if (old.resolution.width * old.resolution.height < resolution.width * resolution.height) {

--- a/src/iteration-buffer/iteration-buffer.ts
+++ b/src/iteration-buffer/iteration-buffer.ts
@@ -23,8 +23,8 @@ export const upsertIterationCache = (
   const idx = iterationCache.findIndex((i) => i.rect.x === rect.x && i.rect.y === rect.y);
 
   // supersampledな場合は別経路の描画なのでiterationCacheには積まない
-  if (isSuperSampled) return item
-  
+  if (isSuperSampled) return item;
+
   if (idx !== -1) {
     const old = iterationCache[idx];
     if (old.resolution.width * old.resolution.height < resolution.width * resolution.height) {

--- a/src/mandelbrot-state/mandelbrot-state.ts
+++ b/src/mandelbrot-state/mandelbrot-state.ts
@@ -64,12 +64,7 @@ export const setCurrentParams = (params: Partial<MandelbrotParams>) => {
   const needModeChange = params.mode != null && currentParams.mode !== params.mode;
   const needResetOffset = params.r != null && !currentParams.r.eq(params.r);
 
-  if (params.isSuperSampling) {
-    currentParams = { ...currentParams, ...params, isSuperSampling: true };
-  } else {
-    // supersamplingは1バッチ間でのみ有効
-    currentParams = { ...currentParams, ...params, isSuperSampling: false };
-  }
+  currentParams = { ...currentParams, ...params };
 
   updateStore("r", currentParams.r);
   updateStore("N", currentParams.N);

--- a/src/mandelbrot-state/mandelbrot-state.ts
+++ b/src/mandelbrot-state/mandelbrot-state.ts
@@ -1,4 +1,3 @@
-import { getRenderer } from "@/rendering/common";
 import { getCanvasSize } from "@/rendering/renderer";
 import { getStore, updateStore, updateStoreWith } from "@/store/store";
 import type { MandelbrotParams, OffsetParams } from "@/types";
@@ -65,11 +64,10 @@ export const setCurrentParams = (params: Partial<MandelbrotParams>) => {
   const needModeChange = params.mode != null && currentParams.mode !== params.mode;
   const needResetOffset = params.r != null && !currentParams.r.eq(params.r);
 
-  // TEMP: supersamplingはp5jsでの描画のみ有効
-  if (params.isSuperSampling && getRenderer() === "p5js") {
+  if (params.isSuperSampling) {
     currentParams = { ...currentParams, ...params, isSuperSampling: true };
   } else {
-    // supersamplingは次の描画で解除される
+    // supersamplingは1バッチ間でのみ有効
     currentParams = { ...currentParams, ...params, isSuperSampling: false };
   }
 

--- a/src/mandelbrot-state/mandelbrot-state.ts
+++ b/src/mandelbrot-state/mandelbrot-state.ts
@@ -1,3 +1,4 @@
+import { getRenderer } from "@/rendering/common";
 import { getCanvasSize } from "@/rendering/renderer";
 import { getStore, updateStore, updateStoreWith } from "@/store/store";
 import type { MandelbrotParams, OffsetParams } from "@/types";
@@ -64,11 +65,11 @@ export const setCurrentParams = (params: Partial<MandelbrotParams>) => {
   const needModeChange = params.mode != null && currentParams.mode !== params.mode;
   const needResetOffset = params.r != null && !currentParams.r.eq(params.r);
 
-  if (!params.isSuperSampling) {
-    // supersamplingは次の描画で解除される
-    currentParams = { ...currentParams, ...params, isSuperSampling: false };
+  // TEMP: supersamplingはp5jsでの描画のみ有効
+  if (params.isSuperSampling && getRenderer() === "p5js") {
+    currentParams = { ...currentParams, ...params, isSuperSampling: true };
   } else {
-    // FIXME: 一時的にsupersamplingは無効にしている
+    // supersamplingは次の描画で解除される
     currentParams = { ...currentParams, ...params, isSuperSampling: false };
   }
 

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -36,6 +36,16 @@ export const startCalculation = async (
   cancelBatch(getPrevBatchId());
   setPrevBatchId(currentBatchId);
 
+  const { isSuperSampling } = getCurrentParams()
+  if (isSuperSampling) {
+    // supersampling用のcanvasを用意
+    const canvas = document.getElementById("supersampling-canvas")
+    if (canvas) {
+      canvas.style.width = "1000px"
+      canvas.style.height = "1000px"
+    }
+  }
+
   const { width: canvasWidth, height: canvasHeight } = getCanvasSize();
 
   const rect = translateIterationCache(canvasWidth, canvasHeight, getOffsetParams());

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -36,13 +36,15 @@ export const startCalculation = async (
   cancelBatch(getPrevBatchId());
   setPrevBatchId(currentBatchId);
 
-  const { isSuperSampling } = getCurrentParams()
+  const { isSuperSampling } = getCurrentParams();
   if (isSuperSampling) {
     // supersampling用のcanvasを用意
-    const canvas = document.getElementById("supersampling-canvas")
+    const canvas = document.getElementById("supersampling-canvas");
     if (canvas) {
-      canvas.style.width = "1000px"
-      canvas.style.height = "1000px"
+      canvas.style.width = "800px";
+      canvas.style.height = "800px";
+      const overlay = document.getElementById("supersampling-overlay")!;
+      overlay.style.display = "block";
     }
   }
 

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -39,10 +39,10 @@ export const startCalculation = async (
   const { isSuperSampling } = getCurrentParams();
   if (isSuperSampling) {
     // supersampling用のcanvasを用意
-    const canvas = document.getElementById("supersampling-canvas");
+    const canvas = document.getElementById("supersampling-canvas") as HTMLCanvasElement;
     if (canvas) {
-      canvas.style.width = "800px";
-      canvas.style.height = "800px";
+      canvas.width = 800;
+      canvas.height = 800;
       const overlay = document.getElementById("supersampling-overlay")!;
       overlay.style.display = "block";
     }

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -13,6 +13,7 @@ import {
   markAsRenderedWithCurrentParams,
   resetOffsetParams,
   resetScaleParams,
+  setCurrentParams,
   setPrevBatchId,
 } from "./mandelbrot-state/mandelbrot-state";
 import type { Rect } from "./math/rect";
@@ -29,6 +30,9 @@ export const startCalculation = async (
   onComplete: (elapsed: number) => void,
   onTranslated: () => void,
 ) => {
+  const { isSuperSampling } = getCurrentParams();
+  // supersamplingは一回きりなのでここで変更はなかったことにする
+  setCurrentParams({ isSuperSampling: false });
   markAsRenderedWithCurrentParams();
 
   const currentBatchId = crypto.randomUUID();
@@ -40,7 +44,6 @@ export const startCalculation = async (
   const SUPER_WIDTH = 2560;
   const SUPER_HEIGHT = 1440;
 
-  const { isSuperSampling } = getCurrentParams();
   if (isSuperSampling) {
     // supersampling用のcanvasを用意
     const canvas = document.getElementById("supersampling-canvas") as HTMLCanvasElement;
@@ -71,7 +74,7 @@ export const startCalculation = async (
 
   // workerに分配するために描画範囲を分割
   const divideRectCount = getWorkerCount("calc-iteration") * (isSuperSampling ? 4 : 1);
-  const currentParams = getCurrentParams();
+  const currentParams = { ...getCurrentParams(), isSuperSampling };
   const calculationRects = getCalculationTargetRects(
     canvasWidth,
     canvasHeight,

--- a/src/rendering/p5-renderer.ts
+++ b/src/rendering/p5-renderer.ts
@@ -204,7 +204,7 @@ const fillColor = (
   x: number,
   y: number,
   canvasWidth: number,
-  pixels: Uint8ClampedArray,
+  imageData: Uint8ClampedArray,
   palette: Palette,
   buffer: Uint32Array<ArrayBuffer>,
   isSuperSampled: boolean,
@@ -264,15 +264,15 @@ const fillColor = (
       }
 
       if (iteration !== maxIteration) {
-        pixels[pixelIndex + 0] = r;
-        pixels[pixelIndex + 1] = g;
-        pixels[pixelIndex + 2] = b;
-        pixels[pixelIndex + 3] = 255;
+        imageData[pixelIndex + 0] = r;
+        imageData[pixelIndex + 1] = g;
+        imageData[pixelIndex + 2] = b;
+        imageData[pixelIndex + 3] = 255;
       } else {
-        pixels[pixelIndex + 0] = 0;
-        pixels[pixelIndex + 1] = 0;
-        pixels[pixelIndex + 2] = 0;
-        pixels[pixelIndex + 3] = 255;
+        imageData[pixelIndex + 0] = 0;
+        imageData[pixelIndex + 1] = 0;
+        imageData[pixelIndex + 2] = 0;
+        imageData[pixelIndex + 3] = 255;
       }
     }
   }
@@ -299,13 +299,13 @@ const renderIterationsToPixel = (
 
   for (let worldY = startY; worldY < endY; worldY++) {
     for (let worldX = startX; worldX < endX; worldX++) {
-      const pixels = graphics.pixels as unknown as Uint8ClampedArray;
+      const imageData = graphics.pixels as unknown as Uint8ClampedArray;
 
       fillColor(
         worldX,
         worldY,
         canvasWidth,
-        pixels,
+        imageData,
         palette,
         unifiedIterationBuffer,
         isSuperSampled,

--- a/src/rendering/p5-renderer.ts
+++ b/src/rendering/p5-renderer.ts
@@ -204,7 +204,7 @@ const fillColor = (
   x: number,
   y: number,
   canvasWidth: number,
-  imageData: Uint8ClampedArray,
+  imageData: Uint8ClampedArray<ArrayBuffer>,
   palette: Palette,
   buffer: Uint32Array<ArrayBuffer>,
   isSuperSampled: boolean,
@@ -299,7 +299,7 @@ const renderIterationsToPixel = (
 
   for (let worldY = startY; worldY < endY; worldY++) {
     for (let worldX = startX; worldX < endX; worldX++) {
-      const imageData = graphics.pixels as unknown as Uint8ClampedArray;
+      const imageData = graphics.pixels as unknown as Uint8ClampedArray<ArrayBuffer>;
 
       fillColor(
         worldX,

--- a/src/rendering/p5-renderer.ts
+++ b/src/rendering/p5-renderer.ts
@@ -400,7 +400,114 @@ const renderIterationsToPixelSupersampled = (
   worldRect: Rect,
   iterationsResult: IterationBuffer[],
 ) => {
-  return null;
+  const canvas = document.getElementById("supersampling-canvas") as HTMLCanvasElement;
+  if (!canvas) {
+    console.error("supersampling-canvas not found");
+    return;
+  }
+
+  const context = canvas.getContext("2d");
+  if (!context) {
+    console.error("Failed to get 2d context from supersampling-canvas");
+    return;
+  }
+
+  const canvasWidth = 800;
+  const canvasHeight = 800;
+
+  const params = getCurrentParams();
+  const palette = getCurrentPalette();
+
+  // 全体のimageDataを取得
+  const imageData = context.getImageData(0, 0, canvasWidth, canvasHeight);
+  const pixelData = imageData.data;
+
+  // iterationsResultから各バッファを処理
+  for (const iteration of iterationsResult) {
+    const { rect, buffer, resolution, isSuperSampled } = iteration;
+
+    // worldRectとiterationのrectが重なっている部分だけ描画する
+    const startY = Math.max(rect.y, worldRect.y);
+    const startX = Math.max(rect.x, worldRect.x);
+    const endY = Math.min(rect.y + rect.height, worldRect.y + worldRect.height);
+    const endX = Math.min(rect.x + rect.width, worldRect.x + worldRect.width);
+
+    for (let worldY = startY; worldY < endY; worldY++) {
+      for (let worldX = startX; worldX < endX; worldX++) {
+        // バッファ内で対応する点のiterationを取得
+        const localX = worldX - rect.x;
+        const localY = worldY - rect.y;
+
+        const ratioX = resolution.width / rect.width;
+        const ratioY = resolution.height / rect.height;
+
+        const scaledX = Math.floor(localX * ratioX);
+        const scaledY = Math.floor(localY * ratioY);
+
+        let r = 0;
+        let g = 0;
+        let b = 0;
+        let iteration = 0;
+
+        if (!isSuperSampled) {
+          const idx = scaledX + scaledY * resolution.width;
+          iteration = buffer[idx];
+
+          r = palette.r(iteration);
+          g = palette.g(iteration);
+          b = palette.b(iteration);
+        } else {
+          // supersampledの場合は4点平均
+          const idx00 = scaledX + scaledY * resolution.width;
+          const idx10 = scaledX + 1 + scaledY * resolution.width;
+          const idx01 = scaledX + (scaledY + 1) * resolution.width;
+          const idx11 = scaledX + 1 + (scaledY + 1) * resolution.width;
+
+          iteration = Math.round(
+            (buffer[idx00] + buffer[idx10] + buffer[idx01] + buffer[idx11]) / 4,
+          );
+
+          const r00 = palette.r(buffer[idx00]);
+          const g00 = palette.g(buffer[idx00]);
+          const b00 = palette.b(buffer[idx00]);
+
+          const r10 = palette.r(buffer[idx10]);
+          const g10 = palette.g(buffer[idx10]);
+          const b10 = palette.b(buffer[idx10]);
+
+          const r01 = palette.r(buffer[idx01]);
+          const g01 = palette.g(buffer[idx01]);
+          const b01 = palette.b(buffer[idx01]);
+
+          const r11 = palette.r(buffer[idx11]);
+          const g11 = palette.g(buffer[idx11]);
+          const b11 = palette.b(buffer[idx11]);
+
+          r = (r00 + r10 + r01 + r11) / 4;
+          g = (g00 + g10 + g01 + g11) / 4;
+          b = (b00 + b10 + b01 + b11) / 4;
+        }
+
+        // imageDataに書き込み
+        const pixelIndex = 4 * (worldY * canvasWidth + worldX);
+
+        if (iteration !== params.N) {
+          pixelData[pixelIndex + 0] = r;
+          pixelData[pixelIndex + 1] = g;
+          pixelData[pixelIndex + 2] = b;
+          pixelData[pixelIndex + 3] = 255;
+        } else {
+          pixelData[pixelIndex + 0] = 0;
+          pixelData[pixelIndex + 1] = 0;
+          pixelData[pixelIndex + 2] = 0;
+          pixelData[pixelIndex + 3] = 255;
+        }
+      }
+    }
+  }
+
+  // canvasに反映
+  context.putImageData(imageData, 0, 0);
 };
 
 const renderToMainBuffer = (rect: Rect = bufferRect) => {

--- a/src/rendering/p5-renderer.ts
+++ b/src/rendering/p5-renderer.ts
@@ -77,8 +77,17 @@ export const addIterationBuffer: Renderer["addIterationBuffer"] = (
   rect = bufferRect,
   iterBuffer,
 ) => {
-  renderIterationsToUnifiedBuffer(rect, unifiedIterationBuffer, iterBuffer ?? getIterationCache());
-  markNeedsRerender();
+  const { isSuperSampling = false } = getCurrentParams();
+  if (isSuperSampling && iterBuffer) {
+    renderIterationsToPixelSupersampled(rect, iterBuffer);
+  } else {
+    renderIterationsToUnifiedBuffer(
+      rect,
+      unifiedIterationBuffer,
+      iterBuffer ?? getIterationCache(),
+    );
+    markNeedsRerender();
+  }
 };
 
 /**
@@ -378,6 +387,20 @@ const renderIterationsToUnifiedBuffer = (
       }
     }
   }
+};
+
+/**
+ * supersampliedなiterationBufferをその場でcanvasに書き込む。
+ * supersampleポップアップ内のcanvasへの描画で使用する
+ *
+ * unifiedIterationBufferは用いない。
+ * canvasに書き込んだらそのiterationBufferは捨てられる
+ */
+const renderIterationsToPixelSupersampled = (
+  worldRect: Rect,
+  iterationsResult: IterationBuffer[],
+) => {
+  return null;
 };
 
 const renderToMainBuffer = (rect: Rect = bufferRect) => {

--- a/src/rendering/p5-renderer.ts
+++ b/src/rendering/p5-renderer.ts
@@ -232,45 +232,12 @@ const fillColor = (
 
       let iteration = 0;
 
-      if (!isSuperSampled) {
-        const idx = x * density + i + (y * density + j) * canvasWidth * density;
-        iteration = buffer[idx];
+      const idx = x * density + i + (y * density + j) * canvasWidth * density;
+      iteration = buffer[idx];
 
-        r = palette.r(buffer[idx]);
-        g = palette.g(buffer[idx]);
-        b = palette.b(buffer[idx]);
-      } else {
-        const doubleCanvasWidth = canvasWidth * 2;
-        const y2 = y * 2;
-        const x2 = x * 2;
-
-        const idx00 = x2 + i + (y2 + j) * doubleCanvasWidth;
-        const idx10 = x2 + i + 1 + (y2 + j) * doubleCanvasWidth;
-        const idx01 = x2 + i + (y2 + j + 1) * doubleCanvasWidth;
-        const idx11 = x2 + i + 1 + (y2 + j + 1) * doubleCanvasWidth;
-
-        iteration = Math.round((buffer[idx00] + buffer[idx10] + buffer[idx01] + buffer[idx11]) / 4);
-
-        const r00 = palette.r(buffer[idx00]);
-        const g00 = palette.g(buffer[idx00]);
-        const b00 = palette.b(buffer[idx00]);
-
-        const r10 = palette.r(buffer[idx10]);
-        const g10 = palette.g(buffer[idx10]);
-        const b10 = palette.b(buffer[idx10]);
-
-        const r01 = palette.r(buffer[idx01]);
-        const g01 = palette.g(buffer[idx01]);
-        const b01 = palette.b(buffer[idx01]);
-
-        const r11 = palette.r(buffer[idx11]);
-        const g11 = palette.g(buffer[idx11]);
-        const b11 = palette.b(buffer[idx11]);
-
-        r = (r00 + r10 + r01 + r11) / 4;
-        g = (g00 + g10 + g01 + g11) / 4;
-        b = (b00 + b10 + b01 + b11) / 4;
-      }
+      r = palette.r(buffer[idx]);
+      g = palette.g(buffer[idx]);
+      b = palette.b(buffer[idx]);
 
       if (iteration !== maxIteration) {
         imageData[pixelIndex + 0] = r;
@@ -340,7 +307,7 @@ const renderIterationsToUnifiedBuffer = (
   const { width: canvasWidth } = getCanvasSize();
 
   for (const iteration of iterationsResult) {
-    const { rect, buffer, resolution, isSuperSampled } = iteration;
+    const { rect, buffer, resolution } = iteration;
 
     // worldRectとiterationのrectが重なっている部分だけ描画する
     const startY = Math.max(rect.y, worldRect.y);
@@ -362,28 +329,9 @@ const renderIterationsToUnifiedBuffer = (
 
         const worldIdx = worldY * canvasWidth + worldX;
 
-        if (!isSuperSampled) {
-          const idx = scaledX + scaledY * resolution.width;
+        const idx = scaledX + scaledY * resolution.width;
 
-          unifiedIterationBuffer[worldIdx] = buffer[idx];
-        } else {
-          const idx00 = scaledX + scaledY * resolution.width;
-          const idx10 = scaledX + 1 + scaledY * resolution.width;
-          const idx01 = scaledX + (scaledY + 1) * resolution.width;
-          const idx11 = scaledX + 1 + (scaledY + 1) * resolution.width;
-
-          // unifiedIterationBufferは幅・高さともに2倍のサイズを想定
-          const doubleCanvasWidth = canvasWidth * 2;
-          const worldY2x = worldY * 2;
-          const worldX2x = worldX * 2;
-
-          // 4点のデータを対応する位置にそのまま格納
-          unifiedIterationBuffer[worldY2x * doubleCanvasWidth + worldX2x] = buffer[idx00];
-          unifiedIterationBuffer[worldY2x * doubleCanvasWidth + (worldX2x + 1)] = buffer[idx10];
-          unifiedIterationBuffer[(worldY2x + 1) * doubleCanvasWidth + worldX2x] = buffer[idx01];
-          unifiedIterationBuffer[(worldY2x + 1) * doubleCanvasWidth + (worldX2x + 1)] =
-            buffer[idx11];
-        }
+        unifiedIterationBuffer[worldIdx] = buffer[idx];
       }
     }
   }

--- a/src/rendering/p5-renderer.ts
+++ b/src/rendering/p5-renderer.ts
@@ -55,7 +55,7 @@ export const initRenderer: Renderer["initRenderer"] = async (w, h, p5) => {
   width = w;
   height = h;
   bufferRect = { x: 0, y: 0, width: w, height: h };
-  unifiedIterationBuffer = new Uint32Array(w * h * 4);
+  unifiedIterationBuffer = new Uint32Array(w * h);
 
   console.log("Camera setup done", { width, height });
 
@@ -117,7 +117,7 @@ export const resizeCanvas: Renderer["resizeCanvas"] = (requestWidth, requestHeig
   height = h;
   bufferRect = { x: 0, y: 0, width: w, height: h };
 
-  unifiedIterationBuffer = new Uint32Array(w * h * 4);
+  unifiedIterationBuffer = new Uint32Array(w * h);
   mainBuffer.resizeCanvas(width, height);
 
   const scaleFactor = Math.min(width, height) / Math.min(from.width, from.height);

--- a/src/rendering/p5-renderer.ts
+++ b/src/rendering/p5-renderer.ts
@@ -76,9 +76,9 @@ export const renderToCanvas: Renderer["renderToCanvas"] = (x, y, width, height) 
 export const addIterationBuffer: Renderer["addIterationBuffer"] = (
   rect = bufferRect,
   iterBuffer,
+  isSuperSampled = false,
 ) => {
-  const { isSuperSampling = false } = getCurrentParams();
-  if (isSuperSampling && iterBuffer) {
+  if (isSuperSampled && iterBuffer) {
     renderIterationsToPixelSupersampled(rect, iterBuffer);
   } else {
     renderIterationsToUnifiedBuffer(
@@ -532,7 +532,7 @@ const renderToMainBuffer = (rect: Rect = bufferRect) => {
     mainBuffer,
     params.N,
     unifiedIterationBuffer,
-    params.isSuperSampling,
+    false,
     getCurrentPalette(),
   );
 };

--- a/src/rendering/p5-renderer.ts
+++ b/src/rendering/p5-renderer.ts
@@ -55,7 +55,7 @@ export const initRenderer: Renderer["initRenderer"] = async (w, h, p5) => {
   width = w;
   height = h;
   bufferRect = { x: 0, y: 0, width: w, height: h };
-  unifiedIterationBuffer = new Uint32Array(w * h);
+  unifiedIterationBuffer = new Uint32Array(w * h * 4);
 
   console.log("Camera setup done", { width, height });
 

--- a/src/rendering/renderer.ts
+++ b/src/rendering/renderer.ts
@@ -4,6 +4,7 @@ import type { IterationBuffer } from "@/types";
 import type p5 from "p5";
 import { getRenderer } from "./common";
 
+import { getCurrentParams } from "@/mandelbrot-state/mandelbrot-state";
 import * as p5Renderer from "./p5-renderer";
 import * as webGPURenderer from "./webgpu-renderer";
 
@@ -97,6 +98,10 @@ export const resizeCanvas: Renderer["resizeCanvas"] = (...args) => {
 
 export const addIterationBuffer: Renderer["addIterationBuffer"] = (...args) => {
   const rendererType = getRenderer();
+  const { isSuperSampling } = getCurrentParams();
+
+  // supersamplingが有効な場合はp5rendererを使って別canvasに書き込む
+  if (isSuperSampling) return p5Renderer.addIterationBuffer(...args);
 
   switch (rendererType) {
     case "p5js":

--- a/src/rendering/renderer.ts
+++ b/src/rendering/renderer.ts
@@ -4,7 +4,6 @@ import type { IterationBuffer } from "@/types";
 import type p5 from "p5";
 import { getRenderer } from "./common";
 
-import { getCurrentParams } from "@/mandelbrot-state/mandelbrot-state";
 import * as p5Renderer from "./p5-renderer";
 import * as webGPURenderer from "./webgpu-renderer";
 
@@ -44,7 +43,11 @@ export type Renderer = {
   /**
    * 描画するためのiterationBufferをrendererに登録する
    */
-  addIterationBuffer: (rect?: Rect, iterBuffer?: IterationBuffer[]) => void;
+  addIterationBuffer: (
+    rect?: Rect,
+    iterBuffer?: IterationBuffer[],
+    isSuperSampled?: boolean,
+  ) => void;
   /**
    * renderer側でのpalette dataの登録を行う
    *
@@ -96,18 +99,21 @@ export const resizeCanvas: Renderer["resizeCanvas"] = (...args) => {
   }
 };
 
-export const addIterationBuffer: Renderer["addIterationBuffer"] = (...args) => {
+export const addIterationBuffer: Renderer["addIterationBuffer"] = (
+  rect,
+  iterBuffer,
+  isSuperSampled,
+) => {
   const rendererType = getRenderer();
-  const { isSuperSampling } = getCurrentParams();
 
   // supersamplingが有効な場合はp5rendererを使って別canvasに書き込む
-  if (isSuperSampling) return p5Renderer.addIterationBuffer(...args);
+  if (isSuperSampled) return p5Renderer.addIterationBuffer(rect, iterBuffer, isSuperSampled);
 
   switch (rendererType) {
     case "p5js":
-      return p5Renderer.addIterationBuffer(...args);
+      return p5Renderer.addIterationBuffer(rect, iterBuffer);
     case "webgpu":
-      return webGPURenderer.addIterationBuffer(...args);
+      return webGPURenderer.addIterationBuffer(rect, iterBuffer);
   }
 };
 

--- a/src/style.css
+++ b/src/style.css
@@ -79,7 +79,7 @@ body {
 }
 
 #main {
-  min-height: 98dvh;
+  min-height: 97dvh;
 
   display: grid;
   gap: 0.2rem;
@@ -129,4 +129,17 @@ body {
 
 #footer {
   grid-area: footer;
+}
+
+#supersampling-overlay {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+
+  padding: calc(var(--spacing) * 2);
+  z-index: 999;
+
+  display: none;
 }

--- a/src/view/app-root.tsx
+++ b/src/view/app-root.tsx
@@ -4,6 +4,7 @@ import { CanvasOverlay } from "./canvas-overlay";
 import { Footer } from "./footer";
 import { Header } from "./header";
 import { RightSidebar } from "./right-sidebar";
+import { SupersamplingOverlay } from "./supersampling-overlay";
 
 export const AppRoot = () => {
   return (
@@ -12,6 +13,7 @@ export const AppRoot = () => {
       {ReactDOM.createPortal(<RightSidebar />, document.getElementById("sidebar-right")!)}
       {ReactDOM.createPortal(<Footer />, document.getElementById("footer")!)}
       {ReactDOM.createPortal(<CanvasOverlay />, document.getElementById("canvas-overlay")!)}
+      {ReactDOM.createPortal(<SupersamplingOverlay />, document.getElementById("supersampling-overlay")!)}
       <Toaster />
     </>
   );

--- a/src/view/app-root.tsx
+++ b/src/view/app-root.tsx
@@ -13,7 +13,10 @@ export const AppRoot = () => {
       {ReactDOM.createPortal(<RightSidebar />, document.getElementById("sidebar-right")!)}
       {ReactDOM.createPortal(<Footer />, document.getElementById("footer")!)}
       {ReactDOM.createPortal(<CanvasOverlay />, document.getElementById("canvas-overlay")!)}
-      {ReactDOM.createPortal(<SupersamplingOverlay />, document.getElementById("supersampling-overlay")!)}
+      {ReactDOM.createPortal(
+        <SupersamplingOverlay />,
+        document.getElementById("supersampling-overlay")!,
+      )}
       <Toaster />
     </>
   );

--- a/src/view/canvas-overlay/index.tsx
+++ b/src/view/canvas-overlay/index.tsx
@@ -4,5 +4,7 @@ import { useStoreValue } from "@/store/store";
 export const CanvasOverlay = () => {
   const progress = useStoreValue("progress");
 
-  return <div className="p-1">{typeof progress === "string" && <LoadingSpinner />}</div>;
+  const showSpinner = typeof progress === "string" && progress !== "";
+
+  return <div className="p-1">{showSpinner && <LoadingSpinner />}</div>;
 };

--- a/src/view/header/actions.tsx
+++ b/src/view/header/actions.tsx
@@ -73,9 +73,6 @@ const SaveImageButton = () => {
 };
 
 const SupersamplingButton = () => {
-  return null;
-
-  // FIXME: Supersampling is temporarily disabled
   return (
     <Button
       variant="outline"

--- a/src/view/supersampling-overlay/index.tsx
+++ b/src/view/supersampling-overlay/index.tsx
@@ -53,6 +53,10 @@ const SupersamplingOverlayComponent = ({ onClose }: SupersamplingOverlayProps) =
     setDragState(prev => ({ ...prev, isDragging: false }));
   }, []);
 
+  const handleBackgroundEvent = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+  }, []);
+
   const handleClose = useCallback(() => {
     const overlay = document.getElementById("supersampling-overlay");
     if (overlay) {
@@ -75,7 +79,11 @@ const SupersamplingOverlayComponent = ({ onClose }: SupersamplingOverlayProps) =
   }, [handleClose]);
 
   return (
-    <div className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm">
+    <div 
+      className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm"
+      onMouseDown={handleBackgroundEvent}
+      onClick={handleBackgroundEvent}
+    >
       {/* キャンバスコンテナ */}
       <div
         ref={containerRef}

--- a/src/view/supersampling-overlay/index.tsx
+++ b/src/view/supersampling-overlay/index.tsx
@@ -1,0 +1,9 @@
+import { useRef } from "react"
+
+export const SupersamplingOverlay = () => {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+
+  return (<div className="h-full w-full">
+    <canvas id="supersampling-canvas" ref={canvasRef} />
+  </div>)
+}

--- a/src/view/supersampling-overlay/index.tsx
+++ b/src/view/supersampling-overlay/index.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useCallback, memo, useEffect } from "react";
+import { memo, useCallback, useEffect, useRef, useState } from "react";
 
 interface SupersamplingOverlayProps {
   onClose?: () => void;
@@ -9,27 +9,27 @@ const SupersamplingOverlayComponent = ({ onClose }: SupersamplingOverlayProps) =
   const [fitMode, setFitMode] = useState(true);
 
   const handleToggleFitMode = useCallback(() => {
-    setFitMode(prev => !prev);
+    setFitMode((prev) => !prev);
   }, []);
 
   const handleClose = useCallback(() => {
     const overlay = document.getElementById("supersampling-overlay");
     if (overlay) {
-      overlay.style.display = "none";
+      overlay.style.display = "";
     }
     onClose?.();
   }, [onClose]);
 
   useEffect(() => {
     const handleEscKey = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
+      if (event.key === "Escape") {
         handleClose();
       }
     };
 
-    document.addEventListener('keydown', handleEscKey);
+    document.addEventListener("keydown", handleEscKey);
     return () => {
-      document.removeEventListener('keydown', handleEscKey);
+      document.removeEventListener("keydown", handleEscKey);
     };
   }, [handleClose]);
 
@@ -41,25 +41,18 @@ const SupersamplingOverlayComponent = ({ onClose }: SupersamplingOverlayProps) =
         id="supersampling-canvas"
         ref={canvasRef}
         className={
-          fitMode
-            ? "w-full h-full object-contain"
-            : "w-full h-full object-none object-center"
+          fitMode ? "w-full h-full object-contain" : "w-full h-full object-none object-center"
         }
         style={fitMode ? {} : { imageRendering: "pixelated" }}
       />
-      
+
       {/* 左上の閉じるボタン */}
       <div className="absolute top-4 left-4">
         <button
           onClick={handleClose}
           className="p-2 text-white/80 hover:text-white hover:bg-red-500/20 rounded-full shadow-lg transition-colors backdrop-blur-sm border border-white/20"
         >
-          <svg
-            className="w-6 h-6"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
+          <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path
               strokeLinecap="round"
               strokeLinejoin="round"

--- a/src/view/supersampling-overlay/index.tsx
+++ b/src/view/supersampling-overlay/index.tsx
@@ -17,57 +17,48 @@ const SupersamplingOverlayComponent = ({ onClose }: SupersamplingOverlayProps) =
   }, [onClose]);
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
-      <div className="relative max-w-[90vw] max-h-[90vh] bg-white rounded-xl shadow-2xl border border-gray-200 overflow-hidden">
-        {/* ヘッダー部分 */}
-        <div className="flex items-center justify-between p-4 bg-gray-50 border-b border-gray-200">
-          <h2 className="text-lg font-semibold text-gray-800">Supersampling Preview</h2>
-          <div className="flex items-center gap-2">
-            <button
-              onClick={handleToggleFitMode}
-              className="px-3 py-1 text-sm bg-blue-500 text-white rounded hover:bg-blue-600 transition-colors"
+    <div className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm">
+      {/* キャンバス - 画面フルサイズ */}
+      <canvas
+        key="supersampling-canvas"
+        id="supersampling-canvas"
+        ref={canvasRef}
+        className={
+          fitMode
+            ? "w-full h-full object-contain"
+            : "w-full h-full object-none object-center"
+        }
+        style={fitMode ? {} : { imageRendering: "pixelated" }}
+      />
+      
+      {/* UIコントロール - canvas上にoverlay */}
+      <div className="absolute top-4 right-4 flex items-center gap-2">
+        <button
+          onClick={handleToggleFitMode}
+          className="px-3 py-1 text-sm bg-blue-500/90 text-white rounded shadow-lg hover:bg-blue-600/90 transition-colors backdrop-blur-sm"
+        >
+          {fitMode ? "原寸表示" : "フィット表示"}
+        </button>
+        {onClose && (
+          <button
+            onClick={handleClose}
+            className="p-2 text-white/80 hover:text-white hover:bg-black/20 rounded shadow-lg transition-colors backdrop-blur-sm"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
             >
-              {fitMode ? "原寸表示" : "フィット表示"}
-            </button>
-            {onClose && (
-              <button
-                onClick={handleClose}
-                className="p-1 text-gray-500 hover:text-gray-700 hover:bg-gray-200 rounded transition-colors"
-              >
-                <svg
-                  className="w-5 h-5"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M6 18L18 6M6 6l12 12"
-                  />
-                </svg>
-              </button>
-            )}
-          </div>
-        </div>
-
-        {/* キャンバス部分 */}
-        <div className="p-4">
-          <div className="flex justify-center">
-            <canvas
-              key="supersampling-canvas"
-              id="supersampling-canvas"
-              ref={canvasRef}
-              className={
-                fitMode
-                  ? "max-w-full max-h-[70vh] object-contain"
-                  : "block"
-              }
-              style={fitMode ? {} : { imageRendering: "pixelated" }}
-            />
-          </div>
-        </div>
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        )}
       </div>
     </div>
   );

--- a/src/view/supersampling-overlay/index.tsx
+++ b/src/view/supersampling-overlay/index.tsx
@@ -20,37 +20,43 @@ const SupersamplingOverlayComponent = ({ onClose }: SupersamplingOverlayProps) =
     setFitMode((prev) => !prev);
   }, []);
 
-  const handleMouseDown = useCallback((e: React.MouseEvent) => {
-    if (fitMode || !containerRef.current) return;
-    
-    setDragState({
-      isDragging: true,
-      startX: e.pageX - containerRef.current.offsetLeft,
-      startY: e.pageY - containerRef.current.offsetTop,
-      scrollLeft: containerRef.current.scrollLeft,
-      scrollTop: containerRef.current.scrollTop,
-    });
-  }, [fitMode]);
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      if (fitMode || !containerRef.current) return;
 
-  const handleMouseMove = useCallback((e: React.MouseEvent) => {
-    if (!dragState.isDragging || !containerRef.current) return;
-    
-    e.preventDefault();
-    const x = e.pageX - containerRef.current.offsetLeft;
-    const y = e.pageY - containerRef.current.offsetTop;
-    const walkX = (x - dragState.startX) * 1;
-    const walkY = (y - dragState.startY) * 1;
-    
-    containerRef.current.scrollLeft = dragState.scrollLeft - walkX;
-    containerRef.current.scrollTop = dragState.scrollTop - walkY;
-  }, [dragState]);
+      setDragState({
+        isDragging: true,
+        startX: e.pageX - containerRef.current.offsetLeft,
+        startY: e.pageY - containerRef.current.offsetTop,
+        scrollLeft: containerRef.current.scrollLeft,
+        scrollTop: containerRef.current.scrollTop,
+      });
+    },
+    [fitMode],
+  );
+
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent) => {
+      if (!dragState.isDragging || !containerRef.current) return;
+
+      e.preventDefault();
+      const x = e.pageX - containerRef.current.offsetLeft;
+      const y = e.pageY - containerRef.current.offsetTop;
+      const walkX = (x - dragState.startX) * 1;
+      const walkY = (y - dragState.startY) * 1;
+
+      containerRef.current.scrollLeft = dragState.scrollLeft - walkX;
+      containerRef.current.scrollTop = dragState.scrollTop - walkY;
+    },
+    [dragState],
+  );
 
   const handleMouseUp = useCallback(() => {
-    setDragState(prev => ({ ...prev, isDragging: false }));
+    setDragState((prev) => ({ ...prev, isDragging: false }));
   }, []);
 
   const handleMouseLeave = useCallback(() => {
-    setDragState(prev => ({ ...prev, isDragging: false }));
+    setDragState((prev) => ({ ...prev, isDragging: false }));
   }, []);
 
   const handleBackgroundEvent = useCallback((e: React.MouseEvent) => {
@@ -79,7 +85,7 @@ const SupersamplingOverlayComponent = ({ onClose }: SupersamplingOverlayProps) =
   }, [handleClose]);
 
   return (
-    <div 
+    <div
       className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm"
       onMouseDown={handleBackgroundEvent}
       onClick={handleBackgroundEvent}
@@ -88,7 +94,7 @@ const SupersamplingOverlayComponent = ({ onClose }: SupersamplingOverlayProps) =
       <div
         ref={containerRef}
         className={
-          fitMode 
+          fitMode
             ? "w-full h-full flex items-center justify-center"
             : "w-full h-full overflow-auto cursor-grab active:cursor-grabbing"
         }
@@ -96,25 +102,21 @@ const SupersamplingOverlayComponent = ({ onClose }: SupersamplingOverlayProps) =
         onMouseMove={handleMouseMove}
         onMouseUp={handleMouseUp}
         onMouseLeave={handleMouseLeave}
-        style={fitMode ? {} : { cursor: dragState.isDragging ? 'grabbing' : 'grab' }}
+        style={fitMode ? {} : { cursor: dragState.isDragging ? "grabbing" : "grab" }}
       >
         <canvas
           key="supersampling-canvas"
           id="supersampling-canvas"
           ref={canvasRef}
-          className={
-            fitMode 
-              ? "max-w-full max-h-full object-contain"
-              : "block"
-          }
+          className={fitMode ? "max-w-full max-h-full object-contain" : "block"}
           style={
-            fitMode 
-              ? {} 
-              : { 
+            fitMode
+              ? {}
+              : {
                   imageRendering: "pixelated",
                   minWidth: "100%",
                   minHeight: "100%",
-                  display: "block"
+                  display: "block",
                 }
           }
         />
@@ -124,7 +126,7 @@ const SupersamplingOverlayComponent = ({ onClose }: SupersamplingOverlayProps) =
       <div className="absolute top-4 left-4">
         <button
           onClick={handleClose}
-          className="p-2 text-white/80 hover:text-white hover:bg-red-500/20 rounded-full shadow-lg transition-colors backdrop-blur-sm border border-white/20"
+          className="p-2 text-white/80 bg-black/80 hover:text-white hover:bg-red-500/70 rounded-full shadow-lg transition-colors backdrop-blur-sm border border-white/20"
         >
           <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path

--- a/src/view/supersampling-overlay/index.tsx
+++ b/src/view/supersampling-overlay/index.tsx
@@ -1,3 +1,4 @@
+import { LoadingSpinner } from "@/components/loading-spinner";
 import { getPrevBatchId } from "@/mandelbrot-state/mandelbrot-state";
 import { cancelBatch } from "@/worker-pool/worker-pool";
 import { memo, useCallback, useEffect, useRef, useState } from "react";
@@ -109,11 +110,23 @@ const SupersamplingOverlayComponent = ({ onClose }: SupersamplingOverlayProps) =
         onMouseLeave={handleMouseLeave}
         style={fitMode ? {} : { cursor: dragState.isDragging ? "grabbing" : "grab" }}
       >
+        {/* ローディングスピナー - canvasの下に表示 */}
+        <div className="absolute inset-0 flex items-center justify-center">
+          <div className="bg-black/80 text-white px-6 py-4 rounded-lg shadow-lg backdrop-blur-sm border border-white/20">
+            <div className="flex items-center gap-3">
+              <LoadingSpinner />
+              <span className="text-sm font-medium">描画中...</span>
+            </div>
+          </div>
+        </div>
+
         <canvas
           key="supersampling-canvas"
           id="supersampling-canvas"
           ref={canvasRef}
-          className={fitMode ? "max-w-full max-h-full object-contain" : "block"}
+          className={
+            fitMode ? "max-w-full max-h-full object-contain relative z-10" : "block relative z-10"
+          }
           style={
             fitMode
               ? {}

--- a/src/view/supersampling-overlay/index.tsx
+++ b/src/view/supersampling-overlay/index.tsx
@@ -141,7 +141,7 @@ const SupersamplingOverlayComponent = ({ onClose }: SupersamplingOverlayProps) =
       </div>
 
       {/* 左上の閉じるボタン */}
-      <div className="absolute top-4 left-4">
+      <div className="absolute top-4 left-4 z-20">
         <button
           onClick={handleClose}
           className="p-2 text-white/80 bg-black/80 hover:text-white hover:bg-red-500/70 rounded-full shadow-lg transition-colors backdrop-blur-sm border border-white/20"
@@ -158,7 +158,7 @@ const SupersamplingOverlayComponent = ({ onClose }: SupersamplingOverlayProps) =
       </div>
 
       {/* 右上のコントロール */}
-      <div className="absolute top-4 right-4">
+      <div className="absolute top-4 right-4 z-20">
         <button
           onClick={handleToggleFitMode}
           className="px-3 py-1 text-sm bg-blue-500/90 text-white rounded shadow-lg hover:bg-blue-600/90 transition-colors backdrop-blur-sm"

--- a/src/view/supersampling-overlay/index.tsx
+++ b/src/view/supersampling-overlay/index.tsx
@@ -1,9 +1,11 @@
-import { useRef } from "react"
+import { useRef } from "react";
 
 export const SupersamplingOverlay = () => {
-  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const canvasRef = useRef<HTMLCanvasElement>(null);
 
-  return (<div className="h-full w-full">
-    <canvas id="supersampling-canvas" ref={canvasRef} />
-  </div>)
-}
+  return (
+    <div className="h-full w-full">
+      <canvas id="supersampling-canvas" ref={canvasRef} />
+    </div>
+  );
+};

--- a/src/view/supersampling-overlay/index.tsx
+++ b/src/view/supersampling-overlay/index.tsx
@@ -1,3 +1,5 @@
+import { getPrevBatchId } from "@/mandelbrot-state/mandelbrot-state";
+import { cancelBatch } from "@/worker-pool/worker-pool";
 import { memo, useCallback, useEffect, useRef, useState } from "react";
 
 interface SupersamplingOverlayProps {
@@ -68,6 +70,9 @@ const SupersamplingOverlayComponent = ({ onClose }: SupersamplingOverlayProps) =
     if (overlay) {
       overlay.style.display = "";
     }
+    // 処理中だったらバッチを止める
+    cancelBatch(getPrevBatchId());
+
     onClose?.();
   }, [onClose]);
 

--- a/src/view/supersampling-overlay/index.tsx
+++ b/src/view/supersampling-overlay/index.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useCallback, memo } from "react";
+import { useRef, useState, useCallback, memo, useEffect } from "react";
 
 interface SupersamplingOverlayProps {
   onClose?: () => void;
@@ -13,8 +13,25 @@ const SupersamplingOverlayComponent = ({ onClose }: SupersamplingOverlayProps) =
   }, []);
 
   const handleClose = useCallback(() => {
+    const overlay = document.getElementById("supersampling-overlay");
+    if (overlay) {
+      overlay.style.display = "none";
+    }
     onClose?.();
   }, [onClose]);
+
+  useEffect(() => {
+    const handleEscKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        handleClose();
+      }
+    };
+
+    document.addEventListener('keydown', handleEscKey);
+    return () => {
+      document.removeEventListener('keydown', handleEscKey);
+    };
+  }, [handleClose]);
 
   return (
     <div className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm">
@@ -31,34 +48,36 @@ const SupersamplingOverlayComponent = ({ onClose }: SupersamplingOverlayProps) =
         style={fitMode ? {} : { imageRendering: "pixelated" }}
       />
       
-      {/* UIコントロール - canvas上にoverlay */}
-      <div className="absolute top-4 right-4 flex items-center gap-2">
+      {/* 左上の閉じるボタン */}
+      <div className="absolute top-4 left-4">
+        <button
+          onClick={handleClose}
+          className="p-2 text-white/80 hover:text-white hover:bg-red-500/20 rounded-full shadow-lg transition-colors backdrop-blur-sm border border-white/20"
+        >
+          <svg
+            className="w-6 h-6"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+        </button>
+      </div>
+
+      {/* 右上のコントロール */}
+      <div className="absolute top-4 right-4">
         <button
           onClick={handleToggleFitMode}
           className="px-3 py-1 text-sm bg-blue-500/90 text-white rounded shadow-lg hover:bg-blue-600/90 transition-colors backdrop-blur-sm"
         >
           {fitMode ? "原寸表示" : "フィット表示"}
         </button>
-        {onClose && (
-          <button
-            onClick={handleClose}
-            className="p-2 text-white/80 hover:text-white hover:bg-black/20 rounded shadow-lg transition-colors backdrop-blur-sm"
-          >
-            <svg
-              className="w-5 h-5"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M6 18L18 6M6 6l12 12"
-              />
-            </svg>
-          </button>
-        )}
       </div>
     </div>
   );

--- a/src/view/supersampling-overlay/index.tsx
+++ b/src/view/supersampling-overlay/index.tsx
@@ -2,6 +2,7 @@ import { LoadingSpinner } from "@/components/loading-spinner";
 import { getPrevBatchId } from "@/mandelbrot-state/mandelbrot-state";
 import { cancelBatch } from "@/worker-pool/worker-pool";
 import { memo, useCallback, useEffect, useRef, useState } from "react";
+import { Footer } from "../footer";
 
 interface SupersamplingOverlayProps {
   onClose?: () => void;
@@ -166,6 +167,9 @@ const SupersamplingOverlayComponent = ({ onClose }: SupersamplingOverlayProps) =
           {fitMode ? "原寸表示" : "フィット表示"}
         </button>
       </div>
+      <div className="absolute bottom-4 z-1 w-full px-8">
+        <Progress />
+      </div>
     </div>
   );
 };
@@ -173,3 +177,7 @@ const SupersamplingOverlayComponent = ({ onClose }: SupersamplingOverlayProps) =
 SupersamplingOverlayComponent.displayName = "SupersamplingOverlay";
 
 export const SupersamplingOverlay = memo(SupersamplingOverlayComponent);
+
+const Progress = () => {
+  return <Footer />;
+};

--- a/src/view/supersampling-overlay/index.tsx
+++ b/src/view/supersampling-overlay/index.tsx
@@ -1,11 +1,78 @@
-import { useRef } from "react";
+import { useRef, useState, useCallback, memo } from "react";
 
-export const SupersamplingOverlay = () => {
+interface SupersamplingOverlayProps {
+  onClose?: () => void;
+}
+
+const SupersamplingOverlayComponent = ({ onClose }: SupersamplingOverlayProps) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [fitMode, setFitMode] = useState(true);
+
+  const handleToggleFitMode = useCallback(() => {
+    setFitMode(prev => !prev);
+  }, []);
+
+  const handleClose = useCallback(() => {
+    onClose?.();
+  }, [onClose]);
 
   return (
-    <div className="h-full w-full">
-      <canvas id="supersampling-canvas" ref={canvasRef} />
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
+      <div className="relative max-w-[90vw] max-h-[90vh] bg-white rounded-xl shadow-2xl border border-gray-200 overflow-hidden">
+        {/* ヘッダー部分 */}
+        <div className="flex items-center justify-between p-4 bg-gray-50 border-b border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-800">Supersampling Preview</h2>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={handleToggleFitMode}
+              className="px-3 py-1 text-sm bg-blue-500 text-white rounded hover:bg-blue-600 transition-colors"
+            >
+              {fitMode ? "原寸表示" : "フィット表示"}
+            </button>
+            {onClose && (
+              <button
+                onClick={handleClose}
+                className="p-1 text-gray-500 hover:text-gray-700 hover:bg-gray-200 rounded transition-colors"
+              >
+                <svg
+                  className="w-5 h-5"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M6 18L18 6M6 6l12 12"
+                  />
+                </svg>
+              </button>
+            )}
+          </div>
+        </div>
+
+        {/* キャンバス部分 */}
+        <div className="p-4">
+          <div className="flex justify-center">
+            <canvas
+              key="supersampling-canvas"
+              id="supersampling-canvas"
+              ref={canvasRef}
+              className={
+                fitMode
+                  ? "max-w-full max-h-[70vh] object-contain"
+                  : "block"
+              }
+              style={fitMode ? {} : { imageRendering: "pixelated" }}
+            />
+          </div>
+        </div>
+      </div>
     </div>
   );
 };
+
+SupersamplingOverlayComponent.displayName = "SupersamplingOverlay";
+
+export const SupersamplingOverlay = memo(SupersamplingOverlayComponent);

--- a/src/worker-pool/callbacks/iteration-worker.ts
+++ b/src/worker-pool/callbacks/iteration-worker.ts
@@ -60,7 +60,7 @@ export const onIterationWorkerResult: IterationResultCallback = (result, job) =>
 
   batchContext.onChangeProgress();
 
-  addIterationBuffer(rect, [iterBuffer]);
+  addIterationBuffer(rect, [iterBuffer], isSuperSampled);
 
   // UIに変更を通知
   notifyIterationCacheUpdate();

--- a/src/worker-pool/worker-facade.ts
+++ b/src/worker-pool/worker-facade.ts
@@ -14,7 +14,7 @@ import { refOrbitWorkerPath, workerPaths } from "@/workers";
 import type { RefOrbitContext } from "@/workers/calc-ref-orbit";
 
 export interface IterationResult {
-  type: "result";
+  type: "result" | "terminated";
   iterations: ArrayBuffer;
   elapsed: number;
 }
@@ -103,6 +103,13 @@ export class CalcIterationWorker implements MandelbrotFacadeLike {
         case "progress": {
           const { progress } = data;
           this.progressCallback?.({ type: "progress", progress }, job);
+          break;
+        }
+        case "terminated": {
+          this.worker.removeEventListener("message", f);
+          this.running = false;
+
+          // this.terminatedCallback?.(job);
           break;
         }
       }

--- a/src/workers/mandelbrot-perturbation-worker.ts
+++ b/src/workers/mandelbrot-perturbation-worker.ts
@@ -226,6 +226,9 @@ const calcHandler = (data: IterationWorkerParams) => {
   }
   if (terminateChecker[workerIdx] !== 0) {
     console.debug(`${jobId}: terminated`);
+    self.postMessage({
+      type: "terminated",
+    });
   } else {
     // console.debug(`${jobId}: completed`);
   }


### PR DESCRIPTION
## Summary
スーパーサンプリングを別ビューにして再度復活させた
描画を別口にすることで考えることが減った

iterationResultが来る端からcanvasのimageDataに直書きすることで余計なbufferを持つ必要がなくなった

右クリックで保存も可能

現状固定でWQHD出力なので自由に解像度変えられるようにする（あとで）
たぶん4K出力もいける


## スクリーンショット
[![Image from Gyazo](https://i.gyazo.com/eb2fce96d34e0c3dc38fc13845a53d0c.png)](https://gyazo.com/eb2fce96d34e0c3dc38fc13845a53d0c)

んん～～～～最高