### PR TITLE
BLATableをjs objectに変換せず直接bufferから読むようにした

### DIFF
--- a/src/workers/bla-table-item.ts
+++ b/src/workers/bla-table-item.ts
@@ -140,8 +140,8 @@ export class BLATableView {
    */
   getBLAItemOffset(rowIdx: number, columnIdx: number) {
     const { byteOffset, length } = this.offsetMap[rowIdx];
-    if (columnIdx < length)
-      throw new Error(`Invalid offset specified: row: ${rowIdx}, ${columnIdx} < ${length}`);
+    if (columnIdx > length)
+      throw new Error(`Invalid offset specified: row: ${rowIdx}, ${columnIdx} > ${length}`);
 
     return byteOffset + columnIdx * ITEM_BYTE_LENGTH;
   }

--- a/src/workers/bla-table-item.ts
+++ b/src/workers/bla-table-item.ts
@@ -131,7 +131,7 @@ export class BLATableView {
       };
 
       // 次のrowLengthのoffsetにセットしておく
-      byteOffset = 4 + ITEM_BYTE_LENGTH * rowLength;
+      byteOffset += 4 + ITEM_BYTE_LENGTH * rowLength;
     }
   }
 

--- a/src/workers/bla-table-item.ts
+++ b/src/workers/bla-table-item.ts
@@ -107,3 +107,63 @@ export function decodeBLATableItems(buffer: ArrayBuffer): BLATableItem[][] {
 
   return items;
 }
+
+/**
+ * BLATableを表現するbufferから直接値を取り出せるようにするラッパー
+ */
+export class BLATableView {
+  private view: DataView;
+  public readonly length: number;
+  public readonly offsetMap: { [rowIndex: number]: { byteOffset: number; length: number } };
+
+  constructor(buffer: ArrayBuffer) {
+    this.view = new DataView(buffer);
+
+    this.length = this.view.getInt32(0, true);
+
+    this.offsetMap = {};
+    let byteOffset = 4; // ↑で読み込んだi32ひとつ分
+    for (let idx = 0; idx < this.length; idx++) {
+      const rowLength = this.view.getInt32(byteOffset, true);
+      this.offsetMap[idx] = {
+        byteOffset: byteOffset + 4, // itemの開始offsetが欲しいのでrowLength分は飛ばす
+        length: rowLength,
+      };
+
+      // 次のrowLengthのoffsetにセットしておく
+      byteOffset = 4 + ITEM_BYTE_LENGTH * rowLength;
+    }
+  }
+
+  /**
+   * 指定した位置のBLAItemが格納されているbyteOffsetを返す
+   */
+  getBLAItemOffset(rowIdx: number, columnIdx: number) {
+    const { byteOffset, length } = this.offsetMap[rowIdx];
+    if (columnIdx < length)
+      throw new Error(`Invalid offset specified: row: ${rowIdx}, ${columnIdx} < ${length}`);
+
+    return byteOffset + columnIdx * ITEM_BYTE_LENGTH;
+  }
+
+  getR(rowIdx: number, columnIdx: number) {
+    const byteOffset = this.getBLAItemOffset(rowIdx, columnIdx);
+    return this.view.getFloat64(byteOffset + 32, true);
+  }
+
+  getL(rowIdx: number, columnIdx: number) {
+    const byteOffset = this.getBLAItemOffset(rowIdx, columnIdx);
+    return this.view.getInt32(byteOffset + 40, true); // l
+  }
+
+  getAB(rowIdx: number, columnIdx: number) {
+    const byteOffset = this.getBLAItemOffset(rowIdx, columnIdx);
+
+    const aRe = this.view.getFloat64(byteOffset, true);
+    const aIm = this.view.getFloat64(byteOffset + 8, true);
+    const bRe = this.view.getFloat64(byteOffset + 16, true);
+    const bIm = this.view.getFloat64(byteOffset + 24, true);
+
+    return { aRe, aIm, bRe, bIm };
+  }
+}

--- a/src/workers/calc-ref-orbit.ts
+++ b/src/workers/calc-ref-orbit.ts
@@ -4,6 +4,7 @@ import {
   encodeBlaTableItems,
   SKIP_BLA_ENTRY_UNTIL_THIS_L,
   type BLATableItem,
+  type BLATableView,
 } from "@/workers/bla-table-item";
 import type { ComplexArrayView } from "@/workers/xn-buffer";
 import { encodeComplexArray } from "@/workers/xn-buffer";
@@ -33,7 +34,7 @@ export type RefOrbitContext = {
 
 export type RefOrbitContextPopulated = {
   xnView: ComplexArrayView;
-  blaTable: BLATableItem[][];
+  blaTableView: BLATableView;
 };
 
 // FIXME: 手抜き

--- a/src/workers/xn-buffer.ts
+++ b/src/workers/xn-buffer.ts
@@ -17,27 +17,7 @@ export function encodeComplexArray(complexArray: Complex[]): ArrayBuffer {
 }
 
 /**
- * ArrayBufferから複素数配列へのデコードを行う
- * メモリ効率改善版: 巨大なバッファをデコードする場合は注意
- * @param buffer 複素数データを含むArrayBuffer
- * @param limit 最大デコード数（省略時は全てデコード）
- * @returns デコードされた複素数配列
- */
-export function decodeComplexArray(buffer: ArrayBuffer, limit?: number): Complex[] {
-  const view = new Float64Array(buffer);
-  const length = limit ? Math.min(limit * 2, view.length) : view.length;
-  const complexArray: Complex[] = new Array(Math.floor(length / 2));
-
-  for (let i = 0, j = 0; i < length; i += 2, j++) {
-    complexArray[j] = { re: view[i], im: view[i + 1] };
-  }
-
-  return complexArray;
-}
-
-/**
- * 複素数データを直接Float64Arrayとして扱うためのラッパー
- * オブジェクト生成を避けてメモリ効率を向上
+ * refOrbit(xn)をArrayBufferのまま扱い直接値取得できるようにしたラッパー
  */
 export class ComplexArrayView {
   private view: Float64Array;
@@ -47,7 +27,7 @@ export class ComplexArrayView {
   }
 
   /**
-   * 配列の長さを取得
+   * refOrbitの長さを取得
    */
   get length(): number {
     return this.view.length / 2;
@@ -77,10 +57,6 @@ export class ComplexArrayView {
     };
   }
 
-  /**
-   * バッファデータを配列に変換（必要な場合のみ使用）
-   * @param limit 最大変換数（省略時は全て変換）
-   */
   toArray(limit?: number): Complex[] {
     const length = limit ? Math.min(limit, this.length) : this.length;
     const result = new Array(length);


### PR DESCRIPTION
## Summary
- 速度はそこまで変わらない
   - 特定地点の10回くらいの平均取って計測した
   - 150ms近く速くなる箇所もあれば、30msほど遅くなる箇所もある...
- 消費メモリは半減した 1200MB -> 600MB
   - 1つのworkerごとの消費メモリが減るので、worker数が多いほど恩恵が大きい

## next
- xnに続きblaTableもbufferのまま扱えるようになったので、これはもうSharedArrayBuffer行くしかないだろ！！！
   - workerへの転送コストが消える
   - といっても現状転送にかかる時間は数msなので、速度的な恩恵はほぼない