### PR TITLE
xn, blaTableのworker間受け渡しにSharedArrayBufferを使うようにした

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -74,8 +74,8 @@ export interface IterationWorkerParams {
   workerIdx: number;
 }
 
-export type XnBuffer = ArrayBuffer;
-export type BLATableBuffer = ArrayBuffer;
+export type XnBuffer = SharedArrayBuffer;
+export type BLATableBuffer = SharedArrayBuffer;
 
 export interface RefOrbitWorkerParams {
   complexCenterX: string;

--- a/src/workers/bla-table-item.ts
+++ b/src/workers/bla-table-item.ts
@@ -52,7 +52,7 @@ export function decodeBLATableItem(view: DataView, offset: number): BLATableItem
   };
 }
 
-export function encodeBlaTableItems(items: BLATableItem[][]): ArrayBuffer {
+export function encodeBlaTableItems(items: BLATableItem[][]): SharedArrayBuffer {
   // 行の数と、それぞれの行の要素数を格納するのに必要なバイト数を加算
   let totalSize = 4; // 最初の4バイトは行の数
   items.forEach((row) => {
@@ -60,7 +60,7 @@ export function encodeBlaTableItems(items: BLATableItem[][]): ArrayBuffer {
     totalSize += row.length * ITEM_BYTE_LENGTH; // 実際の各行のデータ
   });
 
-  const buffer = new ArrayBuffer(totalSize);
+  const buffer = new SharedArrayBuffer(totalSize);
   const view = new Int32Array(buffer);
 
   // 最初のエントリに行の数を設定
@@ -116,7 +116,7 @@ export class BLATableView {
   public readonly length: number;
   public readonly offsetMap: { [rowIndex: number]: { byteOffset: number; length: number } };
 
-  constructor(buffer: ArrayBuffer) {
+  constructor(buffer: SharedArrayBuffer) {
     this.view = new DataView(buffer);
 
     this.length = this.view.getInt32(0, true);

--- a/src/workers/xn-buffer.ts
+++ b/src/workers/xn-buffer.ts
@@ -4,8 +4,8 @@ const COMPLEX_BYTE_LENGTH = 16;
 
 // このファイルはほとんどChatGPTくんによって生成されました
 
-export function encodeComplexArray(complexArray: Complex[]): ArrayBuffer {
-  const buffer = new ArrayBuffer(complexArray.length * COMPLEX_BYTE_LENGTH);
+export function encodeComplexArray(complexArray: Complex[]): SharedArrayBuffer {
+  const buffer = new SharedArrayBuffer(complexArray.length * COMPLEX_BYTE_LENGTH);
   const view = new Float64Array(buffer);
 
   complexArray.forEach((complex, index) => {
@@ -22,7 +22,7 @@ export function encodeComplexArray(complexArray: Complex[]): ArrayBuffer {
 export class ComplexArrayView {
   private view: Float64Array;
 
-  constructor(buffer: ArrayBuffer) {
+  constructor(buffer: SharedArrayBuffer) {
     this.view = new Float64Array(buffer);
   }
 


### PR DESCRIPTION
## Summary
- ref-orbit-worker -> main -> iteration-workerのxn, blaTableの受け渡しがSharedArrayBufferになった
- worker間のコピーが発生しなくなった
   - 消費メモリが #91 よりさらに減った
   - 600MB -> 300MBくらい

## 破棄
- batchContextから消えたらすべての参照は消えるので勝手に破棄されると思われる
- devtoolsのmemoryタブ開いてたけどleakしてそうな動きはなかったのでヨシ！！