### PR TITLE
retinaでsupersampling時の出力が派手に壊れていたのを修正

### DIFF
--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -47,15 +47,9 @@ export const startCalculation = async (
     // supersampling用のcanvasを用意
     const canvas = document.getElementById("supersampling-canvas") as HTMLCanvasElement;
     if (canvas) {
-      const devicePixelRatio = window.devicePixelRatio || 1;
-
-      // retina対応: 物理ピクセルサイズを設定
-      canvas.width = supersamplingWidth * devicePixelRatio;
-      canvas.height = supersamplingHeight * devicePixelRatio;
-
-      // 論理サイズを設定
-      canvas.style.width = supersamplingWidth + "px";
-      canvas.style.height = supersamplingHeight + "px";
+      // FIXME: 真面目にretina対応するときはここでdevicePixelRatio倍する
+      canvas.width = supersamplingWidth;
+      canvas.height = supersamplingHeight;
 
       const overlay = document.getElementById("supersampling-overlay");
       if (overlay) overlay.style.display = "block";

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -47,8 +47,15 @@ export const startCalculation = async (
     // supersampling用のcanvasを用意
     const canvas = document.getElementById("supersampling-canvas") as HTMLCanvasElement;
     if (canvas) {
-      canvas.width = supersamplingWidth;
-      canvas.height = supersamplingHeight;
+      const devicePixelRatio = window.devicePixelRatio || 1;
+
+      // retina対応: 物理ピクセルサイズを設定
+      canvas.width = supersamplingWidth * devicePixelRatio;
+      canvas.height = supersamplingHeight * devicePixelRatio;
+
+      // 論理サイズを設定
+      canvas.style.width = supersamplingWidth + "px";
+      canvas.style.height = supersamplingHeight + "px";
 
       const overlay = document.getElementById("supersampling-overlay");
       if (overlay) overlay.style.display = "block";

--- a/src/rendering/p5-renderer.ts
+++ b/src/rendering/p5-renderer.ts
@@ -384,7 +384,7 @@ const renderIterationsToPixelSupersampled = (
 
   // iterationsResultから直接canvasに描画
   for (const iterBuffer of iterationsResult) {
-    const { rect, buffer, resolution, isSuperSampled } = iterBuffer;
+    const { rect, buffer, resolution } = iterBuffer;
 
     // worldRectとiterationのrectが重なっている部分だけ処理
     const startY = Math.max(rect.y, worldRect.y);
@@ -429,67 +429,46 @@ const renderIterationsToPixelSupersampled = (
             let b = 0;
             let iteration = 0;
 
-            if (!isSuperSampled) {
-              const idx = scaledX + scaledY * resolution.width;
-              iteration = buffer[idx];
+            // supersamplingの場合は4点平均
+            const idx00 = scaledX + scaledY * resolution.width;
+            const idx10 = scaledX + 1 + scaledY * resolution.width;
+            const idx01 = scaledX + (scaledY + 1) * resolution.width;
+            const idx11 = scaledX + 1 + (scaledY + 1) * resolution.width;
 
-              r = palette.r(buffer[idx]);
-              g = palette.g(buffer[idx]);
-              b = palette.b(buffer[idx]);
+            iteration = Math.round(
+              (buffer[idx00] + buffer[idx10] + buffer[idx01] + buffer[idx11]) / 4,
+            );
 
-              if (iteration !== params.N) {
-                pixelData[pixelIndex + 0] = r;
-                pixelData[pixelIndex + 1] = g;
-                pixelData[pixelIndex + 2] = b;
-                pixelData[pixelIndex + 3] = 255;
-              } else {
-                pixelData[pixelIndex + 0] = 0;
-                pixelData[pixelIndex + 1] = 0;
-                pixelData[pixelIndex + 2] = 0;
-                pixelData[pixelIndex + 3] = 255;
-              }
+            const r00 = palette.r(buffer[idx00]);
+            const g00 = palette.g(buffer[idx00]);
+            const b00 = palette.b(buffer[idx00]);
+
+            const r10 = palette.r(buffer[idx10]);
+            const g10 = palette.g(buffer[idx10]);
+            const b10 = palette.b(buffer[idx10]);
+
+            const r01 = palette.r(buffer[idx01]);
+            const g01 = palette.g(buffer[idx01]);
+            const b01 = palette.b(buffer[idx01]);
+
+            const r11 = palette.r(buffer[idx11]);
+            const g11 = palette.g(buffer[idx11]);
+            const b11 = palette.b(buffer[idx11]);
+
+            r = (r00 + r10 + r01 + r11) / 4;
+            g = (g00 + g10 + g01 + g11) / 4;
+            b = (b00 + b10 + b01 + b11) / 4;
+
+            if (iteration !== params.N) {
+              pixelData[pixelIndex + 0] = r;
+              pixelData[pixelIndex + 1] = g;
+              pixelData[pixelIndex + 2] = b;
+              pixelData[pixelIndex + 3] = 255;
             } else {
-              // supersamplingの場合は4点平均
-              const idx00 = scaledX + scaledY * resolution.width;
-              const idx10 = scaledX + 1 + scaledY * resolution.width;
-              const idx01 = scaledX + (scaledY + 1) * resolution.width;
-              const idx11 = scaledX + 1 + (scaledY + 1) * resolution.width;
-
-              iteration = Math.round(
-                (buffer[idx00] + buffer[idx10] + buffer[idx01] + buffer[idx11]) / 4,
-              );
-
-              const r00 = palette.r(buffer[idx00]);
-              const g00 = palette.g(buffer[idx00]);
-              const b00 = palette.b(buffer[idx00]);
-
-              const r10 = palette.r(buffer[idx10]);
-              const g10 = palette.g(buffer[idx10]);
-              const b10 = palette.b(buffer[idx10]);
-
-              const r01 = palette.r(buffer[idx01]);
-              const g01 = palette.g(buffer[idx01]);
-              const b01 = palette.b(buffer[idx01]);
-
-              const r11 = palette.r(buffer[idx11]);
-              const g11 = palette.g(buffer[idx11]);
-              const b11 = palette.b(buffer[idx11]);
-
-              r = (r00 + r10 + r01 + r11) / 4;
-              g = (g00 + g10 + g01 + g11) / 4;
-              b = (b00 + b10 + b01 + b11) / 4;
-
-              if (iteration !== params.N) {
-                pixelData[pixelIndex + 0] = r;
-                pixelData[pixelIndex + 1] = g;
-                pixelData[pixelIndex + 2] = b;
-                pixelData[pixelIndex + 3] = 255;
-              } else {
-                pixelData[pixelIndex + 0] = 0;
-                pixelData[pixelIndex + 1] = 0;
-                pixelData[pixelIndex + 2] = 0;
-                pixelData[pixelIndex + 3] = 255;
-              }
+              pixelData[pixelIndex + 0] = 0;
+              pixelData[pixelIndex + 1] = 0;
+              pixelData[pixelIndex + 2] = 0;
+              pixelData[pixelIndex + 3] = 255;
             }
           }
         }

--- a/src/rendering/p5-renderer.ts
+++ b/src/rendering/p5-renderer.ts
@@ -379,8 +379,8 @@ const renderIterationsToPixelSupersampled = (
   const params = getCurrentParams();
   const palette = getCurrentPalette();
 
-  // HTML canvasのpixel density取得（canvasがretina対応で初期化される）
-  const density = Math.round(window.devicePixelRatio || 1);
+  // FIXME: ちゃんとしたretina対応はあとでやる
+  const density = 1; // Math.round(window.devicePixelRatio || 1);
 
   // iterationsResultから直接canvasに描画
   for (const iterBuffer of iterationsResult) {
@@ -400,7 +400,8 @@ const renderIterationsToPixelSupersampled = (
 
     const imageData = context.getImageData(startX, startY, drawWidth, drawHeight);
     const pixelData = imageData.data;
-    const actualWidth = imageData.width; // 物理ピクセル幅 (drawWidth * density)
+    // 物理ピクセル幅 (drawWidth * density)、現状は常にdrawWidthと同値。retina対応するとずれる
+    const actualWidth = imageData.width;
 
     for (let y = startY; y < endY; y++) {
       for (let x = startX; x < endX; x++) {
@@ -408,7 +409,6 @@ const renderIterationsToPixelSupersampled = (
         const relativeY = y - startY;
         const relativeX = x - startX;
 
-        // retina対応: 各論理ピクセルに対してdensity x density個の物理ピクセルを塗る
         for (let i = 0; i < density; i++) {
           for (let j = 0; j < density; j++) {
             const physicalX = relativeX * density + i;

--- a/src/rendering/p5-renderer.ts
+++ b/src/rendering/p5-renderer.ts
@@ -400,6 +400,7 @@ const renderIterationsToPixelSupersampled = (
 
     const imageData = context.getImageData(startX, startY, drawWidth, drawHeight);
     const pixelData = imageData.data;
+    const actualWidth = imageData.width; // device pixel width
 
     for (let y = startY; y < endY; y++) {
       for (let x = startX; x < endX; x++) {
@@ -411,7 +412,7 @@ const renderIterationsToPixelSupersampled = (
         for (let i = 0; i < density; i++) {
           for (let j = 0; j < density; j++) {
             const pixelIndex = Math.floor(
-              4 * ((relativeY * density + j) * drawWidth * density + (relativeX * density + i)),
+              4 * ((relativeY * density + j) * actualWidth + (relativeX * density + i)),
             );
 
             const localX = x - rect.x;


### PR DESCRIPTION
## Summary
描画側でretina対応していたつもりだったが意味がなかった
ちゃんとやるならcanvas側で2倍サイズ確保して縮める対応をしなくてはならない
が、とりあえずは崩れなきゃいいのでそもそもretina対応をやめた
そのまま論理pixelサイズで出力される

そしてたぶん通常描画時もretina対応できてなくて、webgpuは荒くなるしcanvasだと描画ぶっ壊れる
これは後で考える...