### PR TITLE
テキストで指定した座標にジャンプする機能を追加

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -26,6 +26,15 @@ export const en = {
 
   // toolbar
   "toolbar.togglePOIPanel": "Toggle POI panel",
+  "toolbar.jump": "Jump",
+  "toolbar.jumpToCoordinates": "Jump to Coordinates",
+  "toolbar.pasteCoordinates": "Paste coordinates",
+  "toolbar.currentValue": "Current value",
+  "toolbar.parseError": "Could not recognize parameters",
+  "toolbar.invalidCoordinates": "Invalid coordinate values",
+  "toolbar.invalidRadius": "Invalid radius value",
+  "toolbar.invalidIteration": "Invalid iteration count",
+  "toolbar.parseFailed": "Failed to parse parameter values",
 
   // share dialog
   "share.noPreview": "No preview",

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -26,6 +26,15 @@ export const ja: Dictionary = {
 
   // toolbar
   "toolbar.togglePOIPanel": "POIパネルの表示切替",
+  "toolbar.jump": "ジャンプ",
+  "toolbar.jumpToCoordinates": "座標を指定してジャンプ",
+  "toolbar.pasteCoordinates": "座標情報を貼り付け",
+  "toolbar.currentValue": "現在の値",
+  "toolbar.parseError": "パラメータを認識できませんでした",
+  "toolbar.invalidCoordinates": "座標の値が不正です",
+  "toolbar.invalidRadius": "半径の値が不正です",
+  "toolbar.invalidIteration": "反復回数の値が不正です",
+  "toolbar.parseFailed": "パラメータの解析に失敗しました",
 
   // share dialog
   "share.noPreview": "プレビューなし",

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -28,7 +28,7 @@ export const ja: Dictionary = {
   "toolbar.togglePOIPanel": "POIパネルの表示切替",
   "toolbar.jump": "ジャンプ",
   "toolbar.jumpToCoordinates": "座標を指定してジャンプ",
-  "toolbar.pasteCoordinates": "座標情報を貼り付け",
+  "toolbar.pasteCoordinates": "座標情報を入力",
   "toolbar.currentValue": "現在の値",
   "toolbar.parseError": "パラメータを認識できませんでした",
   "toolbar.invalidCoordinates": "座標の値が不正です",

--- a/src/shadcn/components/ui/dialog.tsx
+++ b/src/shadcn/components/ui/dialog.tsx
@@ -19,7 +19,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-110 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className,
     )}
     {...props}
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-110 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,
       )}
       {...props}

--- a/src/view/toolbar/index.tsx
+++ b/src/view/toolbar/index.tsx
@@ -2,11 +2,12 @@ import { SimpleTooltip } from "@/components/simple-tooltip";
 import { useT } from "@/i18n/context";
 import { Button } from "@/shadcn/components/ui/button";
 import { updateStoreWith, useStoreValue } from "@/store/store";
-import { IconBug, IconLayoutSidebar, IconSettings } from "@tabler/icons-react";
+import { IconBug, IconLayoutSidebar, IconNavigation, IconSettings } from "@tabler/icons-react";
 import { Actions } from "../header/actions";
 import { useModalState } from "../modal/use-modal-state";
 import { PalettePopover } from "../palette-popover";
 import { SettingsDialog } from "../settings-dialog";
+import { JumpDialog } from "./jump-dialog";
 
 /** デバッグパネルの開閉トグルボタン */
 const DebugPanelToggle = () => {
@@ -49,6 +50,7 @@ const POIPanelToggle = () => {
 export const Toolbar = () => {
   const t = useT();
   const [settingsOpened, { open: openSettings, close: closeSettings }] = useModalState();
+  const [jumpOpened, { open: openJump, close: closeJump }] = useModalState();
 
   return (
     <>
@@ -58,10 +60,20 @@ export const Toolbar = () => {
           if (!isOpen) closeSettings();
         }}
       />
+      <JumpDialog
+        open={jumpOpened}
+        onOpenChange={(isOpen) => {
+          if (!isOpen) closeJump();
+        }}
+      />
       <div className="fixed top-3 left-3 z-100 flex items-center gap-2 rounded-xl border border-[#2a2a3a] bg-[#1c1c24]/95 px-3 py-2 backdrop-blur-sm">
         <Actions />
         <div className="bg-border mx-1 h-6 w-px" />
         <PalettePopover />
+        <Button variant="outline" size="sm" onClick={openJump}>
+          <IconNavigation className="mr-1 size-5" />
+          {t("Jump", "toolbar.jump")}
+        </Button>
         <Button variant="outline" size="sm" onClick={openSettings}>
           <IconSettings className="mr-1 size-5" />
           {t("Settings", "operations.settings")}

--- a/src/view/toolbar/jump-dialog.tsx
+++ b/src/view/toolbar/jump-dialog.tsx
@@ -188,7 +188,7 @@ export const JumpDialog = ({ open, onOpenChange }: JumpDialogProps) => {
               placeholder={"x=-1.408, y=0.136, r=2e-7, N=500\nreal: -1.408 imag: 0.136 zoom: 1e10"}
               value={rawText}
               onChange={(e) => handleTextChange(e.target.value)}
-              className="min-h-20 break-all font-mono text-xs placeholder:opacity-30"
+              className="h-[250px] break-all font-mono text-xs placeholder:opacity-30"
             />
             {parseError && <p className="text-xs text-destructive">{resolveError(parseError)}</p>}
           </div>

--- a/src/view/toolbar/jump-dialog.tsx
+++ b/src/view/toolbar/jump-dialog.tsx
@@ -1,0 +1,252 @@
+import { useT } from "@/i18n/context";
+import { clearIterationCache } from "@/iteration-buffer/iteration-buffer";
+import {
+  getCurrentParams,
+  setCurrentParams,
+  setManualN,
+} from "@/mandelbrot-state/mandelbrot-state";
+import { Button } from "@/shadcn/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/shadcn/components/ui/dialog";
+import { Input } from "@/shadcn/components/ui/input";
+import { Label } from "@/shadcn/components/ui/label";
+import { Textarea } from "@/shadcn/components/ui/textarea";
+import { PERTURBATION_THRESHOLD } from "@/utils/palette-encoding";
+import BigNumber from "bignumber.js";
+import { useState } from "react";
+
+/** パラメータ名のエイリアスマッピング */
+const PARAM_ALIASES: Record<string, "x" | "y" | "r" | "zoom" | "N"> = {
+  x: "x",
+  real: "x",
+  re: "x",
+  y: "y",
+  imag: "y",
+  im: "y",
+  r: "r",
+  radius: "r",
+  z: "zoom",
+  zoom: "zoom",
+  n: "N",
+  max_iter: "N",
+  max_iteration: "N",
+};
+
+type ParsedParams = {
+  x: string;
+  y: string;
+  r: string;
+  N: string;
+};
+
+/**
+ * テキストからマンデルブロパラメータをパースする
+ *
+ * `key=value` or `key: value` 形式に対応。
+ * デリミタはカンマ・改行・空白。
+ */
+const parseCoordinateText = (text: string): { params: ParsedParams; error: string | null } => {
+  const result: ParsedParams = { x: "", y: "", r: "", N: "" };
+
+  if (text.trim() === "") {
+    return { params: result, error: null };
+  }
+
+  // key=value or key: value のパターンを全てマッチ（値が"..."で囲まれていてもOK）
+  const pattern = /(\w+)\s*[:=]\s*"?([+-]?(?:\d+\.?\d*|\.\d+)(?:e[+-]?\d+)?)"?/gi;
+  let matched = false;
+
+  for (const match of text.matchAll(pattern)) {
+    const rawKey = match[1].toLowerCase();
+    const value = match[2];
+    const normalized = PARAM_ALIASES[rawKey];
+
+    if (normalized == null) continue;
+
+    matched = true;
+
+    if (normalized === "zoom") {
+      // zoom → r 変換: r = 2 / zoom
+      // 非常に大きなzoom値（e308等）に対応するため高精度で除算する
+      try {
+        const HighPrecision = BigNumber.clone({ DECIMAL_PLACES: 400 });
+        const zoomValue = new HighPrecision(value);
+        if (zoomValue.isFinite() && zoomValue.gt(0)) {
+          result.r = new HighPrecision(2).div(zoomValue).toString();
+        }
+      } catch {
+        // 無効な値は無視
+      }
+    } else {
+      result[normalized] = value;
+    }
+  }
+
+  if (!matched) {
+    return { params: result, error: "PARSE_ERROR" };
+  }
+
+  return { params: result, error: null };
+};
+
+type JumpDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+/** 座標を指定してジャンプするダイアログ */
+export const JumpDialog = ({ open, onOpenChange }: JumpDialogProps) => {
+  const t = useT();
+  const [rawText, setRawText] = useState("");
+  const [params, setParams] = useState<ParsedParams>({ x: "", y: "", r: "", N: "" });
+  const [parseError, setParseError] = useState<string | null>(null);
+
+  const canJump = params.x.trim() !== "" && params.y.trim() !== "";
+
+  /** エラーコードを翻訳済みメッセージに変換する */
+  const resolveError = (error: string | null): string | null => {
+    if (error == null) return null;
+    const errorMap: Record<string, string> = {
+      PARSE_ERROR: t("Could not recognize parameters", "toolbar.parseError"),
+      INVALID_COORDINATES: t("Invalid coordinate values", "toolbar.invalidCoordinates"),
+      INVALID_RADIUS: t("Invalid radius value", "toolbar.invalidRadius"),
+      INVALID_ITERATION: t("Invalid iteration count", "toolbar.invalidIteration"),
+      PARSE_FAILED: t("Failed to parse parameter values", "toolbar.parseFailed"),
+    };
+    return errorMap[error] ?? error;
+  };
+
+  /** textareaの内容をパースしてinputに反映する */
+  const handleTextChange = (text: string) => {
+    setRawText(text);
+    const { params: parsed, error } = parseCoordinateText(text);
+    setParams(parsed);
+    setParseError(error);
+  };
+
+  /** 個別inputの変更ハンドラ */
+  const handleParamChange = (key: keyof ParsedParams, value: string) => {
+    setParams((prev) => ({ ...prev, [key]: value }));
+  };
+
+  /** ジャンプ実行 */
+  const handleJump = () => {
+    const current = getCurrentParams();
+
+    try {
+      const x = new BigNumber(params.x);
+      const y = new BigNumber(params.y);
+      if (!x.isFinite() || !y.isFinite()) {
+        setParseError("INVALID_COORDINATES");
+        return;
+      }
+
+      const r = params.r.trim() !== "" ? new BigNumber(params.r) : current.r;
+      if (!r.isFinite() || r.lte(0)) {
+        setParseError("INVALID_RADIUS");
+        return;
+      }
+
+      const N = params.N.trim() !== "" ? Number.parseInt(params.N, 10) : current.N;
+      if (!Number.isFinite(N) || N <= 0) {
+        setParseError("INVALID_ITERATION");
+        return;
+      }
+
+      const mode = r.isLessThan(PERTURBATION_THRESHOLD) ? "perturbation" : "normal";
+
+      setManualN(N);
+      setCurrentParams({ x, y, r, N, mode });
+      clearIterationCache();
+
+      // ダイアログを閉じてリセット
+      onOpenChange(false);
+      setRawText("");
+      setParams({ x: "", y: "", r: "", N: "" });
+      setParseError(null);
+    } catch {
+      setParseError("PARSE_FAILED");
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md overflow-hidden">
+        <DialogHeader>
+          <DialogTitle>{t("Jump to Coordinates", "toolbar.jumpToCoordinates")}</DialogTitle>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1.5">
+            <Label>{t("Paste coordinates", "toolbar.pasteCoordinates")}</Label>
+            <Textarea
+              placeholder={"x=-1.408, y=0.136, r=2e-7, N=500\nreal: -1.408 imag: 0.136 zoom: 1e10"}
+              value={rawText}
+              onChange={(e) => handleTextChange(e.target.value)}
+              className="min-h-20 break-all font-mono text-xs placeholder:opacity-30"
+            />
+            {parseError && <p className="text-xs text-destructive">{resolveError(parseError)}</p>}
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="flex flex-col gap-1">
+              <Label className="text-xs text-muted-foreground">
+                x <span className="opacity-60">(real)</span>
+              </Label>
+              <Input
+                value={params.x}
+                onChange={(e) => handleParamChange("x", e.target.value)}
+                placeholder="0"
+                className="h-8 min-w-0 font-mono text-xs placeholder:opacity-30"
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <Label className="text-xs text-muted-foreground">
+                y <span className="opacity-60">(imag)</span>
+              </Label>
+              <Input
+                value={params.y}
+                onChange={(e) => handleParamChange("y", e.target.value)}
+                placeholder="0"
+                className="h-8 min-w-0 font-mono text-xs placeholder:opacity-30"
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <Label className="text-xs text-muted-foreground">
+                r <span className="opacity-60">(radius)</span>
+              </Label>
+              <Input
+                value={params.r}
+                onChange={(e) => handleParamChange("r", e.target.value)}
+                placeholder={t("Current value", "toolbar.currentValue")}
+                className="h-8 min-w-0 font-mono text-xs placeholder:opacity-30"
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <Label className="text-xs text-muted-foreground">
+                N <span className="opacity-60">(max iter)</span>
+              </Label>
+              <Input
+                value={params.N}
+                onChange={(e) => handleParamChange("N", e.target.value)}
+                placeholder={t("Current value", "toolbar.currentValue")}
+                className="h-8 min-w-0 font-mono text-xs placeholder:opacity-30"
+              />
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button disabled={!canJump} onClick={handleJump}>
+            {t("Jump", "toolbar.jump")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};


### PR DESCRIPTION
## Summary
座標を直接入力して指定位置に飛べるようにした

[![Image from Gyazo](https://i.gyazo.com/9781a32f108235a193b97e76f63f2c06.png)](https://gyazo.com/9781a32f108235a193b97e76f63f2c06)
[![Image from Gyazo](https://i.gyazo.com/badf43aa8f8933ef055ad531da3522d8.png)](https://gyazo.com/badf43aa8f8933ef055ad531da3522d8)

### 入力値
- x, real, re
- y, imag, im
- r, radium
- z, zoom
   -  `r = 2 / zoom` で変換される
- N, max_iter, max_iteration

形式は =か:で区切り、各パラメータのdelimiterは `[",", " ", "\n"]`