### PR TITLE
Supersampling時の解像度をより細かく指定できるようにする

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -106,8 +106,10 @@ export const en = {
   "settings.none": "None",
   "settings.animationCycleStep": "Animation Cycle Step",
   "settings.maxCanvasSize": "Max Canvas Size",
-  "settings.supersamplingWidth": "Supersampling Output Width",
-  "settings.supersamplingHeight": "Supersampling Output Height",
+  "settings.outputSize": "Output Size",
+  "settings.displaySize": "Display Size",
+  "settings.custom": "Custom",
+  "settings.generate": "Generate",
   "settings.useWasm": "Use Wasm for reference orbit",
   "settings.useWasmTooltip": "Approximately 10x faster. Recommended to keep ON.",
   // debug mode

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -106,8 +106,10 @@ export const ja: Dictionary = {
   "settings.none": "なし",
   "settings.animationCycleStep": "アニメーション周期ステップ",
   "settings.maxCanvasSize": "最大キャンバスサイズ",
-  "settings.supersamplingWidth": "スーパーサンプリング出力幅",
-  "settings.supersamplingHeight": "スーパーサンプリング出力高さ",
+  "settings.outputSize": "出力サイズ",
+  "settings.displaySize": "ディスプレイサイズ",
+  "settings.custom": "カスタム",
+  "settings.generate": "生成",
   "settings.useWasm": "Reference Orbit計算にWasmを使用",
   "settings.useWasmTooltip": "10倍ほど高速になるのでON推奨",
 

--- a/src/store/sync-storage/settings.ts
+++ b/src/store/sync-storage/settings.ts
@@ -23,7 +23,7 @@ export type Settings = {
 };
 
 export const DEFAULT_WORKER_COUNT =
-  process.env.NODE_ENV === "test" ? 1 : navigator.hardwareConcurrency;
+  import.meta.env.MODE === "test" ? 1 : navigator.hardwareConcurrency;
 
 /** ブラウザの言語設定からデフォルトのlocaleを判定する */
 const detectDefaultLocale = (): Locale =>

--- a/src/view/header/actions.tsx
+++ b/src/view/header/actions.tsx
@@ -14,9 +14,9 @@ import { Button } from "@/shadcn/components/ui/button";
 import { toast } from "@/shadcn/hooks/use-toast";
 import { buildShareData } from "@/utils/mandelbrot-url-params";
 import { useModalState } from "@/view/modal/use-modal-state";
+import { SupersamplingPopover } from "@/view/supersampling-popover";
 import { IconCircleCheck, IconDice, IconDownload, IconShare } from "@tabler/icons-react";
 import BigNumber from "bignumber.js";
-import { Expand } from "lucide-react";
 import { useEffect, useState } from "react";
 import { ShareDialog } from "./share-dialog";
 
@@ -26,7 +26,7 @@ export const Actions = () => {
       <RandomJumpButton />
       <ShareButton />
       <SaveImageButton />
-      <SupersamplingButton />
+      <SupersamplingPopover />
     </div>
   );
 };
@@ -128,21 +128,5 @@ const RandomJumpButton = () => {
         {t("I'm Feeling Lucky")}
       </Button>
     </SimpleTooltip>
-  );
-};
-
-const SupersamplingButton = () => {
-  const t = useT();
-  return (
-    <Button
-      variant="outline"
-      size="sm"
-      onClick={() => {
-        setCurrentParams({ isSuperSampling: true });
-      }}
-    >
-      <Expand className="mr-1 size-6" />
-      {t("Supersampling x2")}
-    </Button>
   );
 };

--- a/src/view/settings-dialog/index.tsx
+++ b/src/view/settings-dialog/index.tsx
@@ -42,8 +42,6 @@ const createWorkerCountValues = () => {
 const zoomRateValues = ["1.2", "1.5", "2.0", "4.0", "6.0", "10", "50", "100"];
 const workerCountValues = createWorkerCountValues();
 const maxCanvasSizeValues = ["-1", "128", "256", "512", "800", "1024", "2048"];
-const supersamplingWidthValues = ["1280", "1920", "2560", "3840", "5120", "7680"];
-const supersamplingHeightValues = ["720", "1080", "1440", "2160", "2880", "4320"];
 
 /** 左カラム: Rendering セクション */
 const RenderingSection = () => {
@@ -202,47 +200,6 @@ const ExplorationSection = () => {
   );
 };
 
-/** 右カラム: Supersampling Output セクション */
-const SupersamplingSection = () => {
-  const t = useT();
-  const supersamplingWidth = useStoreValue("supersamplingWidth");
-  const supersamplingHeight = useStoreValue("supersamplingHeight");
-  const [supersamplingWidthPreview, setSupersamplingWidthPreview] = useState(supersamplingWidth);
-  const [supersamplingHeightPreview, setSupersamplingHeightPreview] = useState(supersamplingHeight);
-
-  return (
-    <div className="flex flex-col gap-5">
-      <SectionTitle>Supersampling Output</SectionTitle>
-
-      <div>
-        <div className="mb-1 ml-2 text-sm">
-          {t("Supersampling Output Width")}: {supersamplingWidthPreview}px
-        </div>
-        <ValueSlider<number>
-          values={supersamplingWidthValues}
-          defaultValue={supersamplingWidth}
-          valueConverter={(value) => parseInt(value)}
-          onValueChange={(value) => setSupersamplingWidthPreview(value)}
-          onValueCommit={(value) => updateStore("supersamplingWidth", value)}
-        />
-      </div>
-
-      <div>
-        <div className="mb-1 ml-2 text-sm">
-          {t("Supersampling Output Height")}: {supersamplingHeightPreview}px
-        </div>
-        <ValueSlider<number>
-          values={supersamplingHeightValues}
-          defaultValue={supersamplingHeight}
-          valueConverter={(value) => parseInt(value)}
-          onValueChange={(value) => setSupersamplingHeightPreview(value)}
-          onValueCommit={(value) => updateStore("supersamplingHeight", value)}
-        />
-      </div>
-    </div>
-  );
-};
-
 /** 右カラム: About セクション */
 const AboutSection = () => {
   const t = useT();
@@ -333,7 +290,6 @@ export const SettingsDialog = ({
           </div>
           <div className="flex flex-col gap-8">
             <ExplorationSection />
-            <SupersamplingSection />
             <AboutSection />
           </div>
         </div>

--- a/src/view/supersampling-popover/index.tsx
+++ b/src/view/supersampling-popover/index.tsx
@@ -1,0 +1,174 @@
+import { useT } from "@/i18n/context";
+import { setCurrentParams } from "@/mandelbrot-state/mandelbrot-state";
+import { Button } from "@/shadcn/components/ui/button";
+import { Input } from "@/shadcn/components/ui/input";
+import { Label } from "@/shadcn/components/ui/label";
+import { Popover, PopoverContent, PopoverTrigger } from "@/shadcn/components/ui/popover";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/shadcn/components/ui/select";
+import { updateStore, useStoreValue } from "@/store/store";
+import { Expand } from "lucide-react";
+import { useState } from "react";
+
+const MIN_SIZE = 100;
+const MAX_WIDTH = 7680;
+const MAX_HEIGHT = 4320;
+
+/** サイズをmin/max範囲にclampする */
+const clampSize = (value: number, min: number, max: number): number =>
+  Math.max(min, Math.min(max, value));
+
+type Preset = {
+  label: string;
+  width: number;
+  height: number;
+};
+
+const PRESETS: Preset[] = [
+  { label: "HD (1280x720)", width: 1280, height: 720 },
+  { label: "Full HD (1920x1080)", width: 1920, height: 1080 },
+  { label: "QHD (2560x1440)", width: 2560, height: 1440 },
+  { label: "4K (3840x2160)", width: 3840, height: 2160 },
+  { label: "5K (5120x2880)", width: 5120, height: 2880 },
+  { label: "8K (7680x4320)", width: 7680, height: 4320 },
+];
+
+/** 現在の幅・高さに一致するプリセットキーを返す。なければ "custom" */
+const findPresetKey = (width: number, height: number): string => {
+  const match = PRESETS.find((p) => p.width === width && p.height === height);
+  if (match) return match.label;
+
+  if (width === window.screen.width && height === window.screen.height) {
+    return "display";
+  }
+
+  return "custom";
+};
+
+/** スーパーサンプリング設定ポップオーバー */
+export const SupersamplingPopover = () => {
+  const t = useT();
+  const storedWidth = useStoreValue("supersamplingWidth");
+  const storedHeight = useStoreValue("supersamplingHeight");
+
+  const [width, setWidth] = useState(storedWidth);
+  const [height, setHeight] = useState(storedHeight);
+  const [presetKey, setPresetKey] = useState(() => findPresetKey(storedWidth, storedHeight));
+
+  /** プリセット選択時のハンドラ */
+  const handlePresetChange = (key: string) => {
+    setPresetKey(key);
+
+    if (key === "display") {
+      const w = clampSize(window.screen.width, MIN_SIZE, MAX_WIDTH);
+      const h = clampSize(window.screen.height, MIN_SIZE, MAX_HEIGHT);
+      setWidth(w);
+      setHeight(h);
+      updateStore("supersamplingWidth", w);
+      updateStore("supersamplingHeight", h);
+      return;
+    }
+
+    if (key === "custom") return;
+
+    const preset = PRESETS.find((p) => p.label === key);
+    if (preset) {
+      setWidth(preset.width);
+      setHeight(preset.height);
+      updateStore("supersamplingWidth", preset.width);
+      updateStore("supersamplingHeight", preset.height);
+    }
+  };
+
+  /** 幅の入力確定 */
+  const commitWidth = (raw: string) => {
+    const parsed = Number.parseInt(raw, 10);
+    if (Number.isNaN(parsed)) return;
+    const clamped = clampSize(parsed, MIN_SIZE, MAX_WIDTH);
+    setWidth(clamped);
+    updateStore("supersamplingWidth", clamped);
+    setPresetKey(findPresetKey(clamped, height));
+  };
+
+  /** 高さの入力確定 */
+  const commitHeight = (raw: string) => {
+    const parsed = Number.parseInt(raw, 10);
+    if (Number.isNaN(parsed)) return;
+    const clamped = clampSize(parsed, MIN_SIZE, MAX_HEIGHT);
+    setHeight(clamped);
+    updateStore("supersamplingHeight", clamped);
+    setPresetKey(findPresetKey(width, clamped));
+  };
+
+  /** スーパーサンプリング実行 */
+  const handleGenerate = () => {
+    setCurrentParams({ isSuperSampling: true });
+  };
+
+  const displaySizeLabel = `${t("Display Size", "settings.displaySize")} (${window.screen.width}x${window.screen.height})`;
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="outline" size="sm">
+          <Expand className="mr-1 size-5" />
+          {t("Supersampling x2", "header.supersamplingX2")}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-72 border border-[#2a2a3a] p-4 shadow-[0_8px_32px_rgba(0,0,0,0.6)]"
+        align="start"
+        sideOffset={8}
+      >
+        <div className="flex flex-col gap-3">
+          <Label className="text-xs text-muted-foreground">
+            {t("Output Size", "settings.outputSize")}
+          </Label>
+
+          <Select value={presetKey} onValueChange={handlePresetChange}>
+            <SelectTrigger className="h-8 text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="display">{displaySizeLabel}</SelectItem>
+              {PRESETS.map((p) => (
+                <SelectItem key={p.label} value={p.label}>
+                  {p.label}
+                </SelectItem>
+              ))}
+              <SelectItem value="custom">{t("Custom", "settings.custom")}</SelectItem>
+            </SelectContent>
+          </Select>
+
+          <div className="flex items-center gap-2">
+            <Input
+              inputMode="numeric"
+              value={width}
+              onChange={(e) => setWidth(Number.parseInt(e.target.value, 10) || MIN_SIZE)}
+              onBlur={(e) => commitWidth(e.target.value)}
+              className="h-8 font-mono text-xs"
+            />
+            <span className="text-xs text-muted-foreground">x</span>
+            <Input
+              inputMode="numeric"
+              value={height}
+              onChange={(e) => setHeight(Number.parseInt(e.target.value, 10) || MIN_SIZE)}
+              onBlur={(e) => commitHeight(e.target.value)}
+              className="h-8 font-mono text-xs"
+            />
+          </div>
+
+          <Button size="sm" onClick={handleGenerate}>
+            <Expand className="mr-1 size-4" />
+            {t("Generate", "settings.generate")}
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+};


### PR DESCRIPTION
## Summary
- スーパーサンプリングの解像度設定を設定ダイアログ内から移動
- ツールバーのボタン押したときにすぐ生成ではなく、解像度設定を開きつつ生成ボタンを配置した
   - これを押す頻度は低いので、一段奥にあっても問題ない
- 解像度設定を任意の値指定できるようにした
   - ディスプレイサイズも一発で指定できるようにしている
      - 自分の使ってるディスプレイのサイズがなくて困ってた...
   - 100x100～8kまで。それ以上のドデカいマンデルブロ集合を出力したい人は各自でやってもろて

## Screenshot
[![Image from Gyazo](https://i.gyazo.com/acdb71c97f6ad92eb793239b46487553.png)](https://gyazo.com/acdb71c97f6ad92eb793239b46487553)
[![Image from Gyazo](https://i.gyazo.com/06f70eac68fbe93f58f22ba25a528829.png)](https://gyazo.com/06f70eac68fbe93f58f22ba25a528829)