### PR TITLE
最適化（場所によっては2倍速になった）

### DIFF
--- a/src/workers/bla-table-item.ts
+++ b/src/workers/bla-table-item.ts
@@ -55,30 +55,35 @@ export function decodeBLATableItem(view: DataView, offset: number): BLATableItem
 export function encodeBlaTableItems(items: BLATableItem[][]): SharedArrayBuffer {
   // 行の数と、それぞれの行の要素数を格納するのに必要なバイト数を加算
   let totalSize = 4; // 最初の4バイトは行の数
-  items.forEach((row) => {
+  for (let i = 0; i < items.length; i++) {
     totalSize += 4; // 各行の要素数を格納するための4バイト
-    totalSize += row.length * ITEM_BYTE_LENGTH; // 実際の各行のデータ
-  });
+    totalSize += items[i].length * ITEM_BYTE_LENGTH; // 実際の各行のデータ
+  }
 
   const buffer = new SharedArrayBuffer(totalSize);
-  const view = new Int32Array(buffer);
+  const view = new DataView(buffer);
 
   // 最初のエントリに行の数を設定
-  view[0] = items.length;
-  let offset = 1; // Int32のエントリとしてのオフセット
+  view.setInt32(0, items.length, true);
+  let byteOffset = 4;
 
-  items.forEach((row) => {
-    view[offset] = row.length; // 各行の要素数を設定
-    offset += 1; // 次の要素数のためにオフセットを1つ進める
+  for (let i = 0; i < items.length; i++) {
+    const row = items[i];
+    view.setInt32(byteOffset, row.length, true);
+    byteOffset += 4;
 
-    row.forEach((item) => {
-      const itemBuffer = encodeBlaTableItem(item);
-      // Int32のエントリではなく、バイトとしてのオフセットを計算する必要がある
-      const byteOffset = offset * 4;
-      new Uint8Array(buffer, byteOffset, ITEM_BYTE_LENGTH).set(new Uint8Array(itemBuffer));
-      offset += ITEM_BYTE_LENGTH / 4; // 次のアイテムのためにオフセットをアイテムのバイト長分進める
-    });
-  });
+    for (let j = 0; j < row.length; j++) {
+      const item = row[j];
+      // 中間ArrayBufferを作らず直接SharedArrayBufferに書き込む
+      view.setFloat64(byteOffset, item.a.re, true);
+      view.setFloat64(byteOffset + 8, item.a.im, true);
+      view.setFloat64(byteOffset + 16, item.b.re, true);
+      view.setFloat64(byteOffset + 24, item.b.im, true);
+      view.setFloat64(byteOffset + 32, item.r, true);
+      view.setInt32(byteOffset + 40, item.l, true);
+      byteOffset += ITEM_BYTE_LENGTH;
+    }
+  }
 
   return buffer;
 }
@@ -114,21 +119,22 @@ export function decodeBLATableItems(buffer: ArrayBuffer): BLATableItem[][] {
 export class BLATableView {
   private view: DataView;
   public readonly length: number;
-  public readonly offsetMap: { [rowIndex: number]: { byteOffset: number; length: number } };
+  /** 各行の[byteOffset, length]をフラットに格納。rowOffsets[rowIdx * 2] = byteOffset, rowOffsets[rowIdx * 2 + 1] = length */
+  private readonly rowOffsets: Int32Array;
+  /** getABの結果をアロケーションなしで返すための再利用バッファ */
+  readonly abBuffer = new Float64Array(4);
 
   constructor(buffer: SharedArrayBuffer) {
     this.view = new DataView(buffer);
 
     this.length = this.view.getInt32(0, true);
 
-    this.offsetMap = {};
+    this.rowOffsets = new Int32Array(this.length * 2);
     let byteOffset = 4; // ↑で読み込んだi32ひとつ分
     for (let idx = 0; idx < this.length; idx++) {
       const rowLength = this.view.getInt32(byteOffset, true);
-      this.offsetMap[idx] = {
-        byteOffset: byteOffset + 4, // itemの開始offsetが欲しいのでrowLength分は飛ばす
-        length: rowLength,
-      };
+      this.rowOffsets[idx * 2] = byteOffset + 4; // itemの開始offsetが欲しいのでrowLength分は飛ばす
+      this.rowOffsets[idx * 2 + 1] = rowLength;
 
       // 次のrowLengthのoffsetにセットしておく
       byteOffset += 4 + ITEM_BYTE_LENGTH * rowLength;
@@ -139,31 +145,39 @@ export class BLATableView {
    * 指定した位置のBLAItemが格納されているbyteOffsetを返す
    */
   getBLAItemOffset(rowIdx: number, columnIdx: number) {
-    const { byteOffset, length } = this.offsetMap[rowIdx];
-    if (columnIdx > length)
-      throw new Error(`Invalid offset specified: row: ${rowIdx}, ${columnIdx} > ${length}`);
-
-    return byteOffset + columnIdx * ITEM_BYTE_LENGTH;
+    return this.rowOffsets[rowIdx * 2] + columnIdx * ITEM_BYTE_LENGTH;
   }
 
+  /**
+   * 指定した位置のrを返す
+   */
   getR(rowIdx: number, columnIdx: number) {
-    const byteOffset = this.getBLAItemOffset(rowIdx, columnIdx);
+    const byteOffset = this.rowOffsets[rowIdx * 2] + columnIdx * ITEM_BYTE_LENGTH;
     return this.view.getFloat64(byteOffset + 32, true);
   }
 
+  /**
+   * 指定した位置のlを返す
+   */
   getL(rowIdx: number, columnIdx: number) {
-    const byteOffset = this.getBLAItemOffset(rowIdx, columnIdx);
-    return this.view.getInt32(byteOffset + 40, true); // l
+    const byteOffset = this.rowOffsets[rowIdx * 2] + columnIdx * ITEM_BYTE_LENGTH;
+    return this.view.getInt32(byteOffset + 40, true);
   }
 
-  getAB(rowIdx: number, columnIdx: number) {
-    const byteOffset = this.getBLAItemOffset(rowIdx, columnIdx);
+  /**
+   * 指定した位置のa, bの値をabBufferに書き込んで返す。
+   * abBuffer[0]=aRe, [1]=aIm, [2]=bRe, [3]=bIm
+   * 呼び出し側は次のgetAB呼び出し前に値を使い切ること。
+   */
+  getAB(rowIdx: number, columnIdx: number): Float64Array {
+    const byteOffset = this.rowOffsets[rowIdx * 2] + columnIdx * ITEM_BYTE_LENGTH;
+    const buf = this.abBuffer;
 
-    const aRe = this.view.getFloat64(byteOffset, true);
-    const aIm = this.view.getFloat64(byteOffset + 8, true);
-    const bRe = this.view.getFloat64(byteOffset + 16, true);
-    const bIm = this.view.getFloat64(byteOffset + 24, true);
+    buf[0] = this.view.getFloat64(byteOffset, true);
+    buf[1] = this.view.getFloat64(byteOffset + 8, true);
+    buf[2] = this.view.getFloat64(byteOffset + 16, true);
+    buf[3] = this.view.getFloat64(byteOffset + 24, true);
 
-    return { aRe, aIm, bRe, bIm };
+    return buf;
   }
 }

--- a/src/workers/mandelbrot-perturbation-worker.ts
+++ b/src/workers/mandelbrot-perturbation-worker.ts
@@ -67,6 +67,7 @@ const calcHandler = (data: IterationWorkerParams) => {
   ): number {
     const { xnView, blaTableView } = context;
     const maxRefIteration = xnView.length - 1;
+    const blaRows = blaTableView.length;
 
     // Δn
     let deltaNRe = 0.0;
@@ -104,15 +105,16 @@ const calcHandler = (data: IterationWorkerParams) => {
       const absDz = Math.sqrt(dzNorm);
 
       // BLA
-      let blaRowIdx = null;
-      let blaColumnIdx = null;
+      let blaRowIdx = -1;
+      let blaColumnIdx = -1;
 
       // refIteration === (jIdx << d) + 1と|dz| < rを満たす、最大のlを持つデータをblaTableから探す
       if (0 < refIteration) {
-        for (let d = startBLAIndex; d < blaTableView.length; d++) {
+        const refM1 = refIteration - 1;
+        for (let d = startBLAIndex; d < blaRows; d++) {
           // この辺まだよく分かっていない
-          const jIdx = Math.floor((refIteration - 1) / 2 ** d);
-          const checkM = jIdx * 2 ** d + 1;
+          const jIdx = refM1 >> d;
+          const checkM = (jIdx << d) + 1;
 
           const isValid = absDz < blaTableView.getR(d, jIdx);
 
@@ -125,13 +127,13 @@ const calcHandler = (data: IterationWorkerParams) => {
         }
       }
 
-      const hasBLA = blaRowIdx != null && blaColumnIdx != null;
+      const hasBLA = blaRowIdx >= 0;
 
-      const skipped = hasBLA ? blaTableView.getL(blaRowIdx!, blaColumnIdx!) : 0;
+      const skipped = hasBLA ? blaTableView.getL(blaRowIdx, blaColumnIdx) : 0;
       const n = refIteration + skipped;
 
       if (hasBLA && n < maxRefIteration) {
-        const ab = blaTableView.getAB(blaRowIdx!, blaColumnIdx!);
+        const ab = blaTableView.getAB(blaRowIdx, blaColumnIdx);
 
         const dzRe =
           mulRe(ab[0], ab[1], deltaNRe, deltaNIm) + mulRe(ab[2], ab[3], deltaC.re, deltaC.im);

--- a/src/workers/mandelbrot-perturbation-worker.ts
+++ b/src/workers/mandelbrot-perturbation-worker.ts
@@ -131,10 +131,12 @@ const calcHandler = (data: IterationWorkerParams) => {
       const n = refIteration + skipped;
 
       if (hasBLA && n < maxRefIteration) {
-        const { aRe, aIm, bRe, bIm } = blaTableView.getAB(blaRowIdx!, blaColumnIdx!);
+        const ab = blaTableView.getAB(blaRowIdx!, blaColumnIdx!);
 
-        const dzRe = mulRe(aRe, aIm, deltaNRe, deltaNIm) + mulRe(bRe, bIm, deltaC.re, deltaC.im);
-        const dzIm = mulIm(aRe, aIm, deltaNRe, deltaNIm) + mulIm(bRe, bIm, deltaC.re, deltaC.im);
+        const dzRe =
+          mulRe(ab[0], ab[1], deltaNRe, deltaNIm) + mulRe(ab[2], ab[3], deltaC.re, deltaC.im);
+        const dzIm =
+          mulIm(ab[0], ab[1], deltaNRe, deltaNIm) + mulIm(ab[2], ab[3], deltaC.re, deltaC.im);
 
         deltaNRe = dzRe;
         deltaNIm = dzIm;


### PR DESCRIPTION
## Screenshot

|before|after|
|----|----|
|[![Image from Gyazo](https://i.gyazo.com/bfd526aed17ba34376f581312f62ab57.png)](https://gyazo.com/bfd526aed17ba34376f581312f62ab57)|[![Image from Gyazo](https://i.gyazo.com/cf62aa6e3ad99ad19ea117908d7095ea.png)](https://gyazo.com/cf62aa6e3ad99ad19ea117908d7095ea)|

だいたい2倍！

## Summary
- blaTableのview周りのちょっとした最適化
   - アロケーション減らしたが、縮んだのは20msくらい
- iteration workerのループ部分の最適化
   - `number | null` はV8の最適化効きにくいとのことなのでやめたら2.0~2.5倍速になった
   - あとはビットシフトで良いところをビットシフトに変える