### PR TITLE
モバイル対応

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "react-dom": "19.2.4",
     "sonner": "2.0.7",
     "tailwind-merge": "3.5.0",
-    "typegpu": "0.10.2"
+    "typegpu": "0.10.2",
+    "vaul": "1.1.2"
   },
   "devDependencies": {
     "@radix-ui/colors": "3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ importers:
       typegpu:
         specifier: 0.10.2
         version: 0.10.2
+      vaul:
+        specifier: 1.1.2
+        version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     devDependencies:
       '@radix-ui/colors':
         specifier: 3.0.0
@@ -2165,6 +2168,12 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  vaul@1.1.2:
+    resolution: {integrity: sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+
   vite@8.0.1:
     resolution: {integrity: sha512-wt+Z2qIhfFt85uiyRt5LPU4oVEJBXj8hZNWKeqFG4gRG/0RaRGJ7njQCwzFVjO+v4+Ipmf5CY7VdmZRAYYBPHw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -4061,6 +4070,15 @@ snapshots:
   use-sync-external-store@1.6.0(react@19.2.4):
     dependencies:
       react: 19.2.4
+
+  vaul@1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
 
   vite@8.0.1(@types/node@22.16.4)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.4.2):
     dependencies:

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -85,7 +85,7 @@ export const en = {
   "footer.elapsedPrefix": "elapsed: ",
 
   // bump
-  "bump.increaseN": "Increase N by 30%",
+  "bump.increaseN": "Increase max iteration",
 
   // instructions
   "instructions.mouse": "Mouse",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -82,6 +82,7 @@ export const en = {
   "footer.invalidResult": "Invalid Result",
   "footer.calcRefOrbit": "Calculate Reference Orbit",
   "footer.calcIteration": "Calculate Iteration",
+  "footer.elapsedPrefix": "elapsed: ",
 
   // instructions
   "instructions.mouse": "Mouse",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -85,7 +85,7 @@ export const en = {
   "footer.elapsedPrefix": "elapsed: ",
 
   // bump
-  "bump.lowN": "Low N",
+  "bump.increaseN": "Increase N by 30%",
 
   // instructions
   "instructions.mouse": "Mouse",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -120,6 +120,19 @@ export const en = {
   "settings.generate": "Generate",
   "settings.useWasm": "Use Wasm for reference orbit",
   "settings.useWasmTooltip": "Approximately 10x faster. Recommended to keep ON.",
+  // dialog descriptions (a11y用、視覚的には非表示)
+  "dialog.description.share": "Share current view by URL",
+  "dialog.description.jump": "Jump to specified coordinates",
+  "dialog.description.settings": "Application settings",
+  "dialog.description.instructions": "Usage instructions",
+  "dialog.description.minimap": "Overview map of saved POIs",
+  "dialog.description.presetList": "Preset POI list",
+  "dialog.description.poiPanel": "Saved Points of Interest",
+  "dialog.description.supersampling": "Supersampling settings",
+  "dialog.description.benchmark": "Benchmark progress",
+  "dialog.description.poiExport": "Export saved POIs",
+  "dialog.description.poiImport": "Import POIs from text",
+
   // debug mode
   "debug.alwaysComputeDebugData": "Always compute debug data",
   "debug.alwaysComputeTooltip1": "Computes debug data even when this tab is closed.",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -92,7 +92,6 @@ export const en = {
   "instructions.changeCenter": "Change center",
   "instructions.interactiveZoom": "Interactive zoom and change center",
   "instructions.changePalette": "Change Palette",
-  "instructions.toggleMode": "Toggle mode",
   "instructions.resetR": "Reset r to 2.0",
   "instructions.supersampling": "Supersampling(x2) current location",
   "instructions.changeMaxIteration": "Change max iteration (±100)",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -84,6 +84,9 @@ export const en = {
   "footer.calcIteration": "Calculate Iteration",
   "footer.elapsedPrefix": "elapsed: ",
 
+  // bump
+  "bump.lowN": "Low N",
+
   // instructions
   "instructions.mouse": "Mouse",
   "instructions.keys": "Keys",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -122,6 +122,8 @@ export const en = {
   "settings.useWasmTooltip": "Approximately 10x faster. Recommended to keep ON.",
   // supersampling
   "supersampling.result": "Supersampling Result",
+  "supersampling.actualSize": "Actual Size",
+  "supersampling.fitToScreen": "Fit to Screen",
 
   // dialog descriptions (a11y用、視覚的には非表示)
   "dialog.description.share": "Share current view by URL",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -120,6 +120,9 @@ export const en = {
   "settings.generate": "Generate",
   "settings.useWasm": "Use Wasm for reference orbit",
   "settings.useWasmTooltip": "Approximately 10x faster. Recommended to keep ON.",
+  // supersampling
+  "supersampling.result": "Supersampling Result",
+
   // dialog descriptions (a11y用、視覚的には非表示)
   "dialog.description.share": "Share current view by URL",
   "dialog.description.jump": "Jump to specified coordinates",

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -123,6 +123,8 @@ export const ja: Dictionary = {
 
   // supersampling
   "supersampling.result": "Supersamplingの結果",
+  "supersampling.actualSize": "元のサイズで表示",
+  "supersampling.fitToScreen": "ウィンドウに合わせる",
 
   // dialog descriptions (a11y用、視覚的には非表示)
   "dialog.description.share": "現在の表示をURLで共有",

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -121,6 +121,19 @@ export const ja: Dictionary = {
   "settings.useWasm": "Reference Orbit計算にWasmを使用",
   "settings.useWasmTooltip": "10倍ほど高速になるのでON推奨",
 
+  // dialog descriptions (a11y用、視覚的には非表示)
+  "dialog.description.share": "現在の表示をURLで共有",
+  "dialog.description.jump": "指定した座標にジャンプ",
+  "dialog.description.settings": "アプリケーション設定",
+  "dialog.description.instructions": "操作方法の説明",
+  "dialog.description.minimap": "保存したPOIの全体マップ",
+  "dialog.description.presetList": "プリセットPOI一覧",
+  "dialog.description.poiPanel": "保存したPOI",
+  "dialog.description.supersampling": "スーパーサンプリング設定",
+  "dialog.description.benchmark": "ベンチマーク進行状況",
+  "dialog.description.poiExport": "保存したPOIをエクスポート",
+  "dialog.description.poiImport": "テキストからPOIをインポート",
+
   // debug mode
   "debug.alwaysComputeDebugData": "常にデバッグデータを計算",
   "debug.alwaysComputeTooltip1": "このタブが閉じていてもデバッグデータを計算します。",

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -84,6 +84,9 @@ export const ja: Dictionary = {
   "footer.calcIteration": "Iteration",
   "footer.elapsedPrefix": "処理時間: ",
 
+  // bump
+  "bump.lowN": "N不足",
+
   // instructions
   "instructions.mouse": "マウス",
   "instructions.keys": "キー",

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -124,7 +124,7 @@ export const ja: Dictionary = {
   // supersampling
   "supersampling.result": "Supersamplingの結果",
   "supersampling.actualSize": "元のサイズで表示",
-  "supersampling.fitToScreen": "ウィンドウに合わせる",
+  "supersampling.fitToScreen": "全体表示",
 
   // dialog descriptions (a11y用、視覚的には非表示)
   "dialog.description.share": "現在の表示をURLで共有",

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -92,7 +92,6 @@ export const ja: Dictionary = {
   "instructions.changeCenter": "ドラッグで中心を移動",
   "instructions.interactiveZoom": "ドラッグ開始点を中心に動的なズーム",
   "instructions.changePalette": "パレット変更",
-  "instructions.toggleMode": "モード切替",
   "instructions.resetR": "r を 2.0 にリセット",
   "instructions.supersampling": "現在位置をスーパーサンプリング(x2)",
   "instructions.changeMaxIteration": "最大iterationを変更 (±100)",

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -82,6 +82,7 @@ export const ja: Dictionary = {
   "footer.invalidResult": "無効な結果",
   "footer.calcRefOrbit": "参照軌道の計算",
   "footer.calcIteration": "Iteration",
+  "footer.elapsedPrefix": "処理時間: ",
 
   // instructions
   "instructions.mouse": "マウス",

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -85,7 +85,7 @@ export const ja: Dictionary = {
   "footer.elapsedPrefix": "処理時間: ",
 
   // bump
-  "bump.increaseN": "Nを30%増やす",
+  "bump.increaseN": "最大反復数を増やす",
 
   // instructions
   "instructions.mouse": "マウス",

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -121,6 +121,9 @@ export const ja: Dictionary = {
   "settings.useWasm": "Reference Orbit計算にWasmを使用",
   "settings.useWasmTooltip": "10倍ほど高速になるのでON推奨",
 
+  // supersampling
+  "supersampling.result": "Supersamplingの結果",
+
   // dialog descriptions (a11y用、視覚的には非表示)
   "dialog.description.share": "現在の表示をURLで共有",
   "dialog.description.jump": "指定した座標にジャンプ",

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -85,7 +85,7 @@ export const ja: Dictionary = {
   "footer.elapsedPrefix": "処理時間: ",
 
   // bump
-  "bump.lowN": "N不足",
+  "bump.increaseN": "Nを30%増やす",
 
   // instructions
   "instructions.mouse": "マウス",

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -123,8 +123,8 @@ export const ja: Dictionary = {
 
   // supersampling
   "supersampling.result": "Supersamplingの結果",
-  "supersampling.actualSize": "元のサイズで表示",
-  "supersampling.fitToScreen": "全体表示",
+  "supersampling.actualSize": "原寸で表示",
+  "supersampling.fitToScreen": "全体を表示",
 
   // dialog descriptions (a11y用、視覚的には非表示)
   "dialog.description.share": "現在の表示をURLで共有",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,6 +10,7 @@ import {
   p5Setup,
   zoomTo,
 } from "./p5-adapter/p5-adapter";
+import { onP5TouchEnded, onP5TouchMoved, onP5TouchStarted } from "./p5-adapter/touch-handler";
 import { isInside, isOnUIOverlay } from "./p5-adapter/utils";
 import { createStore, getStore, updateStore } from "./store/store";
 import { readPOIListFromStorage } from "./store/sync-storage/poi-list";
@@ -57,6 +58,10 @@ const sketch = (p: p5) => {
 
     zoomTo(event.deltaY > 0);
   };
+
+  p.touchStarted = (ev: TouchEvent | undefined) => onP5TouchStarted(p, ev);
+  p.touchMoved = (ev: TouchEvent | undefined) => onP5TouchMoved(p, ev);
+  p.touchEnded = (ev: TouchEvent | undefined) => onP5TouchEnded(p, ev);
 
   p.keyPressed = (event: KeyboardEvent | undefined) => {
     if (getStore("canvasLocked")) return;

--- a/src/mandelbrot-state/auto-iteration.ts
+++ b/src/mandelbrot-state/auto-iteration.ts
@@ -81,11 +81,11 @@ const calcForZoomIn = (
     suggestedN = currentN;
   } else if (maxedRatio <= 0.6) {
     if (highestNonMaxed > 0) {
-      suggestedN = Math.max(currentN, highestNonMaxed * 2);
+      suggestedN = Math.max(currentN, Math.ceil(highestNonMaxed * 1.5));
     }
   } else if (maxedRatio < 1.0) {
     if (highestNonMaxed > 10) {
-      suggestedN = Math.max(currentN, Math.ceil(highestNonMaxed * 1.5));
+      suggestedN = Math.max(currentN, Math.ceil(highestNonMaxed * 1.3));
     }
   } else {
     // 狭域の全サンプルがmaxed: 広域サンプルで境界付近か判定

--- a/src/mandelbrot-state/auto-iteration.ts
+++ b/src/mandelbrot-state/auto-iteration.ts
@@ -5,6 +5,9 @@ const AUTO_N_SCALE_FACTOR = 50;
 const DEFAULT_N = 500;
 const GRID_SIZE = 16;
 
+/** currentNがこの値以上のときに増加率を緩やかにする */
+const GENTLE_GROWTH_THRESHOLD = 100_000;
+
 /**
  * ズーム操作時に適切なNを計算する
  *
@@ -77,15 +80,19 @@ const calcForZoomIn = (
 
   let suggestedN = currentN;
 
+  const isGentle = currentN >= GENTLE_GROWTH_THRESHOLD;
+  const midRatioMul = isGentle ? 1.5 : 2;
+  const highRatioMul = isGentle ? 1.3 : 1.5;
+
   if (maxedRatio < 0.05) {
     suggestedN = currentN;
   } else if (maxedRatio <= 0.6) {
     if (highestNonMaxed > 0) {
-      suggestedN = Math.max(currentN, Math.ceil(highestNonMaxed * 1.5));
+      suggestedN = Math.max(currentN, Math.ceil(highestNonMaxed * midRatioMul));
     }
   } else if (maxedRatio < 1.0) {
     if (highestNonMaxed > 10) {
-      suggestedN = Math.max(currentN, Math.ceil(highestNonMaxed * 1.3));
+      suggestedN = Math.max(currentN, Math.ceil(highestNonMaxed * highRatioMul));
     }
   } else {
     // 狭域の全サンプルがmaxed: 広域サンプルで境界付近か判定

--- a/src/mandelbrot-state/mandelbrot-state.ts
+++ b/src/mandelbrot-state/mandelbrot-state.ts
@@ -1,9 +1,18 @@
 import { getCanvasSize } from "@/rendering/renderer";
 import { getStore, updateStore } from "@/store/store";
-import type { MandelbrotParams, OffsetParams } from "@/types";
+import type { MandelbrotParams, MandelbrotWorkerType, OffsetParams } from "@/types";
+import { PERTURBATION_THRESHOLD } from "@/utils/palette-encoding";
 import { prepareWorkerPool } from "@/worker-pool/pool-instance";
-import { cycleWorkerType } from "@/worker-pool/worker-pool";
 import BigNumber from "bignumber.js";
+
+/**
+ * r に応じて最適な worker mode を決定する
+ *
+ * r が double precision の実用閾値 (PERTURBATION_THRESHOLD) を下回ると
+ * normal では解像度不足でぼやけるため、自動的にperturbationを選ぶ。
+ */
+const modeForR = (r: BigNumber): MandelbrotWorkerType =>
+  r.isLessThan(PERTURBATION_THRESHOLD) ? "perturbation" : "normal";
 
 const DEFAULT_N = 500;
 
@@ -76,10 +85,14 @@ const isSameParams = (a: MandelbrotParams, b: MandelbrotParams) =>
   a.isSuperSampling === b.isSuperSampling;
 
 export const setCurrentParams = (params: Partial<MandelbrotParams>) => {
-  const needModeChange = params.mode != null && currentParams.mode !== params.mode;
   const needResetOffset = params.r != null && !currentParams.r.eq(params.r);
 
-  currentParams = { ...currentParams, ...params };
+  const merged = { ...currentParams, ...params };
+  // modeは常に r から自動決定 (呼び出し側からのmode指定は無視)
+  merged.mode = modeForR(merged.r);
+  const needModeChange = currentParams.mode !== merged.mode;
+
+  currentParams = merged;
 
   updateStore("r", currentParams.r);
   updateStore("N", currentParams.N);
@@ -142,12 +155,6 @@ export const setDeepIterationCount = () => {
 };
 
 export const resetRadius = () => setCurrentParams({ r: new BigNumber("2.0") });
-
-export const cycleMode = () => {
-  const mode = cycleWorkerType();
-  setCurrentParams({ mode });
-  setOffsetParams({ x: 0, y: 0 });
-};
 
 export const radiusTimesTo = (times: number) => {
   if (1 < times && currentParams.r.times(times).gte(5)) {

--- a/src/p5-adapter/p5-adapter.ts
+++ b/src/p5-adapter/p5-adapter.ts
@@ -54,6 +54,7 @@ import { extractMandelbrotParams } from "@/utils/mandelbrot-url-params";
 import { getProgressData } from "@/worker-pool/worker-pool";
 import BigNumber from "bignumber.js";
 import type p5 from "p5";
+import { disableCanvasTouchAction } from "./touch-handler";
 import { isInside } from "./utils";
 
 // p5.jsのcanvas操作状態を管理したりcallbackを定義しておくファイル
@@ -76,7 +77,9 @@ let pendingCanvasImageHeight = 0;
  */
 let isTranslatingMainBuffer = false;
 /** どのドラッグ操作をしているか */
-let draggingMode: "move" | "zoom" | undefined = undefined;
+let draggingMode: "move" | "zoom" | "pinch" | undefined = undefined;
+/** ピンチ操作中のscaleFactor */
+let pinchScaleFactor = 1;
 /** 前回処理からの累計時間 (palette animation用) */
 let elapsed = 0;
 /** canvas内でマウスクリックが開始されたかどうか */
@@ -314,6 +317,42 @@ export const changeDraggingState = (state: "move" | "zoom", p: p5) => {
 };
 
 /**
+ * ピンチ操作開始時の状態をセットアップする
+ *
+ * 以降の描画でキャンバス中心を基準にpinchScaleFactor倍の拡縮プレビューが走る。
+ */
+export const startPinchGesture = (p: p5) => {
+  cancelInterestingPointsComputation();
+  currentInterestingPoints = [];
+
+  mouseClickedOn = { mouseX: p.width / 2, mouseY: p.height / 2 };
+  mouseClickStartedInside = true;
+  mouseDragged = true;
+  draggingMode = "pinch";
+  pinchScaleFactor = 1;
+  isTranslatingMainBuffer = true;
+};
+
+/**
+ * ピンチ操作中のscaleFactorを更新する
+ */
+export const updatePinchGesture = (scaleFactor: number) => {
+  pinchScaleFactor = scaleFactor;
+};
+
+/**
+ * ピンチ操作終了時に現在のscaleFactorで拡縮を確定する
+ */
+export const confirmPinchGesture = (p: p5) => {
+  if (draggingMode === "pinch") {
+    scaleTo(pinchScaleFactor, { x: mouseClickedOn.mouseX, y: mouseClickedOn.mouseY });
+  }
+  changeCursor(p, p.CROSS);
+  changeToMouseReleasedState();
+  pinchScaleFactor = 1;
+};
+
+/**
  * ドラッグした分だけ位置を移動する
  */
 export const moveTo = (dragOffset: { pixelDiffX: number; pixelDiffY: number }) => {
@@ -431,6 +470,8 @@ export const p5Setup = async (p: p5) => {
   const canvas = p.createCanvas(width, height);
   // canvas上での右クリックを無効化
   canvas.elt.addEventListener("contextmenu", (e: Event) => e.preventDefault());
+  // ブラウザ標準のピンチズーム/スクロールを抑止 (タッチ操作は p.touchStarted 等で処理)
+  disableCanvasTouchAction(canvas.elt as HTMLCanvasElement);
   resetScaleParams();
 
   p.colorMode(p.HSB, 360, 100, 100, 100);
@@ -682,11 +723,12 @@ export const p5Draw = (p: p5) => {
       x = pixelDiffX;
       y = pixelDiffY;
       lastTranslationOffset = { x, y, width: undefined, height: undefined };
-    } else if (draggingMode === "zoom") {
+    } else if (draggingMode === "zoom" || draggingMode === "pinch") {
       const { mouseX, mouseY } = mouseClickedOn;
-      scaleFactor = calcInteractiveScaleFactor(p, mouseClickedOn);
+      scaleFactor =
+        draggingMode === "pinch" ? pinchScaleFactor : calcInteractiveScaleFactor(p, mouseClickedOn);
 
-      // クリック位置を画面の中心に置く
+      // 基準位置を画面の中心に置く (zoom: クリック位置, pinch: キャンバス中心)
       const offsetX = p.width / 2 - mouseX * scaleFactor;
       const offsetY = p.height / 2 - mouseY * scaleFactor;
 

--- a/src/p5-adapter/p5-adapter.ts
+++ b/src/p5-adapter/p5-adapter.ts
@@ -335,15 +335,27 @@ export const startPinchGesture = (p: p5) => {
 };
 
 /**
+ * ピンチ距離比 r を scaleFactor にマッピングする
+ *
+ * - 1 ≤ r ≤ 2 : 線形で zoomRate 倍まで到達 (微調整しやすいレンジ)
+ * - r > 2     : tanh で 2*zoomRate に漸近 (行き過ぎ防止)
+ * - r < 1     : 1/r を同じ関数に通し逆数を取る (縮小側は対称)
+ */
+const pinchScaleFromRatio = (r: number, zoomRate: number): number => {
+  if (r < 1) return 1 / pinchScaleFromRatio(1 / r, zoomRate);
+  if (r <= 2) return 1 + (zoomRate - 1) * (r - 1);
+  return zoomRate + zoomRate * Math.tanh(r - 2);
+};
+
+/**
  * ピンチ操作中のscaleFactorを更新する
  *
- * 指間距離比 (現在距離 / 開始距離) を受け取り、設定の zoomRate を指数的に反映する。
- * r=2 で zoomRate倍、r=0.5 で 1/zoomRate倍 となるようマッピングする
- * (PC右クリックドラッグの calcInteractiveScaleFactor と同等の感覚)。
+ * 指間距離比 (現在距離 / 開始距離) を受け取り、設定 zoomRate に応じた倍率を計算する。
+ * マッピング詳細は pinchScaleFromRatio を参照。
  */
 export const updatePinchGesture = (distanceRatio: number) => {
   const zoomRate = getStore("zoomRate");
-  pinchScaleFactor = Math.pow(zoomRate, Math.log2(distanceRatio));
+  pinchScaleFactor = pinchScaleFromRatio(distanceRatio, zoomRate);
 };
 
 /**

--- a/src/p5-adapter/p5-adapter.ts
+++ b/src/p5-adapter/p5-adapter.ts
@@ -336,9 +336,14 @@ export const startPinchGesture = (p: p5) => {
 
 /**
  * ピンチ操作中のscaleFactorを更新する
+ *
+ * 指間距離比 (現在距離 / 開始距離) を受け取り、設定の zoomRate を指数的に反映する。
+ * r=2 で zoomRate倍、r=0.5 で 1/zoomRate倍 となるようマッピングする
+ * (PC右クリックドラッグの calcInteractiveScaleFactor と同等の感覚)。
  */
-export const updatePinchGesture = (scaleFactor: number) => {
-  pinchScaleFactor = scaleFactor;
+export const updatePinchGesture = (distanceRatio: number) => {
+  const zoomRate = getStore("zoomRate");
+  pinchScaleFactor = Math.pow(zoomRate, Math.log2(distanceRatio));
 };
 
 /**
@@ -769,6 +774,9 @@ export const p5Draw = (p: p5) => {
       break;
     case "zoom":
       drawUIScaleRate(p, scaleFactor);
+      break;
+    case "pinch":
+      drawUIScaleRate(p, scaleFactor, "top-center");
       break;
   }
 

--- a/src/p5-adapter/p5-adapter.ts
+++ b/src/p5-adapter/p5-adapter.ts
@@ -54,6 +54,7 @@ import { extractMandelbrotParams } from "@/utils/mandelbrot-url-params";
 import { getProgressData } from "@/worker-pool/worker-pool";
 import BigNumber from "bignumber.js";
 import type p5 from "p5";
+import { isMobileViewport } from "@/view/use-is-mobile";
 import { disableCanvasTouchAction } from "./touch-handler";
 import { isInside } from "./utils";
 
@@ -666,7 +667,9 @@ export const keyInputHandler = (event: KeyboardEvent) => {
  * 機能が無効またはキャッシュが不十分な場合はポイントをクリアする。
  */
 const scheduleInterestingPointsDetection = (): void => {
-  if (!getStore("showInterestingPoints") && !getStore("alwaysComputeIPDebugData")) {
+  // モバイルではタップズームに統一しmarkerは常に非表示。計算も走らせない (debugモードは除く)
+  const showMarkers = !isMobileViewport() && getStore("showInterestingPoints");
+  if (!showMarkers && !getStore("alwaysComputeIPDebugData")) {
     currentInterestingPoints = [];
     return;
   }
@@ -774,7 +777,7 @@ export const p5Draw = (p: p5) => {
 
   drawUICurrentParams(p, getCurrentParams(), getAutoIterationEnabled());
   drawUIIterationAtCursor(p, getStore("iteration"));
-  if (getStore("showInterestingPoints")) {
+  if (getStore("showInterestingPoints") && !isMobileViewport()) {
     const hoveredPoint =
       draggingMode === undefined
         ? findHitInterestingPoint(p.mouseX, p.mouseY, currentInterestingPoints)

--- a/src/p5-adapter/p5-adapter.ts
+++ b/src/p5-adapter/p5-adapter.ts
@@ -50,7 +50,7 @@ import { getCanvasSize, initRenderer, renderToCanvas, resizeCanvas } from "@/ren
 import { getStore, updateStore } from "@/store/store";
 import type { MandelbrotParams } from "@/types";
 import { extractMandelbrotParams } from "@/utils/mandelbrot-url-params";
-import { getProgressData } from "@/worker-pool/worker-pool";
+import { getNHitRatio, getProgressData } from "@/worker-pool/worker-pool";
 import BigNumber from "bignumber.js";
 import type p5 from "p5";
 import { isMobileViewport } from "@/view/use-is-mobile";
@@ -160,6 +160,7 @@ const syncStoreValues = (p: p5) => {
   }
 
   updateStore("progress", progress);
+  updateStore("nHitRatio", getNHitRatio());
 };
 
 /**

--- a/src/p5-adapter/p5-adapter.ts
+++ b/src/p5-adapter/p5-adapter.ts
@@ -334,15 +334,18 @@ export const startPinchGesture = (p: p5) => {
   isTranslatingMainBuffer = true;
 };
 
+/** 縮小側の最小スケール (r=0で到達) */
+const MIN_PINCH_SCALE = 0.01;
+
 /**
  * ピンチ距離比 r を scaleFactor にマッピングする
  *
  * - 1 ≤ r ≤ 2 : 線形で zoomRate 倍まで到達 (微調整しやすいレンジ)
  * - r > 2     : tanh で 2*zoomRate に漸近 (行き過ぎ防止)
- * - r < 1     : 1/r を同じ関数に通し逆数を取る (縮小側は対称)
+ * - r < 1     : 線形で r=0 → MIN_PINCH_SCALE まで下がる
  */
 const pinchScaleFromRatio = (r: number, zoomRate: number): number => {
-  if (r < 1) return 1 / pinchScaleFromRatio(1 / r, zoomRate);
+  if (r < 1) return Math.max(MIN_PINCH_SCALE, MIN_PINCH_SCALE + (1 - MIN_PINCH_SCALE) * r);
   if (r <= 2) return 1 + (zoomRate - 1) * (r - 1);
   return zoomRate + zoomRate * Math.tanh(r - 2);
 };

--- a/src/p5-adapter/p5-adapter.ts
+++ b/src/p5-adapter/p5-adapter.ts
@@ -12,7 +12,6 @@ import {
 import { startCalculation } from "@/mandelbrot";
 import { calcAutoN } from "@/mandelbrot-state/auto-iteration";
 import {
-  cycleMode,
   getAutoIterationEnabled,
   getCurrentParams,
   getManualN,
@@ -643,7 +642,6 @@ export const keyInputHandler = (event: KeyboardEvent) => {
   if (event.key === "0") resetIterationCount();
   if (event.key === "9") setDeepIterationCount();
   if (event.key === "r") resetRadius();
-  if (event.key === "m") cycleMode();
   if (event.key === "ArrowDown") {
     const { width, height } = getCanvasSize();
     applyAutoIteration(width / 2, height / 2, 1 / rate, width, height);

--- a/src/p5-adapter/touch-handler.ts
+++ b/src/p5-adapter/touch-handler.ts
@@ -30,6 +30,13 @@ let singleTouchMoved = false;
  * このフラグで識別する (= UI上のタップで synthesized click が潰れるのを防ぐ)。
  */
 let gestureActive = false;
+/**
+ * このジェスチャ中に一度でもピンチが発生したか
+ *
+ * ピンチ後に最後の指が離れる touchEnded で tap/swipe 扱いの zoomTo/moveTo が
+ * 誤発火しないよう抑止するために使う。
+ */
+let pinchOccurredInThisGesture = false;
 
 /**
  * 2本指のclient座標間距離を計算
@@ -75,6 +82,7 @@ export const onP5TouchStarted = (p: p5, ev: TouchEvent | undefined): boolean => 
 
   if (ev.touches.length >= 2) {
     pinchStartDistance = pinchDistance(ev);
+    pinchOccurredInThisGesture = true;
     startPinchGesture(p);
   } else if (ev.touches.length === 1) {
     const pos = getCanvasLocalTouch(p, 0);
@@ -136,22 +144,28 @@ export const onP5TouchEnded = (p: p5, ev: TouchEvent | undefined): boolean => {
     pinchStartDistance = null;
     singleTouchStart = null;
     singleTouchMoved = false;
-    if (ev.touches.length === 0) gestureActive = false;
+    if (ev.touches.length === 0) {
+      gestureActive = false;
+      pinchOccurredInThisGesture = false;
+    }
     return false;
   }
 
   if (ev.touches.length === 0) {
-    if (singleTouchMoved) {
-      // スワイプ確定 → 既存mouseReleasedでmoveTo
-      p5MouseReleased(p, new MouseEvent("mouseup"));
-    } else {
-      // タップ → 画面中央を基準にズームイン (タップ位置では動かさない)
-      zoomTo(false);
-      changeToMouseReleasedState();
+    if (!pinchOccurredInThisGesture) {
+      if (singleTouchMoved) {
+        // スワイプ確定 → 既存mouseReleasedでmoveTo
+        p5MouseReleased(p, new MouseEvent("mouseup"));
+      } else {
+        // タップ → 画面中央を基準にズームイン (タップ位置では動かさない)
+        zoomTo(false);
+        changeToMouseReleasedState();
+      }
     }
     singleTouchStart = null;
     singleTouchMoved = false;
     gestureActive = false;
+    pinchOccurredInThisGesture = false;
   }
 
   return false;

--- a/src/p5-adapter/touch-handler.ts
+++ b/src/p5-adapter/touch-handler.ts
@@ -1,10 +1,8 @@
 import { getStore } from "@/store/store";
-import { isMobileViewport } from "@/view/use-is-mobile";
 import type p5 from "p5";
 import {
   changeDraggingState,
   changeToMousePressedState,
-  changeToMouseReleasedState,
   confirmPinchGesture,
   p5MouseReleased,
   startPinchGesture,
@@ -141,16 +139,10 @@ export const onP5TouchEnded = (p: p5, ev: TouchEvent | undefined): boolean => {
   }
 
   if (ev.touches.length === 0) {
-    if (singleTouchMoved) {
-      // スワイプ確定 → 既存のmouseReleasedフローへ
-      p5MouseReleased(p, new MouseEvent("mouseup"));
-    } else if (!isMobileViewport()) {
-      // デスクトップ幅でのタップ: 既存のclick→zoomを発火
-      p5MouseReleased(p, new MouseEvent("mouseup"));
-    } else {
-      // モバイル幅でのタップ: ズームせず状態だけリセット
-      changeToMouseReleasedState();
-    }
+    // スワイプ確定 (移動あり) / タップ (移動なし) どちらも既存mouseReleasedに委譲:
+    //   - 移動あり: moveTo でパン確定
+    //   - 移動なし: タップ位置を中心にscaleTo (ピンチ以外の拡大手段)
+    p5MouseReleased(p, new MouseEvent("mouseup"));
     singleTouchStart = null;
     singleTouchMoved = false;
     gestureActive = false;

--- a/src/p5-adapter/touch-handler.ts
+++ b/src/p5-adapter/touch-handler.ts
@@ -21,6 +21,15 @@ let pinchStartDistance: number | null = null;
 let singleTouchStart: { x: number; y: number } | null = null;
 /** 1本指タッチがしきい値を超えて移動したか */
 let singleTouchMoved = false;
+/**
+ * canvas向けのgesture処理中かどうか
+ *
+ * p5はtouchイベントをwindowにバインドするため、UI要素上のタッチでも
+ * 本ハンドラが呼ばれる。touchStartedでUI判定してgesture開始をスキップした
+ * 場合、後続のtouchMoved/touchEndedでもfalse返却でpreventDefaultしないよう
+ * このフラグで識別する (= UI上のタップで synthesized click が潰れるのを防ぐ)。
+ */
+let gestureActive = false;
 
 /**
  * 2本指のclient座標間距離を計算
@@ -68,6 +77,8 @@ export const onP5TouchStarted = (p: p5, ev: TouchEvent | undefined): boolean => 
   if (isOnUIOverlay(ev as unknown as MouseEvent)) return true;
   if (getStore("canvasLocked")) return false;
 
+  gestureActive = true;
+
   if (ev.touches.length >= 2) {
     pinchStartDistance = pinchDistance(ev);
     startPinchGesture(p);
@@ -89,6 +100,7 @@ export const onP5TouchStarted = (p: p5, ev: TouchEvent | undefined): boolean => 
  */
 export const onP5TouchMoved = (p: p5, ev: TouchEvent | undefined): boolean => {
   if (!ev) return true;
+  if (!gestureActive) return true;
   if (getStore("canvasLocked")) return false;
 
   if (pinchStartDistance !== null && ev.touches.length >= 2) {
@@ -122,6 +134,7 @@ export const onP5TouchMoved = (p: p5, ev: TouchEvent | undefined): boolean => {
  */
 export const onP5TouchEnded = (p: p5, ev: TouchEvent | undefined): boolean => {
   if (!ev) return true;
+  if (!gestureActive) return true;
   if (getStore("canvasLocked")) return false;
 
   if (pinchStartDistance !== null) {
@@ -129,6 +142,7 @@ export const onP5TouchEnded = (p: p5, ev: TouchEvent | undefined): boolean => {
     pinchStartDistance = null;
     singleTouchStart = null;
     singleTouchMoved = false;
+    if (ev.touches.length === 0) gestureActive = false;
     return false;
   }
 
@@ -145,6 +159,7 @@ export const onP5TouchEnded = (p: p5, ev: TouchEvent | undefined): boolean => {
     }
     singleTouchStart = null;
     singleTouchMoved = false;
+    gestureActive = false;
   }
 
   return false;

--- a/src/p5-adapter/touch-handler.ts
+++ b/src/p5-adapter/touch-handler.ts
@@ -1,5 +1,5 @@
 import { getStore } from "@/store/store";
-import { MOBILE_MAX_WIDTH } from "@/view/use-is-mobile";
+import { isMobileViewport } from "@/view/use-is-mobile";
 import type p5 from "p5";
 import {
   changeDraggingState,
@@ -50,12 +50,6 @@ const syncP5MousePos = (p: p5, x: number, y: number): void => {
   (p as unknown as { mouseX: number; mouseY: number }).mouseX = x;
   (p as unknown as { mouseX: number; mouseY: number }).mouseY = y;
 };
-
-/**
- * 現在のビューポートがモバイル幅かどうか
- */
-const isMobileViewport = (): boolean =>
-  window.matchMedia(`(max-width: ${MOBILE_MAX_WIDTH}px)`).matches;
 
 /**
  * p5のp.touches配列からcanvasローカル座標を取り出す

--- a/src/p5-adapter/touch-handler.ts
+++ b/src/p5-adapter/touch-handler.ts
@@ -3,10 +3,12 @@ import type p5 from "p5";
 import {
   changeDraggingState,
   changeToMousePressedState,
+  changeToMouseReleasedState,
   confirmPinchGesture,
   p5MouseReleased,
   startPinchGesture,
   updatePinchGesture,
+  zoomTo,
 } from "./p5-adapter";
 import { isOnUIOverlay } from "./utils";
 
@@ -139,10 +141,14 @@ export const onP5TouchEnded = (p: p5, ev: TouchEvent | undefined): boolean => {
   }
 
   if (ev.touches.length === 0) {
-    // スワイプ確定 (移動あり) / タップ (移動なし) どちらも既存mouseReleasedに委譲:
-    //   - 移動あり: moveTo でパン確定
-    //   - 移動なし: タップ位置を中心にscaleTo (ピンチ以外の拡大手段)
-    p5MouseReleased(p, new MouseEvent("mouseup"));
+    if (singleTouchMoved) {
+      // スワイプ確定 → 既存mouseReleasedでmoveTo
+      p5MouseReleased(p, new MouseEvent("mouseup"));
+    } else {
+      // タップ → 画面中央を基準にズームイン (タップ位置では動かさない)
+      zoomTo(false);
+      changeToMouseReleasedState();
+    }
     singleTouchStart = null;
     singleTouchMoved = false;
     gestureActive = false;

--- a/src/p5-adapter/touch-handler.ts
+++ b/src/p5-adapter/touch-handler.ts
@@ -1,0 +1,158 @@
+import { getStore } from "@/store/store";
+import { MOBILE_MAX_WIDTH } from "@/view/use-is-mobile";
+import type p5 from "p5";
+import {
+  changeDraggingState,
+  changeToMousePressedState,
+  changeToMouseReleasedState,
+  confirmPinchGesture,
+  p5MouseReleased,
+  startPinchGesture,
+  updatePinchGesture,
+} from "./p5-adapter";
+import { isOnUIOverlay } from "./utils";
+
+/** タップかドラッグかを判定するしきい値 (px) */
+const TAP_MOVE_THRESHOLD_PX = 10;
+
+/** ピンチ開始時の2本指間距離 (ピクセル) */
+let pinchStartDistance: number | null = null;
+/** 1本指タッチの開始位置 (タップ/ドラッグ判定用) */
+let singleTouchStart: { x: number; y: number } | null = null;
+/** 1本指タッチがしきい値を超えて移動したか */
+let singleTouchMoved = false;
+
+/**
+ * 2本指のclient座標間距離を計算
+ */
+const pinchDistance = (ev: TouchEvent): number => {
+  const t0 = ev.touches[0];
+  const t1 = ev.touches[1];
+  return Math.hypot(t0.clientX - t1.clientX, t0.clientY - t1.clientY);
+};
+
+/**
+ * p5のmouseX/mouseYをタッチ座標で上書きする
+ *
+ * p5のドラッグ計算 (getDraggingPixelDiff等) はp.mouseX/mouseYを参照するため、
+ * 既存のmouse系ロジックに乗せるためタッチ座標で同期する。
+ */
+const syncP5MousePos = (p: p5, x: number, y: number): void => {
+  (p as unknown as { mouseX: number; mouseY: number }).mouseX = x;
+  (p as unknown as { mouseX: number; mouseY: number }).mouseY = y;
+};
+
+/**
+ * 現在のビューポートがモバイル幅かどうか
+ */
+const isMobileViewport = (): boolean =>
+  window.matchMedia(`(max-width: ${MOBILE_MAX_WIDTH}px)`).matches;
+
+/**
+ * p5のp.touches配列からcanvasローカル座標を取り出す
+ */
+const getCanvasLocalTouch = (p: p5, index: number): { x: number; y: number } | null => {
+  const touches = p.touches as { x: number; y: number }[] | undefined;
+  if (!touches || touches.length <= index) return null;
+  return { x: touches[index].x, y: touches[index].y };
+};
+
+/**
+ * p.touchStartedに設定するハンドラ
+ *
+ * falseを返すことでp5の touch→mouse 合成を抑制し、p.mousePressed の発火を防ぐ。
+ * UI要素上のタッチはfalseを返さずブラウザ/UIに任せる。
+ */
+export const onP5TouchStarted = (p: p5, ev: TouchEvent | undefined): boolean => {
+  if (!ev) return true;
+  if (isOnUIOverlay(ev as unknown as MouseEvent)) return true;
+  if (getStore("canvasLocked")) return false;
+
+  if (ev.touches.length >= 2) {
+    pinchStartDistance = pinchDistance(ev);
+    startPinchGesture(p);
+  } else if (ev.touches.length === 1) {
+    const pos = getCanvasLocalTouch(p, 0);
+    if (pos) {
+      singleTouchStart = pos;
+      singleTouchMoved = false;
+      syncP5MousePos(p, pos.x, pos.y);
+      changeToMousePressedState(p);
+    }
+  }
+
+  return false;
+};
+
+/**
+ * p.touchMovedに設定するハンドラ
+ */
+export const onP5TouchMoved = (p: p5, ev: TouchEvent | undefined): boolean => {
+  if (!ev) return true;
+  if (getStore("canvasLocked")) return false;
+
+  if (pinchStartDistance !== null && ev.touches.length >= 2) {
+    const d = pinchDistance(ev);
+    updatePinchGesture(d / pinchStartDistance);
+    return false;
+  }
+
+  if (ev.touches.length === 1 && pinchStartDistance === null) {
+    const pos = getCanvasLocalTouch(p, 0);
+    if (pos) {
+      if (singleTouchStart) {
+        const dx = pos.x - singleTouchStart.x;
+        const dy = pos.y - singleTouchStart.y;
+        if (!singleTouchMoved && Math.hypot(dx, dy) > TAP_MOVE_THRESHOLD_PX) {
+          singleTouchMoved = true;
+        }
+      }
+      syncP5MousePos(p, pos.x, pos.y);
+      if (singleTouchMoved) {
+        changeDraggingState("move", p);
+      }
+    }
+  }
+
+  return false;
+};
+
+/**
+ * p.touchEndedに設定するハンドラ
+ */
+export const onP5TouchEnded = (p: p5, ev: TouchEvent | undefined): boolean => {
+  if (!ev) return true;
+  if (getStore("canvasLocked")) return false;
+
+  if (pinchStartDistance !== null) {
+    confirmPinchGesture(p);
+    pinchStartDistance = null;
+    singleTouchStart = null;
+    singleTouchMoved = false;
+    return false;
+  }
+
+  if (ev.touches.length === 0) {
+    if (singleTouchMoved) {
+      // スワイプ確定 → 既存のmouseReleasedフローへ
+      p5MouseReleased(p, new MouseEvent("mouseup"));
+    } else if (!isMobileViewport()) {
+      // デスクトップ幅でのタップ: 既存のclick→zoomを発火
+      p5MouseReleased(p, new MouseEvent("mouseup"));
+    } else {
+      // モバイル幅でのタップ: ズームせず状態だけリセット
+      changeToMouseReleasedState();
+    }
+    singleTouchStart = null;
+    singleTouchMoved = false;
+  }
+
+  return false;
+};
+
+/**
+ * canvasにtouch-action: noneを適用してブラウザ標準のピンチズーム/スクロールを抑止する
+ */
+export const disableCanvasTouchAction = (canvas: HTMLCanvasElement): void => {
+  canvas.style.touchAction = "none";
+};

--- a/src/rendering/p5-renderer.ts
+++ b/src/rendering/p5-renderer.ts
@@ -140,11 +140,17 @@ export const drawUICrossHair = (p: p5) => {
 };
 
 /**
- * カーソル位置に倍率を表示
+ * 倍率を表示
  *
- * interactive zoom中に表示する
+ * interactive zoom(右クリックドラッグ)とピンチ操作中に表示する。
+ * placement="cursor": カーソル位置追従 (PC右クリック用)
+ * placement="top-center": 画面中央上部固定 (モバイルピンチ用、利き手問わず指で隠れない位置)
  */
-export const drawUIScaleRate = (p: p5, scaleFactor: number) => {
+export const drawUIScaleRate = (
+  p: p5,
+  scaleFactor: number,
+  placement: "cursor" | "top-center" = "cursor",
+) => {
   p.fill(255);
   p.stroke(0);
   p.strokeWeight(4);
@@ -152,10 +158,17 @@ export const drawUIScaleRate = (p: p5, scaleFactor: number) => {
 
   const { text, size } = scaleRateText(scaleFactor);
 
+  if (placement === "top-center") {
+    const x = Math.floor(p.width / 2 - size / 2);
+    const y = 30;
+    p.text(text, x, y);
+    return;
+  }
+
   const x = clamp(p.mouseX, 0, p.width - size);
   const y = clamp(p.mouseY, 0, p.height - 25);
 
-  p.text(`${text}`, x + 10, y + 20);
+  p.text(text, x + 10, y + 20);
 };
 
 /**

--- a/src/rendering/p5-renderer.ts
+++ b/src/rendering/p5-renderer.ts
@@ -9,6 +9,7 @@ import { getIterationCache } from "@/iteration-buffer/iteration-buffer";
 import { applyMaxCanvasSize, rescaleIterationCacheForResize } from "@/rendering/common";
 import { getCurrentParams } from "@/mandelbrot-state/mandelbrot-state";
 import { clamp } from "@/math/util";
+import { isMobileViewport } from "@/view/use-is-mobile";
 import type p5 from "p5";
 import type { InterestingPoint } from "../interesting-points/find-interesting-points";
 import type { Rect } from "../math/rect";
@@ -159,12 +160,16 @@ export const drawUIScaleRate = (p: p5, scaleFactor: number) => {
 
 /**
  * 現状の描画位置に関する情報をcanvasにUIとして描画する
+ *
+ * モバイル幅ではfloating iconsと重なるので描画せず、HTML側の footer に表示する。
  */
 export const drawUICurrentParams = (
   p: p5,
   params: MandelbrotParams,
   autoIterationEnabled: boolean,
 ) => {
+  if (isMobileViewport()) return;
+
   p.textAlign(p.LEFT, p.BASELINE);
   p.fill(255);
   p.stroke(0);
@@ -177,8 +182,12 @@ export const drawUICurrentParams = (
 
 /**
  * 現在マウスが指している位置のiteration数をcanvasにUIとして描画する
+ *
+ * モバイルではマウス追従のカーソルが存在しないため描画しない。
  */
 export const drawUIIterationAtCursor = (p: p5, iteration: string | number) => {
+  if (isMobileViewport()) return;
+
   p.textAlign(p.RIGHT, p.TOP);
   p.fill(255);
   p.stroke(0);

--- a/src/rendering/p5-renderer.ts
+++ b/src/rendering/p5-renderer.ts
@@ -9,7 +9,6 @@ import { getIterationCache } from "@/iteration-buffer/iteration-buffer";
 import { applyMaxCanvasSize, rescaleIterationCacheForResize } from "@/rendering/common";
 import { getCurrentParams } from "@/mandelbrot-state/mandelbrot-state";
 import { clamp } from "@/math/util";
-import { PERTURBATION_THRESHOLD } from "@/utils/palette-encoding";
 import type p5 from "p5";
 import type { InterestingPoint } from "../interesting-points/find-interesting-points";
 import type { Rect } from "../math/rect";
@@ -174,18 +173,6 @@ export const drawUICurrentParams = (
 
   const nLabel = autoIterationEnabled ? `N: ${params.N} [auto]` : `N: ${params.N}`;
   p.text(`r: ${params.r.toPrecision(10)}\n${nLabel}`, 4, 14);
-
-  const isNotEnoughPrecision =
-    params.mode === "normal" && params.r.isLessThan(PERTURBATION_THRESHOLD);
-  if (isNotEnoughPrecision) {
-    p.textSize(16);
-    p.textAlign(p.CENTER, p.CENTER);
-    p.text(
-      `Not enough precision.\nSwitch to perturbation mode by [m] key!`,
-      p.width / 2,
-      p.height / 2,
-    );
-  }
 };
 
 /**

--- a/src/shadcn/components/ui/drawer.tsx
+++ b/src/shadcn/components/ui/drawer.tsx
@@ -37,7 +37,7 @@ function DrawerOverlay({
     <DrawerPrimitive.Overlay
       data-slot="drawer-overlay"
       className={cn(
-        "fixed inset-0 z-50 bg-black/10 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        "fixed inset-0 z-50 bg-black/10 supports-backdrop-filter:backdrop-blur-xs data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0",
         className
       )}
       {...props}

--- a/src/shadcn/components/ui/drawer.tsx
+++ b/src/shadcn/components/ui/drawer.tsx
@@ -1,0 +1,127 @@
+"use client"
+
+import * as React from "react"
+import { Drawer as DrawerPrimitive } from "vaul"
+
+import { cn } from "../../utils"
+
+function Drawer({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Root>) {
+  return <DrawerPrimitive.Root data-slot="drawer" {...props} />
+}
+
+function DrawerTrigger({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Trigger>) {
+  return <DrawerPrimitive.Trigger data-slot="drawer-trigger" {...props} />
+}
+
+function DrawerPortal({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Portal>) {
+  return <DrawerPrimitive.Portal data-slot="drawer-portal" {...props} />
+}
+
+function DrawerClose({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Close>) {
+  return <DrawerPrimitive.Close data-slot="drawer-close" {...props} />
+}
+
+function DrawerOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Overlay>) {
+  return (
+    <DrawerPrimitive.Overlay
+      data-slot="drawer-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/10 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DrawerContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Content>) {
+  return (
+    <DrawerPortal data-slot="drawer-portal">
+      <DrawerOverlay />
+      <DrawerPrimitive.Content
+        data-slot="drawer-content"
+        className={cn(
+          "group/drawer-content fixed z-50 flex h-auto flex-col bg-popover text-sm text-popover-foreground data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-xl data-[vaul-drawer-direction=bottom]:border-t data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:rounded-r-xl data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:rounded-l-xl data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-xl data-[vaul-drawer-direction=top]:border-b data-[vaul-drawer-direction=left]:sm:max-w-sm data-[vaul-drawer-direction=right]:sm:max-w-sm",
+          className
+        )}
+        {...props}
+      >
+        <div className="mx-auto mt-4 hidden h-1 w-25 shrink-0 rounded-full bg-muted group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
+        {children}
+      </DrawerPrimitive.Content>
+    </DrawerPortal>
+  )
+}
+
+function DrawerHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="drawer-header"
+      className={cn(
+        "flex flex-col gap-0.5 p-4 group-data-[vaul-drawer-direction=bottom]/drawer-content:text-center group-data-[vaul-drawer-direction=top]/drawer-content:text-center md:gap-0.5 md:text-left",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DrawerFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="drawer-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function DrawerTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Title>) {
+  return (
+    <DrawerPrimitive.Title
+      data-slot="drawer-title"
+      className={cn(
+        "cn-font-heading text-base font-medium text-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DrawerDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Description>) {
+  return (
+    <DrawerPrimitive.Description
+      data-slot="drawer-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Drawer, DrawerClose,
+  DrawerContent, DrawerDescription, DrawerFooter, DrawerHeader, DrawerOverlay, DrawerPortal, DrawerTitle, DrawerTrigger
+}
+

--- a/src/shadcn/components/ui/dropdown.tsx
+++ b/src/shadcn/components/ui/dropdown.tsx
@@ -43,7 +43,7 @@ function DropdownMenuContent({
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
         align={align}
-        className={cn("z-50 max-h-(--radix-dropdown-menu-content-available-height) w-(--radix-dropdown-menu-trigger-width) min-w-32 origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:overflow-hidden data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+        className={cn("z-150 max-h-(--radix-dropdown-menu-content-available-height) w-(--radix-dropdown-menu-trigger-width) min-w-32 origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:overflow-hidden data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
         {...props}
       />
     </DropdownMenuPrimitive.Portal>
@@ -242,7 +242,7 @@ function DropdownMenuSubContent({
   return (
     <DropdownMenuPrimitive.SubContent
       data-slot="dropdown-menu-sub-content"
-      className={cn("z-50 min-w-24 origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-lg bg-popover p-1 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+      className={cn("z-150 min-w-24 origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-lg bg-popover p-1 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
       {...props}
     />
   )

--- a/src/shadcn/components/ui/dropdown.tsx
+++ b/src/shadcn/components/ui/dropdown.tsx
@@ -1,0 +1,259 @@
+"use client"
+
+import { CheckIcon, ChevronRightIcon } from "lucide-react"
+import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui"
+import * as React from "react"
+
+import { cn } from "../../utils"
+
+function DropdownMenu({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+}
+
+function DropdownMenuPortal({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
+  return (
+    <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+  )
+}
+
+function DropdownMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  return (
+    <DropdownMenuPrimitive.Trigger
+      data-slot="dropdown-menu-trigger"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuContent({
+  className,
+  align = "start",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        data-slot="dropdown-menu-content"
+        sideOffset={sideOffset}
+        align={align}
+        className={cn("z-50 max-h-(--radix-dropdown-menu-content-available-height) w-(--radix-dropdown-menu-trigger-width) min-w-32 origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:overflow-hidden data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  )
+}
+
+function DropdownMenuGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
+  return (
+    <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
+  )
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+  inset?: boolean
+  variant?: "default" | "destructive"
+}) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "group/dropdown-menu-item relative flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:*:[svg]:text-destructive",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span
+        className="pointer-events-none absolute right-2 flex items-center justify-center"
+        data-slot="dropdown-menu-checkbox-item-indicator"
+      >
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  )
+}
+
+function DropdownMenuRadioGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+  return (
+    <DropdownMenuPrimitive.RadioGroup
+      data-slot="dropdown-menu-radio-group"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <span
+        className="pointer-events-none absolute right-2 flex items-center justify-center"
+        data-slot="dropdown-menu-radio-item-indicator"
+      >
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.RadioItem>
+  )
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.Label
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-1.5 py-1 text-xs font-medium text-muted-foreground data-inset:pl-7",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground group-focus/dropdown-menu-item:text-accent-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSub({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
+  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.SubTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-open:bg-accent data-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="cn-rtl-flip ml-auto" />
+    </DropdownMenuPrimitive.SubTrigger>
+  )
+}
+
+function DropdownMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+  return (
+    <DropdownMenuPrimitive.SubContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn("z-50 min-w-24 origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-lg bg-popover p-1 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+      {...props}
+    />
+  )
+}
+
+export {
+  DropdownMenu, DropdownMenuCheckboxItem, DropdownMenuContent,
+  DropdownMenuGroup, DropdownMenuItem, DropdownMenuLabel, DropdownMenuPortal, DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub, DropdownMenuSubContent, DropdownMenuSubTrigger, DropdownMenuTrigger
+}
+

--- a/src/shadcn/components/ui/dropdown.tsx
+++ b/src/shadcn/components/ui/dropdown.tsx
@@ -43,7 +43,7 @@ function DropdownMenuContent({
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
         align={align}
-        className={cn("z-150 max-h-(--radix-dropdown-menu-content-available-height) w-(--radix-dropdown-menu-trigger-width) min-w-32 origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:overflow-hidden data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+        className={cn("z-150 max-h-(--radix-dropdown-menu-content-available-height) w-(--radix-dropdown-menu-trigger-width) min-w-32 origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:overflow-hidden data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95", className )}
         {...props}
       />
     </DropdownMenuPrimitive.Portal>
@@ -224,7 +224,7 @@ function DropdownMenuSubTrigger({
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        "flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-open:bg-accent data-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -242,7 +242,7 @@ function DropdownMenuSubContent({
   return (
     <DropdownMenuPrimitive.SubContent
       data-slot="dropdown-menu-sub-content"
-      className={cn("z-150 min-w-24 origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-lg bg-popover p-1 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+      className={cn("z-150 min-w-24 origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-lg bg-popover p-1 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95", className )}
       {...props}
     />
   )

--- a/src/shadcn/components/ui/popover.tsx
+++ b/src/shadcn/components/ui/popover.tsx
@@ -28,7 +28,7 @@ function PopoverContent({
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          "z-150 flex w-72 origin-(--radix-popover-content-transform-origin) flex-col gap-2.5 rounded-lg bg-popover p-2.5 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "z-150 flex w-72 origin-(--radix-popover-content-transform-origin) flex-col gap-2.5 rounded-lg bg-popover p-2.5 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
           className
         )}
         {...props}

--- a/src/shadcn/components/ui/popover.tsx
+++ b/src/shadcn/components/ui/popover.tsx
@@ -28,7 +28,7 @@ function PopoverContent({
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          "z-50 flex w-72 origin-(--radix-popover-content-transform-origin) flex-col gap-2.5 rounded-lg bg-popover p-2.5 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "z-150 flex w-72 origin-(--radix-popover-content-transform-origin) flex-col gap-2.5 rounded-lg bg-popover p-2.5 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className
         )}
         {...props}

--- a/src/shadcn/components/ui/select.tsx
+++ b/src/shadcn/components/ui/select.tsx
@@ -66,7 +66,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "relative z-150 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className,

--- a/src/shadcn/components/ui/tooltip.tsx
+++ b/src/shadcn/components/ui/tooltip.tsx
@@ -18,7 +18,7 @@ const TooltipContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-150 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className,
       )}
       {...props}

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -59,6 +59,8 @@ type Store = {
 
   // state
   progress: string | ResultSpans;
+  /** 直近描画のiteration=N到達率 (0..1)。描画未完了や集計不能時はnull */
+  nHitRatio: number | null;
   /** 現在使用中のrenderer */
   rendererType: "webgpu" | "p5js";
   /** Debug Mode中か否か */
@@ -109,6 +111,7 @@ const store: Store = {
   supersamplingHeight: 1080,
   // state
   progress: "",
+  nHitRatio: null,
   rendererType: "p5js",
   isDebugMode: false,
   showInterestingPoints: false,

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -38,6 +38,8 @@ type Store = {
   canvasLocked: boolean;
   /** POIパネルの開閉状態 */
   poiPanelOpen: boolean;
+  /** モバイル時のPOI Drawer状態 (closed=非表示 / small=横ストリップ / full=画面全体) */
+  poiDrawerSnap: "closed" | "small" | "full";
 
   // mandelbrot state
   /** reference orbit計算にwasmを使うかどうか */
@@ -93,6 +95,7 @@ const store: Store = {
   // UI state
   canvasLocked: false,
   poiPanelOpen: true,
+  poiDrawerSnap: "closed",
   // mandelbrot state
   useWasm: true,
   manualLimbsOverride: null,

--- a/src/types.ts
+++ b/src/types.ts
@@ -155,6 +155,11 @@ export interface BatchContext {
   startedAt: number;
   finishedAt?: number;
   spans: Span[];
+
+  /** iteration値が N に到達した画素の累積数 (描画済みtile全体) */
+  nHitCount: number;
+  /** 累積画素数 (描画済みtile全体) */
+  totalPixelCount: number;
 }
 
 export type InitialOmittedBatchContextKeys =
@@ -163,7 +168,9 @@ export type InitialOmittedBatchContextKeys =
   | "progressMap"
   | "startedAt"
   | "refProgress"
-  | "spans";
+  | "spans"
+  | "nHitCount"
+  | "totalPixelCount";
 
 export type JobType = "calc-iteration" | "calc-ref-orbit";
 

--- a/src/view/app-root.tsx
+++ b/src/view/app-root.tsx
@@ -10,6 +10,7 @@ import { COLLAPSED_STRIP_WIDTH, POIPanel } from "./poi-panel";
 import { ProgressBar } from "./progress-bar";
 import { SupersamplingOverlay } from "./supersampling-overlay";
 import { Toolbar } from "./toolbar";
+import { useIsMobile } from "./use-is-mobile";
 import { PanelLayoutProvider, useExclusivePanels, usePanelLayout } from "./use-panel-layout";
 
 /**
@@ -21,18 +22,20 @@ import { PanelLayoutProvider, useExclusivePanels, usePanelLayout } from "./use-p
 const useCanvasPositionAdjust = () => {
   const isDebugMode = useStoreValue("isDebugMode");
   const poiPanelOpen = useStoreValue("poiPanelOpen");
+  const isMobile = useIsMobile();
   const { debugPanelWidth, poiPanelWidth } = usePanelLayout();
 
   useEffect(() => {
     const wrapper = document.getElementById("canvas-wrapper");
     if (!wrapper) return;
 
-    const debugWidth = isDebugMode ? debugPanelWidth : 0;
-    const poiWidth = poiPanelOpen ? poiPanelWidth : COLLAPSED_STRIP_WIDTH;
+    // モバイルではデバッグパネル非表示・POIはBottomSheetで上に乗るためオフセット不要
+    const debugWidth = !isMobile && isDebugMode ? debugPanelWidth : 0;
+    const poiWidth = isMobile ? 0 : poiPanelOpen ? poiPanelWidth : COLLAPSED_STRIP_WIDTH;
 
     wrapper.style.left = `${debugWidth}px`;
     wrapper.style.right = `${poiWidth}px`;
-  }, [isDebugMode, poiPanelOpen, debugPanelWidth, poiPanelWidth]);
+  }, [isMobile, isDebugMode, poiPanelOpen, debugPanelWidth, poiPanelWidth]);
 };
 
 /** AppRoot内部（PanelLayoutProvider内で動作する） */

--- a/src/view/bump-pill/bump-state.ts
+++ b/src/view/bump-pill/bump-state.ts
@@ -1,0 +1,55 @@
+import type BigNumber from "bignumber.js";
+
+/** バンプ操作後、効果判定で「効いた」とみなす比率: 新比率 ≤ 旧比率/2 */
+const EFFECTIVENESS_RATIO = 0.5;
+
+/** iteration=N到達率がこの値を超えたときにバンプピルを表示する */
+export const BUMP_DISPLAY_THRESHOLD = 0.01;
+
+type BumpContext = {
+  ratioBefore: number;
+  paramsHash: string;
+};
+
+let lastBumpContext: BumpContext | null = null;
+
+/**
+ * x/y/r を合成した位置識別キーを返す
+ *
+ * これが同じなら「同じ場所」とみなし、バンプの効果追跡を引き継ぐ
+ */
+export const makeParamsHash = (x: BigNumber, y: BigNumber, r: BigNumber): string =>
+  `${x.toString()}|${y.toString()}|${r.toString()}`;
+
+/**
+ * バンプピル押下時に呼ぶ。直前の比率と場所を記憶する
+ */
+export const recordBump = (ratioBefore: number, paramsHash: string) => {
+  lastBumpContext = { ratioBefore, paramsHash };
+};
+
+/**
+ * バンプピルを表示すべきかを判定する
+ *
+ * - 比率が閾値以下なら非表示
+ * - 直前のバンプが同じ場所で行われていて、効果が弱かった場合は非表示（minibrot対策）
+ */
+export const shouldShowBumpPill = (ratio: number, paramsHash: string): boolean => {
+  if (ratio <= BUMP_DISPLAY_THRESHOLD) return false;
+
+  if (lastBumpContext && lastBumpContext.paramsHash === paramsHash) {
+    // 同じ場所で前回バンプした。新比率が旧比率の半分以下に落ちていないなら効果なしと判断
+    if (ratio > lastBumpContext.ratioBefore * EFFECTIVENESS_RATIO) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+/**
+ * バンプ追跡をリセットする。場所移動時などに呼ぶ
+ */
+export const clearBumpContext = () => {
+  lastBumpContext = null;
+};

--- a/src/view/bump-pill/index.tsx
+++ b/src/view/bump-pill/index.tsx
@@ -6,8 +6,12 @@ import clsx from "clsx";
 import { TriangleAlert } from "lucide-react";
 import { makeParamsHash, recordBump, shouldShowBumpPill } from "./bump-state";
 
-/** バンプ率: 現在のNに +30% 上積みする */
-const BUMP_RATE = 0.3;
+/** 小Nで固定増加に切り替える閾値。未満は固定量、以上は比率で上積みする */
+const BUMP_THRESHOLD = 10000;
+/** N<BUMP_THRESHOLD時の固定増加量 */
+const BUMP_STEP_SMALL = 2000;
+/** N>=BUMP_THRESHOLD時の増加率 (+30%) */
+const BUMP_RATE_LARGE = 0.3;
 
 /**
  * iteration=N到達率が高いときだけ表示される「N不足→バンプ」操作ピル
@@ -31,7 +35,8 @@ export const BumpPill = () => {
 
   const handleClick = () => {
     recordBump(nHitRatio, paramsHash);
-    const bumpAmount = Math.max(1, Math.floor(N * BUMP_RATE));
+    const bumpAmount =
+      N < BUMP_THRESHOLD ? BUMP_STEP_SMALL : Math.max(1, Math.floor(N * BUMP_RATE_LARGE));
     setManualN(N + bumpAmount);
   };
 
@@ -47,7 +52,7 @@ export const BumpPill = () => {
       )}
     >
       <TriangleAlert className="size-[18px] shrink-0 text-[var(--tomato-11)]" />
-      <span>{t("Increase N by 30%", "bump.increaseN")}</span>
+      <span>{t("Increase max iteration", "bump.increaseN")}</span>
     </button>
   );
 };

--- a/src/view/bump-pill/index.tsx
+++ b/src/view/bump-pill/index.tsx
@@ -35,9 +35,7 @@ export const BumpPill = () => {
     setManualN(N + bumpAmount);
   };
 
-  const positionClass = isMobile
-    ? "bottom-7 left-1/2 -translate-x-1/2"
-    : "right-4 bottom-5 -translate-x-0";
+  const positionClass = isMobile ? "bottom-7 left-1/2 -translate-x-1/2" : "bottom-20 left-3";
 
   return (
     <button
@@ -49,8 +47,7 @@ export const BumpPill = () => {
       )}
     >
       <TriangleAlert className="size-4 text-[var(--tomato-11)]" />
-      <span>{t("Low N", "bump.lowN")}</span>
-      <span className="font-mono">+30%</span>
+      <span>{t("Increase N by 30%", "bump.increaseN")}</span>
     </button>
   );
 };

--- a/src/view/bump-pill/index.tsx
+++ b/src/view/bump-pill/index.tsx
@@ -35,18 +35,18 @@ export const BumpPill = () => {
     setManualN(N + bumpAmount);
   };
 
-  const positionClass = isMobile ? "bottom-7 left-1/2 -translate-x-1/2" : "bottom-20 left-3";
+  const positionClass = isMobile ? "bottom-10 left-1/2 -translate-x-1/2" : "bottom-20 left-3";
 
   return (
     <button
       type="button"
       onClick={handleClick}
       className={clsx(
-        "fixed z-[95] flex items-center gap-1.5 rounded-full border border-[var(--tomato-9)] bg-[#1c1c24]/95 px-4 py-2 text-sm font-medium text-[var(--sage-12)] shadow-lg backdrop-blur-sm transition hover:bg-[#26262e]/95 active:scale-95",
+        "fixed z-[95] flex items-center gap-1.5 rounded-full border-2 border-[var(--tomato-10)] bg-[#1c1c24]/95 px-4 py-2 text-sm font-medium text-[var(--sage-12)] shadow-[0_0_20px_rgba(229,77,46,0.4),0_4px_12px_rgba(0,0,0,0.6)] backdrop-blur-sm transition hover:bg-[#26262e]/95 active:scale-95",
         positionClass,
       )}
     >
-      <TriangleAlert className="size-4 text-[var(--tomato-11)]" />
+      <TriangleAlert className="size-[18px] shrink-0 text-[var(--tomato-11)]" />
       <span>{t("Increase N by 30%", "bump.increaseN")}</span>
     </button>
   );

--- a/src/view/bump-pill/index.tsx
+++ b/src/view/bump-pill/index.tsx
@@ -1,0 +1,56 @@
+import { useT } from "@/i18n/context";
+import { setManualN } from "@/mandelbrot-state/mandelbrot-state";
+import { useStoreValue } from "@/store/store";
+import { useIsMobile } from "@/view/use-is-mobile";
+import clsx from "clsx";
+import { TriangleAlert } from "lucide-react";
+import { makeParamsHash, recordBump, shouldShowBumpPill } from "./bump-state";
+
+/** バンプ率: 現在のNに +30% 上積みする */
+const BUMP_RATE = 0.3;
+
+/**
+ * iteration=N到達率が高いときだけ表示される「N不足→バンプ」操作ピル
+ *
+ * Mobile: 画面下中央、footerのすぐ上
+ * PC: 画面右下、Footer BarGraphの右側
+ */
+export const BumpPill = () => {
+  const t = useT();
+  const isMobile = useIsMobile();
+  const nHitRatio = useStoreValue("nHitRatio");
+  const N = useStoreValue("N");
+  const centerX = useStoreValue("centerX");
+  const centerY = useStoreValue("centerY");
+  const r = useStoreValue("r");
+
+  if (nHitRatio == null) return null;
+
+  const paramsHash = makeParamsHash(centerX, centerY, r);
+  if (!shouldShowBumpPill(nHitRatio, paramsHash)) return null;
+
+  const handleClick = () => {
+    recordBump(nHitRatio, paramsHash);
+    const bumpAmount = Math.max(1, Math.floor(N * BUMP_RATE));
+    setManualN(N + bumpAmount);
+  };
+
+  const positionClass = isMobile
+    ? "bottom-7 left-1/2 -translate-x-1/2"
+    : "right-4 bottom-5 -translate-x-0";
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className={clsx(
+        "fixed z-[95] flex items-center gap-1.5 rounded-full border border-[var(--tomato-9)] bg-[#1c1c24]/95 px-4 py-2 text-sm font-medium text-[var(--sage-12)] shadow-lg backdrop-blur-sm transition hover:bg-[#26262e]/95 active:scale-95",
+        positionClass,
+      )}
+    >
+      <TriangleAlert className="size-4 text-[var(--tomato-11)]" />
+      <span>{t("Low N", "bump.lowN")}</span>
+      <span className="font-mono">+30%</span>
+    </button>
+  );
+};

--- a/src/view/debug-panel/index.tsx
+++ b/src/view/debug-panel/index.tsx
@@ -1,12 +1,16 @@
 import { updateStore, useStoreValue } from "@/store/store";
+import { useIsMobile } from "@/view/use-is-mobile";
 import { IconX } from "@tabler/icons-react";
 import { DebugMode } from "../right-sidebar/debug-mode/debug-mode";
 import { usePanelLayout } from "../use-panel-layout";
 
-/** 左側スライドインデバッグパネル */
+/** 左側スライドインデバッグパネル (モバイル時は非表示) */
 export const DebugPanel = () => {
+  const isMobile = useIsMobile();
   const isDebugMode = useStoreValue("isDebugMode");
   const { debugPanelWidth } = usePanelLayout();
+
+  if (isMobile) return null;
 
   return (
     <div

--- a/src/view/header/actions.tsx
+++ b/src/view/header/actions.tsx
@@ -1,6 +1,6 @@
 import { getCurrentPalette, setSerializedPalette } from "@/camera/palette";
 import { SimpleTooltip } from "@/components/simple-tooltip";
-import { useT } from "@/i18n/context";
+import { type TFunction, useT } from "@/i18n/context";
 import { clearIterationCache } from "@/iteration-buffer/iteration-buffer";
 import {
   getCurrentParams,
@@ -12,28 +12,23 @@ import { getRandomPresetPOI } from "@/preset-poi/preset-poi";
 import { getCanvasSize } from "@/rendering/renderer";
 import { Button } from "@/shadcn/components/ui/button";
 import { toast } from "sonner";
-import { buildShareData } from "@/utils/mandelbrot-url-params";
-import { useModalState } from "@/view/modal/use-modal-state";
+import { buildShareData, type ShareData } from "@/utils/mandelbrot-url-params";
 import { SupersamplingPopover } from "@/view/supersampling-popover";
 import { IconDice, IconDownload, IconShare } from "@tabler/icons-react";
 import BigNumber from "bignumber.js";
 import { useEffect, useState } from "react";
 import { ShareDialog } from "./share-dialog";
 
-export const Actions = () => {
-  return (
-    <div className="flex items-center gap-x-2">
-      <RandomJumpButton />
-      <ShareButton />
-      <SaveImageButton />
-      <SupersamplingPopover />
-    </div>
-  );
-};
+/** 空のshareData */
+const EMPTY_SHARE_DATA: ShareData = { url: "", x: "", y: "", r: "", N: 0 };
 
-const ShareButton = () => {
-  const t = useT();
-  const [opened, { open, close }] = useModalState();
+/**
+ * Shareダイアログを制御するための状態・副作用を管理するフック
+ *
+ * opened=true になった瞬間にcanvas画像をキャプチャし、imageDataUrlとshareDataを
+ * 返す。ShareDialogにそのまま渡せる。
+ */
+export const useShareDialogState = (opened: boolean) => {
   const [imageDataUrl, setImageDataUrl] = useState<string | null>(null);
 
   useEffect(() => {
@@ -49,46 +44,102 @@ const ShareButton = () => {
         ...getCurrentParams(),
         palette: getCurrentPalette(),
       })
-    : { url: "", x: "", y: "", r: "", N: 0 };
+    : EMPTY_SHARE_DATA;
 
+  return { imageDataUrl, shareData };
+};
+
+/**
+ * ShareDialogを外部stateでホストする薄いラッパー
+ */
+export const ShareDialogHost = ({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) => {
+  const { imageDataUrl, shareData } = useShareDialogState(open);
   return (
-    <>
-      <ShareDialog
-        open={opened}
-        onOpenChange={(isOpen) => {
-          if (!isOpen) close();
-        }}
-        shareData={shareData}
-        imageDataUrl={imageDataUrl}
-      />
-      <Button variant="outline" size="sm" onClick={open}>
-        <IconShare className="mr-1 size-6" />
-        {t("Share", "header.share")}
-      </Button>
-    </>
+    <ShareDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      shareData={shareData}
+      imageDataUrl={imageDataUrl}
+    />
   );
 };
 
-const SaveImageButton = () => {
+/**
+ * キャンバス画像をPNGとしてダウンロードする
+ */
+export const performSaveImage = (t: TFunction) => {
+  requestCanvasImage(0, (imageDataURL) => {
+    const link = document.createElement("a");
+    link.download = `mandelbrot-${Date.now()}.png`;
+    link.href = imageDataURL;
+    link.click();
+
+    toast.success(t("Image saved!"), {
+      duration: 2000,
+    });
+  });
+};
+
+/**
+ * プリセットPOIからランダムに1件選んでジャンプする
+ */
+export const performRandomJump = () => {
+  const raw = getRandomPresetPOI();
+  setManualN(raw.N);
+  setCurrentParams({
+    x: new BigNumber(raw.x),
+    y: new BigNumber(raw.y),
+    r: new BigNumber(raw.r),
+    N: raw.N,
+    mode: raw.mode,
+  });
+  clearIterationCache();
+  setSerializedPalette(raw.palette);
+};
+
+/**
+ * I'm Feeling Luckyボタン (プリセットPOIからランダムにジャンプ)
+ */
+export const RandomJumpButton = () => {
+  const t = useT();
+
+  return (
+    <SimpleTooltip content={t("Dive into a hidden gem of the Mandelbrot set.")}>
+      <Button variant="default" size="sm" onClick={performRandomJump}>
+        <IconDice className="mr-1 size-6" />
+        {t("I'm Feeling Lucky")}
+      </Button>
+    </SimpleTooltip>
+  );
+};
+
+/**
+ * Shareダイアログを開くボタン (onClickでダイアログopen)
+ */
+export const ShareButton = ({ onClick }: { onClick: () => void }) => {
+  const t = useT();
+  return (
+    <Button variant="outline" size="sm" onClick={onClick}>
+      <IconShare className="mr-1 size-6" />
+      {t("Share", "header.share")}
+    </Button>
+  );
+};
+
+/**
+ * 画像保存ボタン
+ */
+export const SaveImageButton = () => {
   const t = useT();
   return (
     <SimpleTooltip content={t("Downloads the canvas content as a PNG image.")}>
-      <Button
-        variant="outline"
-        size="sm"
-        onClick={() => {
-          requestCanvasImage(0, (imageDataURL) => {
-            const link = document.createElement("a");
-            link.download = `mandelbrot-${Date.now()}.png`;
-            link.href = imageDataURL;
-            link.click();
-
-            toast.success(t("Image saved!"), {
-              duration: 2000,
-            });
-          });
-        }}
-      >
+      <Button variant="outline" size="sm" onClick={() => performSaveImage(t)}>
         <IconDownload className="mr-1 size-6" />
         {t("Save Image")}
       </Button>
@@ -96,30 +147,16 @@ const SaveImageButton = () => {
   );
 };
 
-/** プリセットPOIからランダムに1件選んでジャンプするボタン */
-const RandomJumpButton = () => {
-  const t = useT();
-
-  const handleClick = () => {
-    const raw = getRandomPresetPOI();
-    setManualN(raw.N);
-    setCurrentParams({
-      x: new BigNumber(raw.x),
-      y: new BigNumber(raw.y),
-      r: new BigNumber(raw.r),
-      N: raw.N,
-      mode: raw.mode,
-    });
-    clearIterationCache();
-    setSerializedPalette(raw.palette);
-  };
-
+/**
+ * デスクトップ用のアクション群 (Lucky / Share / Save / Supersampling)
+ */
+export const Actions = ({ onOpenShare }: { onOpenShare: () => void }) => {
   return (
-    <SimpleTooltip content={t("Dive into a hidden gem of the Mandelbrot set.")}>
-      <Button variant="default" size="sm" onClick={handleClick}>
-        <IconDice className="mr-1 size-6" />
-        {t("I'm Feeling Lucky")}
-      </Button>
-    </SimpleTooltip>
+    <div className="flex items-center gap-x-2">
+      <RandomJumpButton />
+      <ShareButton onClick={onOpenShare} />
+      <SaveImageButton />
+      <SupersamplingPopover />
+    </div>
   );
 };

--- a/src/view/header/instructions.tsx
+++ b/src/view/header/instructions.tsx
@@ -42,11 +42,6 @@ export const Instructions = () => {
         <div>{t("Change Palette")}</div>
 
         <div>
-          <Kbd>m</Kbd>
-        </div>
-        <div>{t("Toggle mode")}</div>
-
-        <div>
           <Kbd>r</Kbd>
         </div>
         <div>{t("Reset r to 2.0")}</div>

--- a/src/view/header/share-dialog.tsx
+++ b/src/view/header/share-dialog.tsx
@@ -1,11 +1,18 @@
 import { Button } from "@/shadcn/components/ui/button";
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/shadcn/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/shadcn/components/ui/dialog";
 import { toast } from "sonner";
 import { isDevMode } from "@/utils/dev-mode";
 import type { ShareData } from "@/utils/mandelbrot-url-params";
 import { ClickFeedback, useClickFeedback } from "@/view/components/click-feedback";
 import { useT } from "@/i18n/context";
 import { IconCircleCheck, IconCopy, IconExternalLink, IconPhoto } from "@tabler/icons-react";
+import { VisuallyHidden } from "radix-ui";
 
 const PRODUCTION_ORIGIN = "https://p5mandelbrot.pages.dev";
 
@@ -77,6 +84,11 @@ export const ShareDialog = ({
       <DialogContent className="max-w-md">
         <DialogHeader>
           <DialogTitle>{t("Share", "header.share")}</DialogTitle>
+          <VisuallyHidden.Root>
+            <DialogDescription>
+              {t("Share current view by URL", "dialog.description.share")}
+            </DialogDescription>
+          </VisuallyHidden.Root>
         </DialogHeader>
 
         <div className="flex gap-4">

--- a/src/view/minimap/minimap-dialog.tsx
+++ b/src/view/minimap/minimap-dialog.tsx
@@ -8,11 +8,12 @@ import {
   usePresetPOIList,
 } from "@/preset-poi/preset-poi";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/shadcn/components/ui/dialog";
+import { Popover, PopoverContent, PopoverTrigger } from "@/shadcn/components/ui/popover";
 import { loadPreview } from "@/store/preview-store";
 import { useStoreValue } from "@/store/store";
 import type { POIData } from "@/types";
 import BigNumber from "bignumber.js";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 /** ミニマップの最大表示サイズ(px) */
 const MAX_DISPLAY_SIZE = 1024;
@@ -128,37 +129,7 @@ const jumpToUserPOI = (poi: POIData) => {
 };
 
 /**
- * ピンの位置 (%) に応じてポップオーバーの配置を決定する
- *
- * 端に近い場合は逆方向に表示し、はみ出しを防ぐ。
- */
-const popoverPosition = (cx: number, cy: number): React.CSSProperties => {
-  const style: React.CSSProperties = {};
-
-  // 縦方向: 上端15%以内なら下に、それ以外は上に表示
-  if (cy < 15) {
-    style.top = "100%";
-    style.marginTop = 8;
-  } else {
-    style.bottom = "100%";
-    style.marginBottom = 8;
-  }
-
-  // 横方向: 左端/右端に近ければ寄せる、それ以外は中央
-  if (cx < 20) {
-    style.left = 0;
-  } else if (cx > 80) {
-    style.right = 0;
-  } else {
-    style.left = "50%";
-    style.transform = "translateX(-50%)";
-  }
-
-  return style;
-};
-
-/**
- * クラスタのホバーポップオーバー
+ * クラスタのサムネイル一覧 (Popover中身)
  */
 const ClusterPopover = ({ cluster, onJump }: { cluster: Cluster; onJump: () => void }) => {
   const [thumbnails, setThumbnails] = useState<Record<string, string | null>>({});
@@ -222,12 +193,12 @@ const ClusterPopover = ({ cluster, onJump }: { cluster: Cluster; onJump: () => v
 
 /**
  * ミニマップ上のピン（またはクラスタ）を描画するコンポーネント
+ *
+ * 複数ピンのクラスタ: タップで Radix Popover (portal) が開いてサムネイル一覧表示。
+ * 単一ピン: タップで直接ジャンプ。
  */
 const ClusterPin = ({ cluster, onJump }: { cluster: Cluster; onJump: () => void }) => {
-  const [showPopover, setShowPopover] = useState(false);
-  const pinRef = useRef<HTMLDivElement>(null);
-  const popoverRef = useRef<HTMLDivElement>(null);
-  const hideTimeoutRef = useRef<ReturnType<typeof setTimeout>>(null);
+  const [open, setOpen] = useState(false);
 
   const isSingle = cluster.pins.length === 1;
   const hasMixed = !isSingle && new Set(cluster.pins.map((p) => p.source)).size > 1;
@@ -237,68 +208,58 @@ const ClusterPin = ({ cluster, onJump }: { cluster: Cluster; onJump: () => void 
       ? PRESET_COLOR
       : USER_POI_COLOR;
 
-  const handleMouseEnter = () => {
-    if (hideTimeoutRef.current) {
-      clearTimeout(hideTimeoutRef.current);
-      hideTimeoutRef.current = null;
-    }
-    setShowPopover(true);
+  const handleJumpAndClose = () => {
+    setOpen(false);
+    onJump();
   };
 
-  const handleMouseLeave = () => {
-    hideTimeoutRef.current = setTimeout(() => {
-      setShowPopover(false);
-    }, 200);
-  };
-
-  return (
+  const pinEl = (
     <div
-      ref={pinRef}
       className="absolute"
       style={{
         left: `${cluster.cx}%`,
         top: `${cluster.cy}%`,
         transform: "translate(-50%, -50%)",
-        zIndex: showPopover ? 50 : 10,
+        zIndex: 10,
       }}
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
     >
-      {/* ピン本体 */}
       <div
         className="flex items-center justify-center rounded-full border-2 border-white/80 shadow-lg shadow-black/50 transition-transform hover:scale-125"
         style={{
           backgroundColor: primaryColor,
-          width: isSingle ? 14 : 22,
-          height: isSingle ? 14 : 22,
+          width: isSingle ? 18 : 26,
+          height: isSingle ? 18 : 26,
           cursor: "pointer",
         }}
         onClick={(e) => {
-          e.stopPropagation();
           if (isSingle) {
+            e.stopPropagation();
             cluster.pins[0].jumpAction();
             onJump();
           }
         }}
       >
         {!isSingle && (
-          <span className="text-[10px] font-bold text-white">{cluster.pins.length}</span>
+          <span className="text-[11px] font-bold text-white">{cluster.pins.length}</span>
         )}
       </div>
-
-      {/* ポップオーバー */}
-      {showPopover && (
-        <div
-          ref={popoverRef}
-          className="absolute z-50 w-fit rounded-lg border border-white/10 bg-[#1e1e2e]/95 p-2 shadow-xl backdrop-blur-sm"
-          style={popoverPosition(cluster.cx, cluster.cy)}
-          onMouseEnter={handleMouseEnter}
-          onMouseLeave={handleMouseLeave}
-        >
-          <ClusterPopover cluster={cluster} onJump={onJump} />
-        </div>
-      )}
     </div>
+  );
+
+  if (isSingle) return pinEl;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>{pinEl}</PopoverTrigger>
+      <PopoverContent
+        side="top"
+        align="center"
+        collisionPadding={16}
+        className="w-fit max-w-[min(92vw,360px)] p-2"
+      >
+        <ClusterPopover cluster={cluster} onJump={handleJumpAndClose} />
+      </PopoverContent>
+    </Popover>
   );
 };
 
@@ -377,7 +338,7 @@ export const MinimapDialog = ({ open, onOpenChange }: MinimapDialogProps) => {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
-        className="max-h-[95vh] w-[calc(100vw-2rem)] max-w-[1056px] overflow-y-auto p-4"
+        className="flex max-h-[95vh] w-[calc(100vw-2rem)] max-w-[1056px] flex-col p-4"
         aria-describedby={undefined}
       >
         <DialogHeader>
@@ -399,19 +360,22 @@ export const MinimapDialog = ({ open, onOpenChange }: MinimapDialogProps) => {
             My POI ({userCount})
           </span>
         </div>
-        <div
-          className="relative aspect-square w-full rounded border border-[#2a2a3a]"
-          style={{ maxWidth: MAX_DISPLAY_SIZE }}
-        >
-          <img
-            src={`${import.meta.env.BASE_URL ?? "/"}minimap.png`}
-            alt="Mandelbrot set minimap"
-            className="block size-full"
-            draggable={false}
-          />
-          {clusters.map((cluster, i) => (
-            <ClusterPin key={i} cluster={cluster} onJump={handleJump} />
-          ))}
+        {/* ミニマップをスクロール可能なコンテナに入れる。中身は固定サイズなので小さいviewportではパンして閲覧 */}
+        <div className="min-h-0 flex-1 overflow-auto rounded border border-[#2a2a3a]">
+          <div
+            className="relative aspect-square"
+            style={{ width: MAX_DISPLAY_SIZE, maxWidth: "none" }}
+          >
+            <img
+              src={`${import.meta.env.BASE_URL ?? "/"}minimap.png`}
+              alt="Mandelbrot set minimap"
+              className="block size-full"
+              draggable={false}
+            />
+            {clusters.map((cluster, i) => (
+              <ClusterPin key={i} cluster={cluster} onJump={handleJump} />
+            ))}
+          </div>
         </div>
       </DialogContent>
     </Dialog>

--- a/src/view/minimap/minimap-dialog.tsx
+++ b/src/view/minimap/minimap-dialog.tsx
@@ -213,6 +213,14 @@ const ClusterPin = ({ cluster, onJump }: { cluster: Cluster; onJump: () => void 
     onJump();
   };
 
+  // PCのマウスhoverで開閉、モバイルタッチ時はRadixのclick→onOpenChange任せ
+  const handleMouseEnter = (e: React.PointerEvent) => {
+    if (e.pointerType === "mouse") setOpen(true);
+  };
+  const handleMouseLeave = (e: React.PointerEvent) => {
+    if (e.pointerType === "mouse") setOpen(false);
+  };
+
   const pinEl = (
     <div
       className="absolute"
@@ -222,6 +230,8 @@ const ClusterPin = ({ cluster, onJump }: { cluster: Cluster; onJump: () => void 
         transform: "translate(-50%, -50%)",
         zIndex: 10,
       }}
+      onPointerEnter={handleMouseEnter}
+      onPointerLeave={handleMouseLeave}
     >
       <div
         className="flex items-center justify-center rounded-full border-2 border-white/80 shadow-lg shadow-black/50 transition-transform hover:scale-125"
@@ -247,6 +257,8 @@ const ClusterPin = ({ cluster, onJump }: { cluster: Cluster; onJump: () => void 
         align="center"
         collisionPadding={16}
         className="w-fit max-w-[min(92vw,360px)] p-2"
+        onPointerEnter={handleMouseEnter}
+        onPointerLeave={handleMouseLeave}
       >
         <ClusterPopover cluster={cluster} onJump={handleJumpAndClose} />
       </PopoverContent>

--- a/src/view/minimap/minimap-dialog.tsx
+++ b/src/view/minimap/minimap-dialog.tsx
@@ -341,7 +341,7 @@ export const MinimapDialog = ({ open, onOpenChange }: MinimapDialogProps) => {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
-        className="flex max-h-[95vh] w-[calc(100vw-2rem)] max-w-[1056px] flex-col p-4"
+        className="flex max-h-[95dvh] w-[calc(100vw-2rem)] max-w-[1056px] flex-col p-4"
         aria-describedby={undefined}
       >
         <DialogHeader>

--- a/src/view/minimap/minimap-dialog.tsx
+++ b/src/view/minimap/minimap-dialog.tsx
@@ -162,6 +162,8 @@ const ClusterPopover = ({ cluster, onJump }: { cluster: Cluster; onJump: () => v
         gridTemplateColumns: `repeat(${Math.min(cluster.pins.length, 3)}, 80px)`,
         touchAction: "pan-y",
       }}
+      onTouchStartCapture={(e) => e.stopPropagation()}
+      onTouchMoveCapture={(e) => e.stopPropagation()}
     >
       {cluster.pins.map((pin) => (
         <button

--- a/src/view/minimap/minimap-dialog.tsx
+++ b/src/view/minimap/minimap-dialog.tsx
@@ -14,16 +14,16 @@ import type { POIData } from "@/types";
 import BigNumber from "bignumber.js";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-/** ミニマップの表示サイズ(px) */
-const DISPLAY_SIZE = 1024;
+/** ミニマップの最大表示サイズ(px) */
+const MAX_DISPLAY_SIZE = 1024;
 
 /** ミニマップの複素平面パラメータ */
 const MAP_CENTER_X = -0.75;
 const MAP_CENTER_Y = 0;
 const MAP_R = 1.5;
 
-/** クラスタリングの距離閾値(px) */
-const CLUSTER_RADIUS = 20;
+/** クラスタリングの距離閾値 (% — ミニマップサイズに対する割合) */
+const CLUSTER_RADIUS_PERCENT = 2;
 
 /** ピンの色 */
 const PRESET_COLOR = "#3b82f6";
@@ -56,28 +56,29 @@ type Cluster = {
 };
 
 /**
- * 複素座標をミニマップのピクセル座標に変換する
+ * 複素座標をミニマップ上の% (0-100) に変換する
  */
-const complexToPixel = (re: number, im: number): { x: number; y: number } => {
+const complexToPercent = (re: number, im: number): { x: number; y: number } => {
   const rangeX = MAP_R * 2;
   const rangeY = MAP_R * 2;
-  const x = ((re - (MAP_CENTER_X - MAP_R)) / rangeX) * DISPLAY_SIZE;
-  const y = ((MAP_CENTER_Y + MAP_R - im) / rangeY) * DISPLAY_SIZE;
+  const x = ((re - (MAP_CENTER_X - MAP_R)) / rangeX) * 100;
+  const y = ((MAP_CENTER_Y + MAP_R - im) / rangeY) * 100;
   return { x, y };
 };
 
 /**
- * ピンを貪欲法でクラスタリングする
+ * ピンを貪欲法でクラスタリングする (%単位)
  */
 const clusterPins = (pins: Pin[]): Cluster[] => {
   const clusters: Cluster[] = [];
+  const r = CLUSTER_RADIUS_PERCENT;
 
   for (const pin of pins) {
     let merged = false;
     for (const cluster of clusters) {
       const dx = pin.x - cluster.cx;
       const dy = pin.y - cluster.cy;
-      if (dx * dx + dy * dy <= CLUSTER_RADIUS * CLUSTER_RADIUS) {
+      if (dx * dx + dy * dy <= r * r) {
         cluster.pins.push(pin);
         // クラスタ中心を再計算
         cluster.cx = cluster.pins.reduce((sum, p) => sum + p.x, 0) / cluster.pins.length;
@@ -126,19 +127,16 @@ const jumpToUserPOI = (poi: POIData) => {
   setSerializedPalette(poi.serializedPalette);
 };
 
-/** ポップオーバーの幅(px) */
-const POPOVER_WIDTH = 260;
-
 /**
- * ピンの位置に応じてポップオーバーの配置を決定する
+ * ピンの位置 (%) に応じてポップオーバーの配置を決定する
  *
  * 端に近い場合は逆方向に表示し、はみ出しを防ぐ。
  */
 const popoverPosition = (cx: number, cy: number): React.CSSProperties => {
   const style: React.CSSProperties = {};
 
-  // 縦方向: 上端に近ければ下に、それ以外は上に表示
-  if (cy < 120) {
+  // 縦方向: 上端15%以内なら下に、それ以外は上に表示
+  if (cy < 15) {
     style.top = "100%";
     style.marginTop = 8;
   } else {
@@ -147,9 +145,9 @@ const popoverPosition = (cx: number, cy: number): React.CSSProperties => {
   }
 
   // 横方向: 左端/右端に近ければ寄せる、それ以外は中央
-  if (cx < POPOVER_WIDTH / 2 + 16) {
+  if (cx < 20) {
     style.left = 0;
-  } else if (cx > DISPLAY_SIZE - POPOVER_WIDTH / 2 - 16) {
+  } else if (cx > 80) {
     style.right = 0;
   } else {
     style.left = "50%";
@@ -258,8 +256,8 @@ const ClusterPin = ({ cluster, onJump }: { cluster: Cluster; onJump: () => void 
       ref={pinRef}
       className="absolute"
       style={{
-        left: cluster.cx,
-        top: cluster.cy,
+        left: `${cluster.cx}%`,
+        top: `${cluster.cy}%`,
         transform: "translate(-50%, -50%)",
         zIndex: showPopover ? 50 : 10,
       }}
@@ -332,9 +330,9 @@ export const MinimapDialog = ({ open, onOpenChange }: MinimapDialogProps) => {
       if (duplicatePresetIds.has(poi.id)) continue;
       const re = Number(poi.x);
       const im = Number(poi.y);
-      const { x, y } = complexToPixel(re, im);
+      const { x, y } = complexToPercent(re, im);
       // 表示範囲外はスキップ
-      if (x < 0 || x > DISPLAY_SIZE || y < 0 || y > DISPLAY_SIZE) continue;
+      if (x < 0 || x > 100 || y < 0 || y > 100) continue;
       pins.push({
         x,
         y,
@@ -350,8 +348,8 @@ export const MinimapDialog = ({ open, onOpenChange }: MinimapDialogProps) => {
     for (const poi of userPOIList) {
       const re = poi.x.toNumber();
       const im = poi.y.toNumber();
-      const { x, y } = complexToPixel(re, im);
-      if (x < 0 || x > DISPLAY_SIZE || y < 0 || y > DISPLAY_SIZE) continue;
+      const { x, y } = complexToPercent(re, im);
+      if (x < 0 || x > 100 || y < 0 || y > 100) continue;
       pins.push({
         x,
         y,
@@ -378,7 +376,10 @@ export const MinimapDialog = ({ open, onOpenChange }: MinimapDialogProps) => {
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[95vh] max-w-fit p-4" aria-describedby={undefined}>
+      <DialogContent
+        className="max-h-[95vh] max-w-[min(95vw,1056px)] overflow-y-auto p-4"
+        aria-describedby={undefined}
+      >
         <DialogHeader>
           <DialogTitle>Minimap</DialogTitle>
         </DialogHeader>
@@ -399,14 +400,13 @@ export const MinimapDialog = ({ open, onOpenChange }: MinimapDialogProps) => {
           </span>
         </div>
         <div
-          className="relative overflow-hidden rounded border border-[#2a2a3a]"
-          style={{ width: DISPLAY_SIZE, height: DISPLAY_SIZE }}
+          className="relative aspect-square w-full overflow-hidden rounded border border-[#2a2a3a]"
+          style={{ maxWidth: MAX_DISPLAY_SIZE }}
         >
           <img
             src={`${import.meta.env.BASE_URL ?? "/"}minimap.png`}
             alt="Mandelbrot set minimap"
-            className="block"
-            style={{ width: DISPLAY_SIZE, height: DISPLAY_SIZE }}
+            className="block size-full"
             draggable={false}
           />
           {clusters.map((cluster, i) => (

--- a/src/view/minimap/minimap-dialog.tsx
+++ b/src/view/minimap/minimap-dialog.tsx
@@ -400,7 +400,7 @@ export const MinimapDialog = ({ open, onOpenChange }: MinimapDialogProps) => {
           </span>
         </div>
         <div
-          className="relative aspect-square w-full overflow-hidden rounded border border-[#2a2a3a]"
+          className="relative aspect-square w-full rounded border border-[#2a2a3a]"
           style={{ maxWidth: MAX_DISPLAY_SIZE }}
         >
           <img

--- a/src/view/minimap/minimap-dialog.tsx
+++ b/src/view/minimap/minimap-dialog.tsx
@@ -195,8 +195,7 @@ const ClusterPopover = ({ cluster, onJump }: { cluster: Cluster; onJump: () => v
 /**
  * ミニマップ上のピン（またはクラスタ）を描画するコンポーネント
  *
- * 複数ピンのクラスタ: タップで Radix Popover (portal) が開いてサムネイル一覧表示。
- * 単一ピン: タップで直接ジャンプ。
+ * タップで Radix Popover (portal) が開いてサムネイル一覧表示（1件でも表示）。
  */
 const ClusterPin = ({ cluster, onJump }: { cluster: Cluster; onJump: () => void }) => {
   const [open, setOpen] = useState(false);
@@ -232,13 +231,6 @@ const ClusterPin = ({ cluster, onJump }: { cluster: Cluster; onJump: () => void 
           height: isSingle ? 18 : 26,
           cursor: "pointer",
         }}
-        onClick={(e) => {
-          if (isSingle) {
-            e.stopPropagation();
-            cluster.pins[0].jumpAction();
-            onJump();
-          }
-        }}
       >
         {!isSingle && (
           <span className="text-[11px] font-bold text-white">{cluster.pins.length}</span>
@@ -246,8 +238,6 @@ const ClusterPin = ({ cluster, onJump }: { cluster: Cluster; onJump: () => void 
       </div>
     </div>
   );
-
-  if (isSingle) return pinEl;
 
   return (
     <Popover open={open} onOpenChange={setOpen}>

--- a/src/view/minimap/minimap-dialog.tsx
+++ b/src/view/minimap/minimap-dialog.tsx
@@ -13,7 +13,7 @@ import { loadPreview } from "@/store/preview-store";
 import { updateStore, useStoreValue } from "@/store/store";
 import type { POIData } from "@/types";
 import BigNumber from "bignumber.js";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 /** ミニマップの最大表示サイズ(px) */
 const MAX_DISPLAY_SIZE = 1024;
@@ -216,12 +216,30 @@ const ClusterPin = ({ cluster, onJump }: { cluster: Cluster; onJump: () => void 
   };
 
   // PCのマウスhoverで開閉、モバイルタッチ時はRadixのclick→onOpenChange任せ
+  // trigger↔content間のgapを通過中に閉じないよう、leaveはdelay付きでcloseしenterでcancelする
+  const closeTimerRef = useRef<number | null>(null);
+  const cancelClose = () => {
+    if (closeTimerRef.current !== null) {
+      window.clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+  };
   const handleMouseEnter = (e: React.PointerEvent) => {
-    if (e.pointerType === "mouse") setOpen(true);
+    if (e.pointerType !== "mouse") return;
+    cancelClose();
+    setOpen(true);
   };
   const handleMouseLeave = (e: React.PointerEvent) => {
-    if (e.pointerType === "mouse") setOpen(false);
+    if (e.pointerType !== "mouse") return;
+    cancelClose();
+    closeTimerRef.current = window.setTimeout(() => {
+      setOpen(false);
+      closeTimerRef.current = null;
+    }, 150);
   };
+  useEffect(() => {
+    return cancelClose;
+  }, []);
 
   const pinEl = (
     <div

--- a/src/view/minimap/minimap-dialog.tsx
+++ b/src/view/minimap/minimap-dialog.tsx
@@ -164,6 +164,7 @@ const ClusterPopover = ({ cluster, onJump }: { cluster: Cluster; onJump: () => v
       }}
       onTouchStartCapture={(e) => e.stopPropagation()}
       onTouchMoveCapture={(e) => e.stopPropagation()}
+      onWheelCapture={(e) => e.stopPropagation()}
     >
       {cluster.pins.map((pin) => (
         <button

--- a/src/view/minimap/minimap-dialog.tsx
+++ b/src/view/minimap/minimap-dialog.tsx
@@ -1,4 +1,5 @@
 import { setSerializedPalette } from "@/camera/palette";
+import { useT } from "@/i18n/context";
 import { clearIterationCache } from "@/iteration-buffer/iteration-buffer";
 import { setCurrentParams, setManualN } from "@/mandelbrot-state/mandelbrot-state";
 import {
@@ -7,12 +8,19 @@ import {
   isSamePOI,
   usePresetPOIList,
 } from "@/preset-poi/preset-poi";
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/shadcn/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/shadcn/components/ui/dialog";
 import { Popover, PopoverContent, PopoverTrigger } from "@/shadcn/components/ui/popover";
 import { loadPreview } from "@/store/preview-store";
 import { updateStore, useStoreValue } from "@/store/store";
 import type { POIData } from "@/types";
 import BigNumber from "bignumber.js";
+import { VisuallyHidden } from "radix-ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 /** ミニマップの最大表示サイズ(px) */
@@ -294,6 +302,7 @@ const ClusterPin = ({ cluster, onJump }: { cluster: Cluster; onJump: () => void 
  * 近接するピンはクラスタリングされ、ホバーでサムネイル一覧を表示する。
  */
 export const MinimapDialog = ({ open, onOpenChange }: MinimapDialogProps) => {
+  const t = useT();
   const userPOIList: POIData[] = useStoreValue("poi");
   const presetList = usePresetPOIList();
 
@@ -363,12 +372,14 @@ export const MinimapDialog = ({ open, onOpenChange }: MinimapDialogProps) => {
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent
-        className="flex max-h-[95dvh] w-[calc(100vw-2rem)] max-w-[1056px] flex-col p-4"
-        aria-describedby={undefined}
-      >
+      <DialogContent className="flex max-h-[95dvh] w-[calc(100vw-2rem)] max-w-[1056px] flex-col p-4">
         <DialogHeader>
           <DialogTitle>Minimap</DialogTitle>
+          <VisuallyHidden.Root>
+            <DialogDescription>
+              {t("Overview map of saved POIs", "dialog.description.minimap")}
+            </DialogDescription>
+          </VisuallyHidden.Root>
         </DialogHeader>
         <div className="flex items-center gap-4 text-xs text-muted-foreground">
           <span className="flex items-center gap-1">

--- a/src/view/minimap/minimap-dialog.tsx
+++ b/src/view/minimap/minimap-dialog.tsx
@@ -377,7 +377,7 @@ export const MinimapDialog = ({ open, onOpenChange }: MinimapDialogProps) => {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
-        className="max-h-[95vh] max-w-[min(95vw,1056px)] overflow-y-auto p-4"
+        className="max-h-[95vh] w-[calc(100vw-2rem)] max-w-[1056px] overflow-y-auto p-4"
         aria-describedby={undefined}
       >
         <DialogHeader>

--- a/src/view/minimap/minimap-dialog.tsx
+++ b/src/view/minimap/minimap-dialog.tsx
@@ -10,7 +10,7 @@ import {
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/shadcn/components/ui/dialog";
 import { Popover, PopoverContent, PopoverTrigger } from "@/shadcn/components/ui/popover";
 import { loadPreview } from "@/store/preview-store";
-import { useStoreValue } from "@/store/store";
+import { updateStore, useStoreValue } from "@/store/store";
 import type { POIData } from "@/types";
 import BigNumber from "bignumber.js";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -157,9 +157,10 @@ const ClusterPopover = ({ cluster, onJump }: { cluster: Cluster; onJump: () => v
 
   return (
     <div
-      className="grid max-h-72 gap-1.5 overflow-y-auto"
+      className="grid max-h-72 gap-1.5 overflow-y-auto overscroll-contain"
       style={{
         gridTemplateColumns: `repeat(${Math.min(cluster.pins.length, 3)}, 80px)`,
+        touchAction: "pan-y",
       }}
     >
       {cluster.pins.map((pin) => (
@@ -331,6 +332,8 @@ export const MinimapDialog = ({ open, onOpenChange }: MinimapDialogProps) => {
 
   const handleJump = useCallback(() => {
     onOpenChange(false);
+    // 選択結果をキャンバスでしっかり見せるためPOI drawerも閉じる
+    updateStore("poiDrawerSnap", "closed");
   }, [onOpenChange]);
 
   if (!open) return null;

--- a/src/view/poi-panel/index.tsx
+++ b/src/view/poi-panel/index.tsx
@@ -56,8 +56,18 @@ const SuggestRedirect = () => {
 /** POIパネルのヘッダー */
 export const POIPanelHeader = () => {
   const t = useT();
+  const isMobile = useIsMobile();
   const [presetOpened, { open: openPreset, close: closePreset }] = useModalState();
   const [minimapOpened, { open: openMinimap, close: closeMinimap }] = useModalState();
+
+  /** ×ボタン: モバイルならDrawerをclosedへ、デスクトップなら従来通りpoiPanelOpen toggle */
+  const handleClose = () => {
+    if (isMobile) {
+      updateStore("poiDrawerSnap", "closed");
+    } else {
+      updateStoreWith("poiPanelOpen", (v) => !v);
+    }
+  };
 
   return (
     <>
@@ -76,7 +86,7 @@ export const POIPanelHeader = () => {
           </div>
         </div>
         <button
-          onClick={() => updateStoreWith("poiPanelOpen", (v) => !v)}
+          onClick={handleClose}
           className="text-muted-foreground hover:text-foreground rounded p-1 transition-colors"
         >
           <IconX size={18} />

--- a/src/view/poi-panel/index.tsx
+++ b/src/view/poi-panel/index.tsx
@@ -7,7 +7,9 @@ import { isGithubPages } from "@/utils/location";
 import { useModalState } from "@/view/modal/use-modal-state";
 import { MinimapDialog } from "@/view/minimap/minimap-dialog";
 import { PresetListDialog } from "@/view/preset-list/preset-list-dialog";
+import { useIsMobile } from "@/view/use-is-mobile";
 import { IconCirclePlus, IconLayoutSidebar, IconList, IconMap, IconX } from "@tabler/icons-react";
+import { POIPanelMobile } from "./mobile";
 import { POI } from "../right-sidebar/poi";
 import { POICardPreview } from "../right-sidebar/poi-card-preview";
 import { POIHistories } from "../right-sidebar/poi-histories";
@@ -18,7 +20,7 @@ import { usePanelLayout } from "../use-panel-layout";
 export const COLLAPSED_STRIP_WIDTH = 80;
 
 /** POIパネル内のコンテンツ */
-const PanelContent = () => {
+export const PanelContent = () => {
   if (isGithubPages()) {
     return <SuggestRedirect />;
   }
@@ -52,7 +54,7 @@ const SuggestRedirect = () => {
 };
 
 /** POIパネルのヘッダー */
-const POIPanelHeader = () => {
+export const POIPanelHeader = () => {
   const t = useT();
   const [presetOpened, { open: openPreset, close: closePreset }] = useModalState();
   const [minimapOpened, { open: openMinimap, close: closeMinimap }] = useModalState();
@@ -133,10 +135,15 @@ const CollapsedStrip = () => {
   );
 };
 
-/** 右側スライドインPOIパネル */
+/** 右側スライドインPOIパネル (モバイル時はBottomSheetに切り替え) */
 export const POIPanel = () => {
+  const isMobile = useIsMobile();
   const poiPanelOpen = useStoreValue("poiPanelOpen");
   const { poiPanelWidth } = usePanelLayout();
+
+  if (isMobile) {
+    return <POIPanelMobile />;
+  }
 
   return (
     <div

--- a/src/view/poi-panel/mobile.tsx
+++ b/src/view/poi-panel/mobile.tsx
@@ -1,5 +1,6 @@
 import { useT } from "@/i18n/context";
 import { cloneCurrentParams } from "@/mandelbrot-state/mandelbrot-state";
+import { getCanvasSize } from "@/rendering/renderer";
 import { Drawer, DrawerContent, DrawerTitle } from "@/shadcn/components/ui/drawer";
 import { updateStore, useStoreValue } from "@/store/store";
 import { IconCirclePlus } from "@tabler/icons-react";
@@ -10,7 +11,7 @@ import { PanelContent, POIPanelHeader } from "./index";
 
 /** vaul snapPoints: 完全非表示 / 横ストリップ (追加ボタン+サムネイル1行) / フル */
 const SNAP_CLOSED = 0;
-const SNAP_SMALL = "240px";
+const SNAP_SMALL = "280px";
 const SNAP_FULL = 1;
 const SNAP_POINTS = [SNAP_CLOSED, SNAP_SMALL, SNAP_FULL] as const;
 
@@ -34,12 +35,17 @@ const POIPanelSmallContent = () => {
   const t = useT();
   const { poiList, addPOI, applyPOI } = usePOI();
 
+  // 現在のcanvasアスペクトに合わせてSaveボタンを縦長にする (モバイルは縦長canvas想定)
+  const canvasSize = getCanvasSize();
+  const saveButtonAspect = canvasSize.width / canvasSize.height;
+
   return (
     <div className="flex h-[200px] items-center gap-2 overflow-x-auto px-3 pb-2">
       <button
         type="button"
         onClick={() => addPOI(cloneCurrentParams())}
-        className="flex aspect-square h-full shrink-0 flex-col items-center justify-center gap-1 rounded bg-primary/90 px-2 text-primary-foreground transition-colors hover:bg-primary"
+        style={{ aspectRatio: saveButtonAspect }}
+        className="flex h-full shrink-0 flex-col items-center justify-center gap-1 rounded bg-primary/90 px-2 text-primary-foreground transition-colors hover:bg-primary"
       >
         <IconCirclePlus size={28} />
         <span className="text-xs">{t("Save POI")}</span>
@@ -95,7 +101,11 @@ export const POIPanelMobile = () => {
             </div>
           </>
         ) : (
-          <POIPanelSmallContent />
+          <>
+            {/* ドラッグハンドル掴みやすいように上部の非スクロールゾーンを大きく取る */}
+            <div className="h-6 shrink-0" />
+            <POIPanelSmallContent />
+          </>
         )}
       </DrawerContent>
     </Drawer>

--- a/src/view/poi-panel/mobile.tsx
+++ b/src/view/poi-panel/mobile.tsx
@@ -96,7 +96,10 @@ export const POIPanelMobile = () => {
       activeSnapPoint={activeSnapPoint}
       setActiveSnapPoint={handleSnapChange}
     >
-      <DrawerContent className="h-[100dvh] bg-[#161620]/97 pb-4 backdrop-blur-sm data-[vaul-drawer-direction=bottom]:mt-0 data-[vaul-drawer-direction=bottom]:max-h-[100dvh]">
+      <DrawerContent
+        className="h-[100dvh] bg-[#161620]/97 pb-4 backdrop-blur-sm data-[vaul-drawer-direction=bottom]:mt-0 data-[vaul-drawer-direction=bottom]:max-h-[100dvh]"
+        aria-describedby={undefined}
+      >
         <VisuallyHidden.Root>
           <DrawerTitle>Points of Interest</DrawerTitle>
         </VisuallyHidden.Root>

--- a/src/view/poi-panel/mobile.tsx
+++ b/src/view/poi-panel/mobile.tsx
@@ -1,7 +1,12 @@
 import { useT } from "@/i18n/context";
 import { cloneCurrentParams } from "@/mandelbrot-state/mandelbrot-state";
 import { getCanvasSize } from "@/rendering/renderer";
-import { Drawer, DrawerContent, DrawerTitle } from "@/shadcn/components/ui/drawer";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerTitle,
+} from "@/shadcn/components/ui/drawer";
 import { updateStore, useStoreValue } from "@/store/store";
 import { IconCirclePlus } from "@tabler/icons-react";
 import { VisuallyHidden } from "radix-ui";
@@ -78,6 +83,7 @@ const POIPanelSmallContent = () => {
  * storeの `poiDrawerSnap` と vaul の activeSnapPoint を双方向同期する。
  */
 export const POIPanelMobile = () => {
+  const t = useT();
   const snap = useStoreValue("poiDrawerSnap");
   const activeSnapPoint =
     snap === "closed" ? SNAP_CLOSED : snap === "small" ? SNAP_SMALL : SNAP_FULL;
@@ -96,12 +102,12 @@ export const POIPanelMobile = () => {
       activeSnapPoint={activeSnapPoint}
       setActiveSnapPoint={handleSnapChange}
     >
-      <DrawerContent
-        className="h-[100dvh] bg-[#161620]/97 pb-4 backdrop-blur-sm data-[vaul-drawer-direction=bottom]:mt-0 data-[vaul-drawer-direction=bottom]:max-h-[100dvh]"
-        aria-describedby={undefined}
-      >
+      <DrawerContent className="h-[100dvh] bg-[#161620]/97 pb-4 backdrop-blur-sm data-[vaul-drawer-direction=bottom]:mt-0 data-[vaul-drawer-direction=bottom]:max-h-[100dvh]">
         <VisuallyHidden.Root>
           <DrawerTitle>Points of Interest</DrawerTitle>
+          <DrawerDescription>
+            {t("Saved Points of Interest", "dialog.description.poiPanel")}
+          </DrawerDescription>
         </VisuallyHidden.Root>
         {snap === "full" ? (
           <>

--- a/src/view/poi-panel/mobile.tsx
+++ b/src/view/poi-panel/mobile.tsx
@@ -9,9 +9,14 @@ import { POICardPreview } from "../right-sidebar/poi-card-preview";
 import { usePOI } from "../right-sidebar/use-poi";
 import { PanelContent, POIPanelHeader } from "./index";
 
-/** vaul snapPoints: 完全非表示 / 横ストリップ (追加ボタン+サムネイル1行) / フル */
-const SNAP_CLOSED = 0;
-const SNAP_SMALL = "280px";
+/**
+ * vaul snapPoints: 完全非表示 / 横ストリップ (追加ボタン+サムネイル1行) / フル
+ *
+ * closedは `"0px"` にする必要がある (`0` は vaul の useEffect 内の truthy check で
+ * 弾かれて activeSnapPoint の変化に反応しない)。
+ */
+const SNAP_CLOSED = "0px";
+const SNAP_SMALL = "240px";
 const SNAP_FULL = 1;
 const SNAP_POINTS = [SNAP_CLOSED, SNAP_SMALL, SNAP_FULL] as const;
 
@@ -40,7 +45,7 @@ const POIPanelSmallContent = () => {
   const saveButtonAspect = canvasSize.width / canvasSize.height;
 
   return (
-    <div className="flex h-[200px] items-center gap-2 overflow-x-auto px-3 pb-2">
+    <div className="flex h-[180px] items-center gap-2 overflow-x-auto px-3">
       <button
         type="button"
         onClick={() => addPOI(cloneCurrentParams())}

--- a/src/view/poi-panel/mobile.tsx
+++ b/src/view/poi-panel/mobile.tsx
@@ -1,0 +1,42 @@
+import { Drawer, DrawerContent, DrawerTitle } from "@/shadcn/components/ui/drawer";
+import { updateStore, useStoreValue } from "@/store/store";
+import { VisuallyHidden } from "radix-ui";
+import { PanelContent, POIPanelHeader } from "./index";
+
+/** モバイル時のスナップ位置 (ピーク / フル) */
+const SNAP_POINTS = [0.15, 1] as const;
+
+/** モバイル時のPOI BottomSheet (2段階スナップ) */
+export const POIPanelMobile = () => {
+  const poiPanelOpen = useStoreValue("poiPanelOpen");
+  const activeSnapPoint = poiPanelOpen ? SNAP_POINTS[1] : SNAP_POINTS[0];
+
+  const handleSnapChange = (snap: number | string | null) => {
+    if (snap === SNAP_POINTS[1]) {
+      updateStore("poiPanelOpen", true);
+    } else if (snap === SNAP_POINTS[0]) {
+      updateStore("poiPanelOpen", false);
+    }
+  };
+
+  return (
+    <Drawer
+      open
+      dismissible={false}
+      modal={false}
+      snapPoints={[...SNAP_POINTS]}
+      activeSnapPoint={activeSnapPoint}
+      setActiveSnapPoint={handleSnapChange}
+    >
+      <DrawerContent className="bg-[#161620]/97 backdrop-blur-sm">
+        <VisuallyHidden.Root>
+          <DrawerTitle>Points of Interest</DrawerTitle>
+        </VisuallyHidden.Root>
+        <POIPanelHeader />
+        <div className="flex min-h-0 grow flex-col overflow-y-auto px-2 pt-2">
+          <PanelContent />
+        </div>
+      </DrawerContent>
+    </Drawer>
+  );
+};

--- a/src/view/poi-panel/mobile.tsx
+++ b/src/view/poi-panel/mobile.tsx
@@ -41,8 +41,10 @@ const POIPanelSmallContent = () => {
   const { poiList, addPOI, applyPOI } = usePOI();
 
   // 現在のcanvasアスペクトに合わせてSaveボタンを縦長にする (モバイルは縦長canvas想定)
+  // 初期化前はcanvasSizeが0/0でNaNになるので正方形(=1)にフォールバック
   const canvasSize = getCanvasSize();
-  const saveButtonAspect = canvasSize.width / canvasSize.height;
+  const rawAspect = canvasSize.width / canvasSize.height;
+  const saveButtonAspect = Number.isFinite(rawAspect) && rawAspect > 0 ? rawAspect : 1;
 
   return (
     <div className="flex h-[180px] items-center gap-2 overflow-x-auto px-3">

--- a/src/view/poi-panel/mobile.tsx
+++ b/src/view/poi-panel/mobile.tsx
@@ -1,22 +1,77 @@
+import { useT } from "@/i18n/context";
+import { cloneCurrentParams } from "@/mandelbrot-state/mandelbrot-state";
 import { Drawer, DrawerContent, DrawerTitle } from "@/shadcn/components/ui/drawer";
 import { updateStore, useStoreValue } from "@/store/store";
+import { IconCirclePlus } from "@tabler/icons-react";
 import { VisuallyHidden } from "radix-ui";
+import { POICardPreview } from "../right-sidebar/poi-card-preview";
+import { usePOI } from "../right-sidebar/use-poi";
 import { PanelContent, POIPanelHeader } from "./index";
 
-/** モバイル時のスナップ位置 (ピーク / フル) */
-const SNAP_POINTS = [0.15, 1] as const;
+/** vaul snapPoints: 完全非表示 / 横ストリップ (追加ボタン+サムネイル1行) / フル */
+const SNAP_CLOSED = 0;
+const SNAP_SMALL = "240px";
+const SNAP_FULL = 1;
+const SNAP_POINTS = [SNAP_CLOSED, SNAP_SMALL, SNAP_FULL] as const;
 
-/** モバイル時のPOI BottomSheet (2段階スナップ) */
+/**
+ * vaulのsnap値 (`0` | `"240px"` | `1`) をstoreの `poiDrawerSnap` 値に変換する
+ */
+const snapValueToState = (v: number | string | null): "closed" | "small" | "full" | null => {
+  if (v === SNAP_CLOSED) return "closed";
+  if (v === SNAP_SMALL) return "small";
+  if (v === SNAP_FULL) return "full";
+  return null;
+};
+
+/**
+ * 小モード: 追加ボタン + POIサムネイルの横スクロールストリップ
+ *
+ * PC版の閉じているときのCollapsedStripを横倒しにしたイメージ。
+ * サムネイルは "natural" アスペクトで表示する (モバイルはcanvasが非正方形のため)。
+ */
+const POIPanelSmallContent = () => {
+  const t = useT();
+  const { poiList, addPOI, applyPOI } = usePOI();
+
+  return (
+    <div className="mt-auto flex h-[200px] items-center gap-2 overflow-x-auto px-3 pb-2">
+      <button
+        type="button"
+        onClick={() => addPOI(cloneCurrentParams())}
+        className="flex aspect-square h-full shrink-0 flex-col items-center justify-center gap-1 rounded bg-primary/90 px-2 text-primary-foreground transition-colors hover:bg-primary"
+      >
+        <IconCirclePlus size={28} />
+        <span className="text-xs">{t("Save POI")}</span>
+      </button>
+      {poiList.map((poi) => (
+        <button
+          type="button"
+          key={poi.id}
+          onClick={() => applyPOI(poi)}
+          className="flex h-full shrink-0 items-center justify-center overflow-hidden rounded transition-opacity hover:opacity-80"
+        >
+          <POICardPreview poi={poi} aspect="natural" />
+        </button>
+      ))}
+    </div>
+  );
+};
+
+/**
+ * モバイル時のPOI BottomSheet
+ *
+ * 3状態スナップ (closed / small / full)。
+ * storeの `poiDrawerSnap` と vaul の activeSnapPoint を双方向同期する。
+ */
 export const POIPanelMobile = () => {
-  const poiPanelOpen = useStoreValue("poiPanelOpen");
-  const activeSnapPoint = poiPanelOpen ? SNAP_POINTS[1] : SNAP_POINTS[0];
+  const snap = useStoreValue("poiDrawerSnap");
+  const activeSnapPoint =
+    snap === "closed" ? SNAP_CLOSED : snap === "small" ? SNAP_SMALL : SNAP_FULL;
 
-  const handleSnapChange = (snap: number | string | null) => {
-    if (snap === SNAP_POINTS[1]) {
-      updateStore("poiPanelOpen", true);
-    } else if (snap === SNAP_POINTS[0]) {
-      updateStore("poiPanelOpen", false);
-    }
+  const handleSnapChange = (value: number | string | null) => {
+    const next = snapValueToState(value);
+    if (next) updateStore("poiDrawerSnap", next);
   };
 
   return (
@@ -28,14 +83,20 @@ export const POIPanelMobile = () => {
       activeSnapPoint={activeSnapPoint}
       setActiveSnapPoint={handleSnapChange}
     >
-      <DrawerContent className="h-[100dvh] bg-[#161620]/97 backdrop-blur-sm data-[vaul-drawer-direction=bottom]:mt-0 data-[vaul-drawer-direction=bottom]:max-h-[100dvh]">
+      <DrawerContent className="h-[100dvh] bg-[#161620]/97 pb-4 backdrop-blur-sm data-[vaul-drawer-direction=bottom]:mt-0 data-[vaul-drawer-direction=bottom]:max-h-[100dvh]">
         <VisuallyHidden.Root>
           <DrawerTitle>Points of Interest</DrawerTitle>
         </VisuallyHidden.Root>
-        <POIPanelHeader />
-        <div className="flex min-h-0 grow flex-col overflow-y-auto px-2 pt-2">
-          <PanelContent />
-        </div>
+        {snap === "full" ? (
+          <>
+            <POIPanelHeader />
+            <div className="flex min-h-0 grow flex-col overflow-y-auto px-2 pt-2">
+              <PanelContent />
+            </div>
+          </>
+        ) : (
+          <POIPanelSmallContent />
+        )}
       </DrawerContent>
     </Drawer>
   );

--- a/src/view/poi-panel/mobile.tsx
+++ b/src/view/poi-panel/mobile.tsx
@@ -28,7 +28,7 @@ export const POIPanelMobile = () => {
       activeSnapPoint={activeSnapPoint}
       setActiveSnapPoint={handleSnapChange}
     >
-      <DrawerContent className="bg-[#161620]/97 backdrop-blur-sm">
+      <DrawerContent className="h-[100dvh] bg-[#161620]/97 backdrop-blur-sm data-[vaul-drawer-direction=bottom]:mt-0 data-[vaul-drawer-direction=bottom]:max-h-[100dvh]">
         <VisuallyHidden.Root>
           <DrawerTitle>Points of Interest</DrawerTitle>
         </VisuallyHidden.Root>

--- a/src/view/poi-panel/mobile.tsx
+++ b/src/view/poi-panel/mobile.tsx
@@ -35,7 +35,7 @@ const POIPanelSmallContent = () => {
   const { poiList, addPOI, applyPOI } = usePOI();
 
   return (
-    <div className="mt-auto flex h-[200px] items-center gap-2 overflow-x-auto px-3 pb-2">
+    <div className="flex h-[200px] items-center gap-2 overflow-x-auto px-3 pb-2">
       <button
         type="button"
         onClick={() => addPOI(cloneCurrentParams())}

--- a/src/view/preset-list/preset-list-dialog.tsx
+++ b/src/view/preset-list/preset-list-dialog.tsx
@@ -111,7 +111,7 @@ export const PresetListDialog = ({ open, onOpenChange }: PresetListDialogProps) 
 
   return (
     <Dialog open={open} onOpenChange={isRunning ? undefined : onOpenChange}>
-      <DialogContent className="max-h-[80vh] max-w-6xl" aria-describedby={undefined}>
+      <DialogContent className="max-h-[80dvh] max-w-6xl" aria-describedby={undefined}>
         <DialogHeader>
           <DialogTitle>{t("Preset List", "preset.title")}</DialogTitle>
         </DialogHeader>
@@ -185,7 +185,7 @@ export const PresetListDialog = ({ open, onOpenChange }: PresetListDialogProps) 
           className="grid auto-rows-min gap-2 overflow-y-auto pr-1"
           style={{
             gridTemplateColumns: "repeat(auto-fill, minmax(160px, 1fr))",
-            maxHeight: "calc(80vh - 160px)",
+            maxHeight: "calc(80dvh - 160px)",
           }}
         >
           {presetList.map((poi) => (

--- a/src/view/preset-list/preset-list-dialog.tsx
+++ b/src/view/preset-list/preset-list-dialog.tsx
@@ -13,6 +13,7 @@ import {
 import { Alert, AlertDescription } from "@/shadcn/components/ui/alert";
 import { Button } from "@/shadcn/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/shadcn/components/ui/dialog";
+import { updateStore } from "@/store/store";
 import { isDevMode } from "@/utils/dev-mode";
 import {
   type ThumbnailTarget,
@@ -195,6 +196,8 @@ export const PresetListDialog = ({ open, onOpenChange }: PresetListDialogProps) 
               onJump={() => {
                 jumpToPreset(poi);
                 onOpenChange(false);
+                // 選択結果をキャンバスで見せるためPOI drawerも閉じる
+                updateStore("poiDrawerSnap", "closed");
               }}
               onDelete={() => handleDelete(poi.id)}
             />

--- a/src/view/preset-list/preset-list-dialog.tsx
+++ b/src/view/preset-list/preset-list-dialog.tsx
@@ -12,7 +12,13 @@ import {
 } from "@/preset-poi/preset-poi";
 import { Alert, AlertDescription } from "@/shadcn/components/ui/alert";
 import { Button } from "@/shadcn/components/ui/button";
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/shadcn/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/shadcn/components/ui/dialog";
 import { updateStore } from "@/store/store";
 import { isDevMode } from "@/utils/dev-mode";
 import {
@@ -21,6 +27,7 @@ import {
 } from "@/view/thumbnail-batch/use-thumbnail-batch";
 import { IconCloud, IconFolder, IconPhoto, IconRefresh, IconTrash } from "@tabler/icons-react";
 import BigNumber from "bignumber.js";
+import { VisuallyHidden } from "radix-ui";
 import { useCallback, useState } from "react";
 
 type PresetListDialogProps = {
@@ -111,9 +118,14 @@ export const PresetListDialog = ({ open, onOpenChange }: PresetListDialogProps) 
 
   return (
     <Dialog open={open} onOpenChange={isRunning ? undefined : onOpenChange}>
-      <DialogContent className="max-h-[80dvh] max-w-6xl" aria-describedby={undefined}>
+      <DialogContent className="max-h-[80dvh] max-w-6xl">
         <DialogHeader>
           <DialogTitle>{t("Preset List", "preset.title")}</DialogTitle>
+          <VisuallyHidden.Root>
+            <DialogDescription>
+              {t("Preset POI list", "dialog.description.presetList")}
+            </DialogDescription>
+          </VisuallyHidden.Root>
         </DialogHeader>
         <div className="flex items-center justify-between">
           <div className="text-sm text-muted-foreground">

--- a/src/view/progress-bar/index.tsx
+++ b/src/view/progress-bar/index.tsx
@@ -1,9 +1,14 @@
 import { Footer } from "../footer";
 
-/** フローティング進捗バー（左下固定） */
+/**
+ * フローティング進捗バー
+ *
+ * デスクトップ: 左下に500px固定幅で配置。
+ * モバイル (<=768px): 画面下端いっぱいに配置し、POI BottomSheetのピーク(15vh)の上にずらす。
+ */
 export const ProgressBar = () => {
   return (
-    <div className="fixed bottom-3 left-3 z-100 w-125 rounded-xl border border-[#2a2a3a] bg-[#1c1c24]/95 px-3 py-2 backdrop-blur-sm">
+    <div className="fixed right-3 bottom-[calc(15vh+0.75rem)] left-3 z-100 rounded-xl border border-[#2a2a3a] bg-[#1c1c24]/95 px-3 py-2 backdrop-blur-sm md:right-auto md:bottom-3 md:w-125">
       <Footer />
     </div>
   );

--- a/src/view/progress-bar/index.tsx
+++ b/src/view/progress-bar/index.tsx
@@ -24,26 +24,34 @@ const parseProgressPercent = (s: string): number => {
 };
 
 /**
- * モバイル用の細ラインプログレスバー + 完了時footer
+ * モバイル用の細ラインプログレスバー + 常時表示footer
  *
- * - 描画中: 画面下端3pxの細いプログレスラインのみ
- * - 完了後: 16px高の薄背景footerにelapsed表示 + 下端3pxにフルバー
+ * - 左: r と N を常時表示 (canvas上のUI描画と同等の情報)
+ * - 右: 完了後は elapsed を表示
+ * - 下端3pxにプログレスライン (描画中は進行率, 完了後はフル)
  */
 const MobileProgressBar = () => {
   const t = useT();
   const progress = useStoreValue("progress");
+  const r = useStoreValue("r");
+  const N = useStoreValue("N");
 
   const isDone = typeof progress === "object" && progress !== null;
   const percent = isDone ? 100 : typeof progress === "string" ? parseProgressPercent(progress) : 0;
   const elapsedText = isDone ? `${t("elapsed: ", "footer.elapsedPrefix")}${progress.total}ms` : "";
+  const rText = r ? `r:${r.toPrecision(4)}` : "";
+  const statsText = `${rText} N:${N}`;
 
   return (
     <div className="pointer-events-none fixed right-0 bottom-0 left-0 z-[60] h-4">
-      {isDone && (
-        <div className="absolute inset-x-0 top-0 bottom-[3px] flex items-center justify-end bg-[#1c1c24]/70 px-2 backdrop-blur-sm">
-          <span className="text-[10px] leading-none text-muted-foreground">{elapsedText}</span>
-        </div>
-      )}
+      <div className="absolute inset-x-0 top-0 bottom-[3px] flex items-center justify-between gap-2 bg-[#1c1c24]/70 px-2 backdrop-blur-sm">
+        <span className="truncate font-mono text-[10px] leading-none text-muted-foreground">
+          {statsText}
+        </span>
+        <span className="truncate text-[10px] leading-none text-muted-foreground">
+          {elapsedText}
+        </span>
+      </div>
       <div className="absolute right-0 bottom-0 left-0 h-[3px] bg-gray-700/30">
         <div
           className="h-full bg-primary transition-all duration-150"

--- a/src/view/progress-bar/index.tsx
+++ b/src/view/progress-bar/index.tsx
@@ -1,3 +1,4 @@
+import { useT } from "@/i18n/context";
 import { useStoreValue } from "@/store/store";
 import { useIsMobile } from "@/view/use-is-mobile";
 import { Footer } from "../footer";
@@ -26,20 +27,21 @@ const parseProgressPercent = (s: string): number => {
  * モバイル用の細ラインプログレスバー + 完了時footer
  *
  * - 描画中: 画面下端3pxの細いプログレスラインのみ
- * - 完了後: 12px高の薄背景footerにelapsed表示 + 下端3pxにフルバー
+ * - 完了後: 16px高の薄背景footerにelapsed表示 + 下端3pxにフルバー
  */
 const MobileProgressBar = () => {
+  const t = useT();
   const progress = useStoreValue("progress");
 
   const isDone = typeof progress === "object" && progress !== null;
   const percent = isDone ? 100 : typeof progress === "string" ? parseProgressPercent(progress) : 0;
-  const elapsedText = isDone ? `${progress.total}ms` : "";
+  const elapsedText = isDone ? `${t("elapsed: ", "footer.elapsedPrefix")}${progress.total}ms` : "";
 
   return (
-    <div className="pointer-events-none fixed right-0 bottom-0 left-0 z-50 h-3">
+    <div className="pointer-events-none fixed right-0 bottom-0 left-0 z-50 h-4">
       {isDone && (
         <div className="absolute inset-x-0 top-0 bottom-[3px] flex items-center justify-end bg-[#1c1c24]/70 px-2 backdrop-blur-sm">
-          <span className="text-[9px] leading-none text-muted-foreground">{elapsedText}</span>
+          <span className="text-[10px] leading-none text-muted-foreground">{elapsedText}</span>
         </div>
       )}
       <div className="absolute right-0 bottom-0 left-0 h-[3px] bg-gray-700/30">

--- a/src/view/progress-bar/index.tsx
+++ b/src/view/progress-bar/index.tsx
@@ -43,14 +43,12 @@ const MobileProgressBar = () => {
   const statsText = `${rText} N:${N}`;
 
   return (
-    <div className="pointer-events-none fixed right-0 bottom-0 left-0 z-[60] h-4">
+    <div className="pointer-events-none fixed right-0 bottom-0 left-0 z-[60] h-5">
       <div className="absolute inset-x-0 top-0 bottom-[3px] flex items-center justify-between gap-2 bg-[#1c1c24]/70 px-2 backdrop-blur-sm">
-        <span className="truncate font-mono text-[10px] leading-none text-muted-foreground">
+        <span className="truncate font-mono text-xs leading-none text-muted-foreground">
           {statsText}
         </span>
-        <span className="truncate text-[10px] leading-none text-muted-foreground">
-          {elapsedText}
-        </span>
+        <span className="truncate text-xs leading-none text-muted-foreground">{elapsedText}</span>
       </div>
       <div className="absolute right-0 bottom-0 left-0 h-[3px] bg-gray-700/30">
         <div

--- a/src/view/progress-bar/index.tsx
+++ b/src/view/progress-bar/index.tsx
@@ -1,6 +1,8 @@
 import { useT } from "@/i18n/context";
 import { useStoreValue } from "@/store/store";
 import { useIsMobile } from "@/view/use-is-mobile";
+import { BumpPill } from "../bump-pill";
+import { BUMP_DISPLAY_THRESHOLD } from "../bump-pill/bump-state";
 import { Footer } from "../footer";
 
 /**
@@ -35,12 +37,15 @@ const MobileProgressBar = () => {
   const progress = useStoreValue("progress");
   const r = useStoreValue("r");
   const N = useStoreValue("N");
+  const nHitRatio = useStoreValue("nHitRatio");
 
   const isDone = typeof progress === "object" && progress !== null;
   const percent = isDone ? 100 : typeof progress === "string" ? parseProgressPercent(progress) : 0;
   const elapsedText = isDone ? `${t("elapsed: ", "footer.elapsedPrefix")}${progress.total}ms` : "";
   const rText = r ? `r:${r.toPrecision(4)}` : "";
-  const statsText = `${rText} N:${N}`;
+  const showNWarning = nHitRatio != null && nHitRatio > BUMP_DISPLAY_THRESHOLD;
+  const nText = showNWarning ? `⚠ N:${N}` : `N:${N}`;
+  const statsText = `${rText} ${nText}`;
 
   return (
     <div className="pointer-events-none fixed right-0 bottom-0 left-0 z-[60] h-5">
@@ -70,5 +75,10 @@ const DesktopProgressBar = () => (
 /** フローティング進捗バー (モバイル時は細ライン+footerに切替) */
 export const ProgressBar = () => {
   const isMobile = useIsMobile();
-  return isMobile ? <MobileProgressBar /> : <DesktopProgressBar />;
+  return (
+    <>
+      {isMobile ? <MobileProgressBar /> : <DesktopProgressBar />}
+      <BumpPill />
+    </>
+  );
 };

--- a/src/view/progress-bar/index.tsx
+++ b/src/view/progress-bar/index.tsx
@@ -26,13 +26,15 @@ const parseProgressPercent = (s: string): number => {
 };
 
 /**
- * モバイル用の細ラインプログレスバー + 常時表示footer
+ * 薄い帯状のプログレスバー本体 (モバイル画面下/SupersamplingOverlay内で共用)
  *
  * - 左: r と N を常時表示 (canvas上のUI描画と同等の情報)
  * - 右: 完了後は elapsed を表示
  * - 下端3pxにプログレスライン (描画中は進行率, 完了後はフル)
+ *
+ * 配置用のposition/z-indexは呼び出し側で付ける。
  */
-const MobileProgressBar = () => {
+export const ProgressBarInline = () => {
   const t = useT();
   const progress = useStoreValue("progress");
   const r = useStoreValue("r");
@@ -48,7 +50,7 @@ const MobileProgressBar = () => {
   const statsText = `${rText} ${nText}`;
 
   return (
-    <div className="pointer-events-none fixed right-0 bottom-0 left-0 z-[60] h-5">
+    <div className="relative h-5 w-full">
       <div className="absolute inset-x-0 top-0 bottom-[3px] flex items-center justify-between gap-2 bg-[#1c1c24]/70 px-2 backdrop-blur-sm">
         <span className="truncate font-mono text-xs leading-none text-muted-foreground">
           {statsText}
@@ -64,6 +66,15 @@ const MobileProgressBar = () => {
     </div>
   );
 };
+
+/**
+ * モバイル画面下部固定の進捗バー (ProgressBarInlineを画面下端にpin)
+ */
+const MobileProgressBar = () => (
+  <div className="pointer-events-none fixed right-0 bottom-0 left-0 z-[60]">
+    <ProgressBarInline />
+  </div>
+);
 
 /** デスクトップ用の詳細プログレスバー (従来の左下w-125固定) */
 const DesktopProgressBar = () => (

--- a/src/view/progress-bar/index.tsx
+++ b/src/view/progress-bar/index.tsx
@@ -38,7 +38,7 @@ const MobileProgressBar = () => {
   const elapsedText = isDone ? `${t("elapsed: ", "footer.elapsedPrefix")}${progress.total}ms` : "";
 
   return (
-    <div className="pointer-events-none fixed right-0 bottom-0 left-0 z-50 h-4">
+    <div className="pointer-events-none fixed right-0 bottom-0 left-0 z-[60] h-4">
       {isDone && (
         <div className="absolute inset-x-0 top-0 bottom-[3px] flex items-center justify-end bg-[#1c1c24]/70 px-2 backdrop-blur-sm">
           <span className="text-[10px] leading-none text-muted-foreground">{elapsedText}</span>

--- a/src/view/progress-bar/index.tsx
+++ b/src/view/progress-bar/index.tsx
@@ -1,15 +1,66 @@
+import { useStoreValue } from "@/store/store";
+import { useIsMobile } from "@/view/use-is-mobile";
 import { Footer } from "../footer";
 
 /**
- * フローティング進捗バー
+ * progress文字列から進捗率 (0〜100) を抽出する
  *
- * デスクトップ: 左下に500px固定幅で配置。
- * モバイル (<=768px): 画面下端いっぱいに配置し、POI BottomSheetのピーク(15vh)の上にずらす。
+ * - "Generating... 47%" → 47
+ * - "Calculate reference orbit... 42 / 1000" → 4.2
  */
-export const ProgressBar = () => {
+const parseProgressPercent = (s: string): number => {
+  const percentMatch = s.match(/(\d+)%/);
+  if (percentMatch) return Number.parseInt(percentMatch[1], 10);
+
+  const fractionMatch = s.match(/(\d+)\s*\/\s*(\d+)/);
+  if (fractionMatch) {
+    const num = Number.parseInt(fractionMatch[1], 10);
+    const den = Number.parseInt(fractionMatch[2], 10);
+    return den > 0 ? (num / den) * 100 : 0;
+  }
+
+  return 0;
+};
+
+/**
+ * モバイル用の細ラインプログレスバー + 完了時footer
+ *
+ * - 描画中: 画面下端3pxの細いプログレスラインのみ
+ * - 完了後: 12px高の薄背景footerにelapsed表示 + 下端3pxにフルバー
+ */
+const MobileProgressBar = () => {
+  const progress = useStoreValue("progress");
+
+  const isDone = typeof progress === "object" && progress !== null;
+  const percent = isDone ? 100 : typeof progress === "string" ? parseProgressPercent(progress) : 0;
+  const elapsedText = isDone ? `${progress.total}ms` : "";
+
   return (
-    <div className="fixed right-3 bottom-[calc(15vh+0.75rem)] left-3 z-100 rounded-xl border border-[#2a2a3a] bg-[#1c1c24]/95 px-3 py-2 backdrop-blur-sm md:right-auto md:bottom-3 md:w-125">
-      <Footer />
+    <div className="pointer-events-none fixed right-0 bottom-0 left-0 z-50 h-3">
+      {isDone && (
+        <div className="absolute inset-x-0 top-0 bottom-[3px] flex items-center justify-end bg-[#1c1c24]/70 px-2 backdrop-blur-sm">
+          <span className="text-[9px] leading-none text-muted-foreground">{elapsedText}</span>
+        </div>
+      )}
+      <div className="absolute right-0 bottom-0 left-0 h-[3px] bg-gray-700/30">
+        <div
+          className="h-full bg-primary transition-all duration-150"
+          style={{ width: `${percent}%` }}
+        />
+      </div>
     </div>
   );
+};
+
+/** デスクトップ用の詳細プログレスバー (従来の左下w-125固定) */
+const DesktopProgressBar = () => (
+  <div className="fixed bottom-3 left-3 z-100 w-125 rounded-xl border border-[#2a2a3a] bg-[#1c1c24]/95 px-3 py-2 backdrop-blur-sm">
+    <Footer />
+  </div>
+);
+
+/** フローティング進捗バー (モバイル時は細ライン+footerに切替) */
+export const ProgressBar = () => {
+  const isMobile = useIsMobile();
+  return isMobile ? <MobileProgressBar /> : <DesktopProgressBar />;
 };

--- a/src/view/right-sidebar/debug-mode/benchmark-viewer.tsx
+++ b/src/view/right-sidebar/debug-mode/benchmark-viewer.tsx
@@ -9,7 +9,13 @@ import {
 import type { Stats } from "@/benchmark/benchmark-stats";
 import { Button } from "@/shadcn/components/ui/button";
 import { Checkbox } from "@/shadcn/components/ui/check";
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/shadcn/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/shadcn/components/ui/dialog";
 import { Label } from "@/shadcn/components/ui/label";
 import { Slider } from "@/shadcn/components/ui/slider";
 import {
@@ -21,6 +27,7 @@ import {
   TableRow,
 } from "@/shadcn/components/ui/table";
 import { IconCircleCheck, IconCopy } from "@tabler/icons-react";
+import { VisuallyHidden } from "radix-ui";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 
@@ -179,6 +186,9 @@ export const BenchmarkViewer = () => {
         <DialogContent className="sm:max-w-md" onInteractOutside={(e) => e.preventDefault()}>
           <DialogHeader>
             <DialogTitle>Benchmark running...</DialogTitle>
+            <VisuallyHidden.Root>
+              <DialogDescription>Benchmark progress</DialogDescription>
+            </VisuallyHidden.Root>
           </DialogHeader>
           {progress ? (
             <div className="space-y-2 text-sm">

--- a/src/view/right-sidebar/poi-card-preview.tsx
+++ b/src/view/right-sidebar/poi-card-preview.tsx
@@ -4,9 +4,11 @@ import React, { useEffect, useState } from "react";
 
 type Props = {
   poi: POIData;
+  /** サムネイルのアスペクト比指定 ("square": 1:1クロップ表示, "natural": 元画像のアスペクトを保持) */
+  aspect?: "square" | "natural";
 };
 
-export const POICardPreview = React.memo(({ poi }: Props) => {
+export const POICardPreview = React.memo(({ poi, aspect = "square" }: Props) => {
   const [data, setData] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
@@ -38,20 +40,20 @@ export const POICardPreview = React.memo(({ poi }: Props) => {
     };
   }, [poi.id, previewChanged]);
 
+  const isSquare = aspect === "square";
+  const containerClass = isSquare
+    ? "flex w-full aspect-square items-center justify-center border-2"
+    : "flex h-full items-center justify-center border-2";
+  const imgClass = isSquare ? "w-full aspect-square object-cover" : "h-full w-auto object-contain";
+
   if (isLoading) {
-    return (
-      <div className="flex w-full aspect-square items-center justify-center border-2">
-        loading...
-      </div>
-    );
+    return <div className={containerClass}>loading...</div>;
   }
 
   if (data == null) {
-    return (
-      <div className="flex w-full aspect-square items-center justify-center border-2">No Image</div>
-    );
+    return <div className={containerClass}>No Image</div>;
   }
 
-  return <img src={data} className="w-full aspect-square object-cover" />;
+  return <img src={data} className={imgClass} />;
 });
 POICardPreview.displayName = "POICardPreview";

--- a/src/view/right-sidebar/poi-export-dialog.tsx
+++ b/src/view/right-sidebar/poi-export-dialog.tsx
@@ -1,12 +1,19 @@
 import { useT } from "@/i18n/context";
 import { Button } from "@/shadcn/components/ui/button";
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/shadcn/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/shadcn/components/ui/dialog";
 import { Textarea } from "@/shadcn/components/ui/textarea";
 import { toast } from "sonner";
 import { serializePOIListToText } from "@/store/sync-storage/poi-list";
 import { useStoreValue } from "@/store/store";
 import { ClickFeedback, useClickFeedback } from "@/view/components/click-feedback";
 import { IconCircleCheck, IconCopy } from "@tabler/icons-react";
+import { VisuallyHidden } from "radix-ui";
 import type { POIData } from "../../types";
 
 type POIExportDialogProps = {
@@ -40,6 +47,11 @@ export const POIExportDialog = ({ open, onOpenChange }: POIExportDialogProps) =>
       <DialogContent className="max-w-lg">
         <DialogHeader>
           <DialogTitle>{t("Export POI", "poi.exportTitle")}</DialogTitle>
+          <VisuallyHidden.Root>
+            <DialogDescription>
+              {t("Export saved POIs", "dialog.description.poiExport")}
+            </DialogDescription>
+          </VisuallyHidden.Root>
         </DialogHeader>
 
         <div className="text-sm text-muted-foreground">

--- a/src/view/right-sidebar/poi-import-dialog.tsx
+++ b/src/view/right-sidebar/poi-import-dialog.tsx
@@ -1,6 +1,12 @@
 import { useT } from "@/i18n/context";
 import { Button } from "@/shadcn/components/ui/button";
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/shadcn/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/shadcn/components/ui/dialog";
 import { Textarea } from "@/shadcn/components/ui/textarea";
 import {
   deserializePOIListFromText,
@@ -9,6 +15,7 @@ import {
 } from "@/store/sync-storage/poi-list";
 import { updateStore, useStoreValue } from "@/store/store";
 import { IconDownload } from "@tabler/icons-react";
+import { VisuallyHidden } from "radix-ui";
 import { useMemo, useState } from "react";
 import type { POIData } from "../../types";
 
@@ -53,6 +60,11 @@ export const POIImportDialog = ({ open, onOpenChange }: POIImportDialogProps) =>
       <DialogContent className="max-w-lg">
         <DialogHeader>
           <DialogTitle>{t("Import POI", "poi.importTitle")}</DialogTitle>
+          <VisuallyHidden.Root>
+            <DialogDescription>
+              {t("Import POIs from text", "dialog.description.poiImport")}
+            </DialogDescription>
+          </VisuallyHidden.Root>
         </DialogHeader>
 
         <Textarea

--- a/src/view/right-sidebar/use-poi.tsx
+++ b/src/view/right-sidebar/use-poi.tsx
@@ -71,6 +71,8 @@ export const usePOI = () => {
     setCurrentParams(cloneParams(poi));
     clearIterationCache();
     setSerializedPalette(poi.serializedPalette);
+    // 選択結果をキャンバスで見せるためモバイルのPOI drawerを閉じる (デスクトップは無害)
+    updateStore("poiDrawerSnap", "closed");
   }, []);
 
   return {

--- a/src/view/settings-dialog/index.tsx
+++ b/src/view/settings-dialog/index.tsx
@@ -1,4 +1,3 @@
-import { SimpleTooltip } from "@/components/simple-tooltip";
 import { ValueSlider } from "@/components/slider-wrapper";
 import { useT } from "@/i18n/context";
 import { resizeTo } from "@/p5-adapter/p5-adapter";
@@ -28,6 +27,11 @@ const SectionTitle = ({ children }: { children: React.ReactNode }) => (
   <h3 className="mb-3 text-xs font-semibold tracking-wider text-muted-foreground uppercase">
     {children}
   </h3>
+);
+
+/** 設定項目の補足説明 (項目直下に小さい文字で常時表示) */
+const FieldDescription = ({ children }: { children: React.ReactNode }) => (
+  <p className="mt-1 text-xs text-muted-foreground">{children}</p>
 );
 
 /** Worker数の選択肢を生成 */
@@ -97,7 +101,7 @@ const RenderingSection = () => {
         </div>
       )}
 
-      <SimpleTooltip content={t("Approximately 10x faster. Recommended to keep ON.")}>
+      <div>
         <div className="flex items-center space-x-2">
           <Switch
             id="settings-use-wasm"
@@ -108,7 +112,10 @@ const RenderingSection = () => {
             {t("Use Wasm for reference orbit")}
           </Label>
         </div>
-      </SimpleTooltip>
+        <FieldDescription>
+          {t("Approximately 10x faster. Recommended to keep ON.")}
+        </FieldDescription>
+      </div>
 
       <div>
         <div className="mb-1 ml-2 text-sm">
@@ -169,15 +176,7 @@ const ExplorationSection = () => {
         />
       </div>
 
-      <SimpleTooltip
-        content={
-          <>
-            {t("Marks interesting points on the fractal.")}
-            <br />
-            {t("Click a marker to zoom into its center.")}
-          </>
-        }
-      >
+      <div>
         <div className="flex items-center space-x-2">
           <Switch
             id="settings-interesting-points"
@@ -188,7 +187,12 @@ const ExplorationSection = () => {
             {t("Show point marker")}
           </Label>
         </div>
-      </SimpleTooltip>
+        <FieldDescription>
+          {t("Marks interesting points on the fractal.")}
+          <br />
+          {t("Click a marker to zoom into its center.")}
+        </FieldDescription>
+      </div>
     </div>
   );
 };
@@ -228,21 +232,19 @@ const AboutSection = () => {
       </Dialog>
 
       <div className="flex items-center space-x-2">
-        <SimpleTooltip content={t("Switch language")}>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => updateStore("locale", locale === "en" ? "ja" : "en")}
-          >
-            {locale === "en" ? "JA" : "EN"}
-          </Button>
-        </SimpleTooltip>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => updateStore("locale", locale === "en" ? "ja" : "en")}
+        >
+          {locale === "en" ? "JA" : "EN"}
+        </Button>
         <Label className="text-sm text-muted-foreground">
           {locale === "en" ? "English" : "日本語"}
         </Label>
       </div>
 
-      <SimpleTooltip content={t("Shows debug data obtained from rendering results.")}>
+      <div>
         <div className="flex items-center space-x-2">
           <Switch
             id="settings-debug-mode"
@@ -253,7 +255,10 @@ const AboutSection = () => {
             {t("Debug Mode")}
           </Label>
         </div>
-      </SimpleTooltip>
+        <FieldDescription>
+          {t("Shows debug data obtained from rendering results.")}
+        </FieldDescription>
+      </div>
     </div>
   );
 };

--- a/src/view/settings-dialog/index.tsx
+++ b/src/view/settings-dialog/index.tsx
@@ -280,7 +280,7 @@ export const SettingsDialog = ({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[90vh] max-w-[calc(100vw-2rem)] overflow-y-auto md:max-w-3xl">
+      <DialogContent className="max-h-[calc(100dvh-2rem)] max-w-[calc(100vw-2rem)] overflow-y-auto md:max-w-3xl">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <IconSettings className="size-5" />

--- a/src/view/settings-dialog/index.tsx
+++ b/src/view/settings-dialog/index.tsx
@@ -270,14 +270,14 @@ export const SettingsDialog = ({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-3xl">
+      <DialogContent className="max-h-[90vh] max-w-[calc(100vw-2rem)] overflow-y-auto md:max-w-3xl">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <IconSettings className="size-5" />
             {t("Settings", "operations.settings")}
           </DialogTitle>
         </DialogHeader>
-        <div className="grid grid-cols-2 gap-8 pt-2">
+        <div className="grid grid-cols-1 gap-8 pt-2 md:grid-cols-2">
           <div className="flex flex-col gap-8">
             <RenderingSection />
           </div>

--- a/src/view/settings-dialog/index.tsx
+++ b/src/view/settings-dialog/index.tsx
@@ -9,7 +9,13 @@ import {
   setRenderer,
 } from "@/rendering/common";
 import { Button } from "@/shadcn/components/ui/button";
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/shadcn/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/shadcn/components/ui/dialog";
 import { Label } from "@/shadcn/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/shadcn/components/ui/radio-group";
 import { Switch } from "@/shadcn/components/ui/switch";
@@ -19,6 +25,7 @@ import { DEFAULT_WORKER_COUNT } from "@/store/sync-storage/settings";
 import { useIsMobile } from "@/view/use-is-mobile";
 import { prepareWorkerPool } from "@/worker-pool/pool-instance";
 import { IconHelp, IconSettings } from "@tabler/icons-react";
+import { VisuallyHidden } from "radix-ui";
 import { useEffect, useState } from "react";
 import { Instructions } from "../header/instructions";
 import { useModalState } from "../modal/use-modal-state";
@@ -231,6 +238,11 @@ const AboutSection = () => {
         <DialogContent>
           <DialogHeader>
             <DialogTitle className="text-3xl">{t("Instructions")}</DialogTitle>
+            <VisuallyHidden.Root>
+              <DialogDescription>
+                {t("Usage instructions", "dialog.description.instructions")}
+              </DialogDescription>
+            </VisuallyHidden.Root>
           </DialogHeader>
           <Instructions />
         </DialogContent>
@@ -286,6 +298,11 @@ export const SettingsDialog = ({
             <IconSettings className="size-5" />
             {t("Settings", "operations.settings")}
           </DialogTitle>
+          <VisuallyHidden.Root>
+            <DialogDescription>
+              {t("Application settings", "dialog.description.settings")}
+            </DialogDescription>
+          </VisuallyHidden.Root>
         </DialogHeader>
         <div className="grid grid-cols-1 gap-8 pt-2 md:grid-cols-2">
           <div className="flex flex-col gap-8">

--- a/src/view/settings-dialog/index.tsx
+++ b/src/view/settings-dialog/index.tsx
@@ -16,6 +16,7 @@ import { Switch } from "@/shadcn/components/ui/switch";
 import { toast } from "sonner";
 import { updateStore, updateStoreWith, useStoreValue } from "@/store/store";
 import { DEFAULT_WORKER_COUNT } from "@/store/sync-storage/settings";
+import { useIsMobile } from "@/view/use-is-mobile";
 import { prepareWorkerPool } from "@/worker-pool/pool-instance";
 import { IconHelp, IconSettings } from "@tabler/icons-react";
 import { useEffect, useState } from "react";
@@ -155,6 +156,7 @@ const RenderingSection = () => {
 /** 右カラム: Exploration セクション */
 const ExplorationSection = () => {
   const t = useT();
+  const isMobile = useIsMobile();
   const zoomRate = useStoreValue("zoomRate");
   const show = useStoreValue("showInterestingPoints");
   const [zoomRatePreview, setZoomRatePreview] = useState(zoomRate);
@@ -176,23 +178,26 @@ const ExplorationSection = () => {
         />
       </div>
 
-      <div>
-        <div className="flex items-center space-x-2">
-          <Switch
-            id="settings-interesting-points"
-            checked={show}
-            onCheckedChange={() => updateStoreWith("showInterestingPoints", (v) => !v)}
-          />
-          <Label htmlFor="settings-interesting-points" className="cursor-pointer text-sm">
-            {t("Show point marker")}
-          </Label>
+      {/* モバイルでは point marker は常に非表示なので設定項目も隠す */}
+      {!isMobile && (
+        <div>
+          <div className="flex items-center space-x-2">
+            <Switch
+              id="settings-interesting-points"
+              checked={show}
+              onCheckedChange={() => updateStoreWith("showInterestingPoints", (v) => !v)}
+            />
+            <Label htmlFor="settings-interesting-points" className="cursor-pointer text-sm">
+              {t("Show point marker")}
+            </Label>
+          </div>
+          <FieldDescription>
+            {t("Marks interesting points on the fractal.")}
+            <br />
+            {t("Click a marker to zoom into its center.")}
+          </FieldDescription>
         </div>
-        <FieldDescription>
-          {t("Marks interesting points on the fractal.")}
-          <br />
-          {t("Click a marker to zoom into its center.")}
-        </FieldDescription>
-      </div>
+      )}
     </div>
   );
 };

--- a/src/view/supersampling-overlay/index.tsx
+++ b/src/view/supersampling-overlay/index.tsx
@@ -1,5 +1,7 @@
 import { LoadingSpinner } from "@/components/loading-spinner";
+import { useT } from "@/i18n/context";
 import { getPrevBatchId } from "@/mandelbrot-state/mandelbrot-state";
+import { Button } from "@/shadcn/components/ui/button";
 import { useStoreValue } from "@/store/store";
 import { cancelBatch } from "@/worker-pool/worker-pool";
 import { Download, Expand, Shrink, X } from "lucide-react";
@@ -10,11 +12,11 @@ interface SupersamplingOverlayProps {
   onClose?: () => void;
 }
 
-/** overlay上の丸型ボタンのベースクラス (メインUIのsize-16に揃える) */
-const CIRCLE_BUTTON_BASE_CLASS =
-  "size-16 rounded-full bg-black/80 text-white/80 border border-white/20 backdrop-blur-sm shadow-lg flex items-center justify-center transition-colors";
+/** 閉じるアニメーションの時間 (ms)。Dialogの見た目に合わせる */
+const CLOSE_ANIMATION_MS = 200;
 
 const SupersamplingOverlayComponent = ({ onClose }: SupersamplingOverlayProps) => {
+  const t = useT();
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [fitMode, setFitMode] = useState(true);
@@ -27,7 +29,7 @@ const SupersamplingOverlayComponent = ({ onClose }: SupersamplingOverlayProps) =
     scrollTop: 0,
   });
 
-  // progress が object (ResultSpans = 計測完了) のとき描画完了。保存ボタンの出し分けに使う
+  // progress が object (ResultSpans = 計測完了) のとき描画完了。保存ボタン等の出し分けに使う
   const progress = useStoreValue("progress");
   const isRenderComplete = typeof progress === "object" && progress !== null;
 
@@ -77,9 +79,6 @@ const SupersamplingOverlayComponent = ({ onClose }: SupersamplingOverlayProps) =
   const handleBackgroundEvent = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
   }, []);
-
-  /** 閉じるアニメーションの時間 (ms) */
-  const CLOSE_ANIMATION_MS = 250;
 
   const handleClose = useCallback(() => {
     if (isClosing) return;
@@ -134,92 +133,103 @@ const SupersamplingOverlayComponent = ({ onClose }: SupersamplingOverlayProps) =
 
   return (
     <div
-      className={`fixed inset-0 z-50 bg-black/50 backdrop-blur-sm p-2 transition-[opacity,transform] duration-[250ms] ease-out ${
-        isClosing ? "opacity-0 translate-y-full" : "opacity-100 translate-y-0"
+      className={`fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-2 backdrop-blur-sm transition-opacity duration-200 ease-out ${
+        isClosing ? "opacity-0" : "opacity-100"
       }`}
       onMouseDown={handleBackgroundEvent}
       onClick={handleBackgroundEvent}
     >
-      {/* キャンバスコンテナ */}
+      {/* Dialog本体 */}
       <div
-        ref={containerRef}
-        className={`rounded-xl border border-white/20 shadow-2xl bg-black/40 ${
-          fitMode
-            ? "w-full h-full flex items-center justify-center"
-            : "w-full h-full overflow-auto cursor-grab active:cursor-grabbing"
+        className={`flex h-full w-full max-w-5xl flex-col overflow-hidden rounded-lg border border-white/15 bg-background shadow-2xl transition-[opacity,transform] duration-200 ease-out ${
+          isClosing ? "scale-95 opacity-0" : "scale-100 opacity-100"
         }`}
-        onMouseDown={handleMouseDown}
-        onMouseMove={handleMouseMove}
-        onMouseUp={handleMouseUp}
-        onMouseLeave={handleMouseLeave}
-        onTouchStartCapture={(e) => e.stopPropagation()}
-        onTouchMoveCapture={(e) => e.stopPropagation()}
-        style={fitMode ? {} : { cursor: dragState.isDragging ? "grabbing" : "grab" }}
       >
-        {/* ローディングスピナー - canvasの下に表示 */}
-        <div className="absolute inset-0 flex items-center justify-center">
-          <div className="bg-black/80 text-white px-6 py-4 rounded-lg shadow-lg backdrop-blur-sm border border-white/20">
-            <div className="flex items-center gap-3">
-              <LoadingSpinner />
-              <span className="text-sm font-medium">Supersampling...</span>
-            </div>
+        {/* Header: タイトル + × */}
+        <div className="flex shrink-0 items-center justify-between border-b border-white/10 px-4 py-2">
+          <h2 className="text-base font-semibold">
+            {t("Supersampling Result", "supersampling.result")}
+          </h2>
+          <button
+            type="button"
+            onClick={handleClose}
+            aria-label="Close"
+            className="rounded p-1 text-foreground/80 transition-colors hover:bg-foreground/10 hover:text-foreground"
+          >
+            <X className="size-5" />
+          </button>
+        </div>
+
+        {/* Content: canvasコンテナ */}
+        <div className="relative min-h-0 flex-1">
+          <div
+            ref={containerRef}
+            className={
+              fitMode
+                ? "flex h-full w-full items-center justify-center"
+                : "h-full w-full cursor-grab overflow-auto active:cursor-grabbing"
+            }
+            onMouseDown={handleMouseDown}
+            onMouseMove={handleMouseMove}
+            onMouseUp={handleMouseUp}
+            onMouseLeave={handleMouseLeave}
+            onTouchStartCapture={(e) => e.stopPropagation()}
+            onTouchMoveCapture={(e) => e.stopPropagation()}
+            style={fitMode ? {} : { cursor: dragState.isDragging ? "grabbing" : "grab" }}
+          >
+            {/* ローディングスピナー - 描画完了までcanvasの背後に表示 */}
+            {!isRenderComplete && (
+              <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+                <div className="flex items-center gap-3 rounded-lg border border-white/20 bg-black/80 px-6 py-4 text-white shadow-lg backdrop-blur-sm">
+                  <LoadingSpinner />
+                  <span className="text-sm font-medium">Supersampling...</span>
+                </div>
+              </div>
+            )}
+
+            <canvas
+              key="supersampling-canvas"
+              id="supersampling-canvas"
+              ref={canvasRef}
+              className={
+                fitMode
+                  ? "relative z-10 max-h-full max-w-full object-contain"
+                  : "relative z-10 block"
+              }
+              style={
+                fitMode
+                  ? {}
+                  : {
+                      imageRendering: "pixelated",
+                      minWidth: "100%",
+                      minHeight: "100%",
+                      display: "block",
+                    }
+              }
+            />
           </div>
         </div>
 
-        <canvas
-          key="supersampling-canvas"
-          id="supersampling-canvas"
-          ref={canvasRef}
-          className={
-            fitMode ? "max-w-full max-h-full object-contain relative z-10" : "block relative z-10"
-          }
-          style={
-            fitMode
-              ? {}
-              : {
-                  imageRendering: "pixelated",
-                  minWidth: "100%",
-                  minHeight: "100%",
-                  display: "block",
-                }
-          }
-        />
-      </div>
-
-      {/* 左上の閉じるボタン (丸型、メインUIと同じtop-3 left-3) */}
-      <div className="absolute top-3 left-3 z-20">
-        <button
-          type="button"
-          onClick={handleClose}
-          className={`${CIRCLE_BUTTON_BASE_CLASS} hover:bg-red-500/70 hover:text-white`}
-          aria-label="Close"
-        >
-          <X className="size-8" />
-        </button>
-      </div>
-
-      {/* 右上のコントロール (縦並び: Fit切替 + 保存、保存は描画完了時のみ) */}
-      <div className="absolute top-3 right-3 z-20 flex flex-col gap-5">
-        <button
-          type="button"
-          onClick={handleToggleFitMode}
-          className={`${CIRCLE_BUTTON_BASE_CLASS} hover:bg-white/20 hover:text-white`}
-          aria-label={fitMode ? "Actual Size" : "Fit to Screen"}
-        >
-          {fitMode ? <Expand className="size-8" /> : <Shrink className="size-8" />}
-        </button>
-        {isRenderComplete && (
-          <button
-            type="button"
-            onClick={handleSave}
-            className="size-16 rounded-full bg-primary text-primary-foreground shadow-[0_4px_12px_rgba(0,0,0,0.4)] flex items-center justify-center transition-colors hover:bg-primary/90"
-            aria-label="Save image"
+        {/* Footer: 拡大切替 + ダウンロード (生成中はdisable) */}
+        <div className="flex shrink-0 items-center justify-center gap-3 border-t border-white/10 px-4 py-3">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleToggleFitMode}
+            disabled={!isRenderComplete}
           >
-            <Download className="size-8" />
-          </button>
-        )}
+            {fitMode ? <Expand className="mr-1 size-4" /> : <Shrink className="mr-1 size-4" />}
+            {fitMode ? "Actual Size" : "Fit to Screen"}
+          </Button>
+          <Button variant="default" size="sm" onClick={handleSave} disabled={!isRenderComplete}>
+            <Download className="mr-1 size-4" />
+            {t("Save Image", "header.saveImage")}
+          </Button>
+        </div>
       </div>
-      <div className="absolute bottom-4 z-1 w-full px-8">
+
+      {/* 描画進行状況 (背景のoverlay上、Dialogの外に配置) */}
+      <div className="pointer-events-none absolute bottom-4 z-1 w-full px-8">
         <Progress />
       </div>
     </div>

--- a/src/view/supersampling-overlay/index.tsx
+++ b/src/view/supersampling-overlay/index.tsx
@@ -141,7 +141,7 @@ const SupersamplingOverlayComponent = ({ onClose }: SupersamplingOverlayProps) =
     >
       {/* Dialog本体 */}
       <div
-        className={`flex h-full w-full max-w-5xl flex-col overflow-hidden rounded-lg border border-white/15 bg-background shadow-2xl transition-[opacity,transform] duration-200 ease-out ${
+        className={`flex h-full w-full flex-col overflow-hidden rounded-lg border border-white/15 bg-background shadow-2xl transition-[opacity,transform] duration-200 ease-out ${
           isClosing ? "scale-95 opacity-0" : "scale-100 opacity-100"
         }`}
       >

--- a/src/view/supersampling-overlay/index.tsx
+++ b/src/view/supersampling-overlay/index.tsx
@@ -1,12 +1,18 @@
 import { LoadingSpinner } from "@/components/loading-spinner";
 import { getPrevBatchId } from "@/mandelbrot-state/mandelbrot-state";
+import { useStoreValue } from "@/store/store";
 import { cancelBatch } from "@/worker-pool/worker-pool";
+import { Download, Expand, Shrink, X } from "lucide-react";
 import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { Footer } from "../footer";
 
 interface SupersamplingOverlayProps {
   onClose?: () => void;
 }
+
+/** overlay上の丸型ボタンのベースクラス (メインUIのsize-16に揃える) */
+const CIRCLE_BUTTON_BASE_CLASS =
+  "size-16 rounded-full bg-black/80 text-white/80 border border-white/20 backdrop-blur-sm shadow-lg flex items-center justify-center transition-colors";
 
 const SupersamplingOverlayComponent = ({ onClose }: SupersamplingOverlayProps) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -19,6 +25,10 @@ const SupersamplingOverlayComponent = ({ onClose }: SupersamplingOverlayProps) =
     scrollLeft: 0,
     scrollTop: 0,
   });
+
+  // progress が object (ResultSpans = 計測完了) のとき描画完了。保存ボタンの出し分けに使う
+  const progress = useStoreValue("progress");
+  const isRenderComplete = typeof progress === "object" && progress !== null;
 
   const handleToggleFitMode = useCallback(() => {
     setFitMode((prev) => !prev);
@@ -85,6 +95,21 @@ const SupersamplingOverlayComponent = ({ onClose }: SupersamplingOverlayProps) =
     onClose?.();
   }, [onClose]);
 
+  /** supersampling結果canvasをPNGとしてダウンロード */
+  const handleSave = useCallback(() => {
+    const canvas = document.getElementById("supersampling-canvas") as HTMLCanvasElement | null;
+    if (!canvas) return;
+    canvas.toBlob((blob) => {
+      if (!blob) return;
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.download = `mandelbrot-${Date.now()}.png`;
+      link.href = url;
+      link.click();
+      URL.revokeObjectURL(url);
+    }, "image/png");
+  }, []);
+
   useEffect(() => {
     const handleEscKey = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
@@ -116,6 +141,8 @@ const SupersamplingOverlayComponent = ({ onClose }: SupersamplingOverlayProps) =
         onMouseMove={handleMouseMove}
         onMouseUp={handleMouseUp}
         onMouseLeave={handleMouseLeave}
+        onTouchStartCapture={(e) => e.stopPropagation()}
+        onTouchMoveCapture={(e) => e.stopPropagation()}
         style={fitMode ? {} : { cursor: dragState.isDragging ? "grabbing" : "grab" }}
       >
         {/* ローディングスピナー - canvasの下に表示 */}
@@ -148,31 +175,38 @@ const SupersamplingOverlayComponent = ({ onClose }: SupersamplingOverlayProps) =
         />
       </div>
 
-      {/* 左上の閉じるボタン */}
+      {/* 左上の閉じるボタン (丸型) */}
       <div className="absolute top-4 left-4 z-20">
         <button
+          type="button"
           onClick={handleClose}
-          className="p-2 text-white/80 bg-black/80 hover:text-white hover:bg-red-500/70 rounded-full shadow-lg transition-colors backdrop-blur-sm border border-white/20"
+          className={`${CIRCLE_BUTTON_BASE_CLASS} hover:bg-red-500/70 hover:text-white`}
+          aria-label="Close"
         >
-          <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M6 18L18 6M6 6l12 12"
-            />
-          </svg>
+          <X className="size-8" />
         </button>
       </div>
 
-      {/* 右上のコントロール */}
-      <div className="absolute top-4 right-4 z-20">
+      {/* 右上のコントロール (縦並び: Fit切替 + 保存、保存は描画完了時のみ) */}
+      <div className="absolute top-4 right-4 z-20 flex flex-col gap-3">
         <button
+          type="button"
           onClick={handleToggleFitMode}
-          className="px-3 py-1 text-sm bg-blue-500/90 text-white rounded shadow-lg hover:bg-blue-600/90 transition-colors backdrop-blur-sm"
+          className={`${CIRCLE_BUTTON_BASE_CLASS} hover:bg-white/20 hover:text-white`}
+          aria-label={fitMode ? "Actual Size" : "Fit to Screen"}
         >
-          {fitMode ? "Actual Size" : "Fit to Screen"}
+          {fitMode ? <Expand className="size-8" /> : <Shrink className="size-8" />}
         </button>
+        {isRenderComplete && (
+          <button
+            type="button"
+            onClick={handleSave}
+            className={`${CIRCLE_BUTTON_BASE_CLASS} hover:bg-white/20 hover:text-white`}
+            aria-label="Save image"
+          >
+            <Download className="size-8" />
+          </button>
+        )}
       </div>
       <div className="absolute bottom-4 z-1 w-full px-8">
         <Progress />

--- a/src/view/supersampling-overlay/index.tsx
+++ b/src/view/supersampling-overlay/index.tsx
@@ -210,6 +210,11 @@ const SupersamplingOverlayComponent = ({ onClose }: SupersamplingOverlayProps) =
           </div>
         </div>
 
+        {/* Progress (描画の進捗/結果)。Dialog内部に置いて操作ボタンと被らないように */}
+        <div className="shrink-0 border-t border-white/10 px-4 py-2 text-xs text-muted-foreground">
+          <Progress />
+        </div>
+
         {/* Footer: 拡大切替 + ダウンロード (生成中はdisable) */}
         <div className="flex shrink-0 items-center justify-center gap-3 border-t border-white/10 px-4 py-3">
           <Button
@@ -226,11 +231,6 @@ const SupersamplingOverlayComponent = ({ onClose }: SupersamplingOverlayProps) =
             {t("Save Image", "header.saveImage")}
           </Button>
         </div>
-      </div>
-
-      {/* 描画進行状況 (背景のoverlay上、Dialogの外に配置) */}
-      <div className="pointer-events-none absolute bottom-4 z-1 w-full px-8">
-        <Progress />
       </div>
     </div>
   );

--- a/src/view/supersampling-overlay/index.tsx
+++ b/src/view/supersampling-overlay/index.tsx
@@ -6,7 +6,7 @@ import { useStoreValue } from "@/store/store";
 import { cancelBatch } from "@/worker-pool/worker-pool";
 import { Download, Expand, Shrink, X } from "lucide-react";
 import { memo, useCallback, useEffect, useRef, useState } from "react";
-import { Footer } from "../footer";
+import { ProgressBarInline } from "../progress-bar";
 
 interface SupersamplingOverlayProps {
   onClose?: () => void;
@@ -210,9 +210,9 @@ const SupersamplingOverlayComponent = ({ onClose }: SupersamplingOverlayProps) =
           </div>
         </div>
 
-        {/* Progress (描画の進捗/結果)。Dialog内部に置いて操作ボタンと被らないように */}
-        <div className="shrink-0 border-t border-white/10 px-4 py-2 text-xs text-muted-foreground">
-          <Progress />
+        {/* Progress (描画の進捗/結果)。モバイルfooterと同じ薄帯スタイルでDialog下部に埋め込み */}
+        <div className="shrink-0 border-t border-white/10">
+          <ProgressBarInline />
         </div>
 
         {/* Footer: 拡大切替 + ダウンロード (生成中はdisable) */}
@@ -239,7 +239,3 @@ const SupersamplingOverlayComponent = ({ onClose }: SupersamplingOverlayProps) =
 SupersamplingOverlayComponent.displayName = "SupersamplingOverlay";
 
 export const SupersamplingOverlay = memo(SupersamplingOverlayComponent);
-
-const Progress = () => {
-  return <Footer />;
-};

--- a/src/view/supersampling-overlay/index.tsx
+++ b/src/view/supersampling-overlay/index.tsx
@@ -79,7 +79,7 @@ const SupersamplingOverlayComponent = ({ onClose }: SupersamplingOverlayProps) =
   }, []);
 
   /** 閉じるアニメーションの時間 (ms) */
-  const CLOSE_ANIMATION_MS = 200;
+  const CLOSE_ANIMATION_MS = 250;
 
   const handleClose = useCallback(() => {
     if (isClosing) return;
@@ -134,7 +134,7 @@ const SupersamplingOverlayComponent = ({ onClose }: SupersamplingOverlayProps) =
 
   return (
     <div
-      className={`fixed inset-0 z-50 bg-black/50 backdrop-blur-sm transition-[opacity,transform] duration-200 ease-out ${
+      className={`fixed inset-0 z-50 bg-black/50 backdrop-blur-sm transition-[opacity,transform] duration-[250ms] ease-out ${
         isClosing ? "opacity-0 scale-95" : "opacity-100 scale-100"
       }`}
       onMouseDown={handleBackgroundEvent}

--- a/src/view/supersampling-overlay/index.tsx
+++ b/src/view/supersampling-overlay/index.tsx
@@ -215,23 +215,28 @@ const SupersamplingOverlayComponent = ({ onClose }: SupersamplingOverlayProps) =
           <ProgressBarInline />
         </div>
 
-        {/* Footer: 拡大切替 + ダウンロード (生成中はdisable) */}
-        <div className="flex shrink-0 items-center justify-center gap-3 border-t border-white/10 px-4 py-3">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={handleToggleFitMode}
-            disabled={!isRenderComplete}
-          >
-            {fitMode ? <Expand className="mr-1 size-4" /> : <Shrink className="mr-1 size-4" />}
-            {fitMode
-              ? t("Actual Size", "supersampling.actualSize")
-              : t("Fit to Screen", "supersampling.fitToScreen")}
-          </Button>
-          <Button variant="default" size="sm" onClick={handleSave} disabled={!isRenderComplete}>
-            <Download className="mr-1 size-4" />
-            {t("Save Image", "header.saveImage")}
-          </Button>
+        {/* Footer: 拡大切替 + ダウンロード (生成中はdisable)。
+            ボタンの境目を中央に固定するため grid-cols-2 で左右均等分配 */}
+        <div className="grid shrink-0 grid-cols-2 items-center gap-3 border-t border-white/10 px-4 py-3">
+          <div className="flex justify-end">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleToggleFitMode}
+              disabled={!isRenderComplete}
+            >
+              {fitMode ? <Expand className="mr-1 size-4" /> : <Shrink className="mr-1 size-4" />}
+              {fitMode
+                ? t("Actual Size", "supersampling.actualSize")
+                : t("Fit to Screen", "supersampling.fitToScreen")}
+            </Button>
+          </div>
+          <div className="flex justify-start">
+            <Button variant="default" size="sm" onClick={handleSave} disabled={!isRenderComplete}>
+              <Download className="mr-1 size-4" />
+              {t("Save Image", "header.saveImage")}
+            </Button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/view/supersampling-overlay/index.tsx
+++ b/src/view/supersampling-overlay/index.tsx
@@ -134,8 +134,8 @@ const SupersamplingOverlayComponent = ({ onClose }: SupersamplingOverlayProps) =
 
   return (
     <div
-      className={`fixed inset-0 z-50 bg-black/50 backdrop-blur-sm transition-[opacity,transform] duration-[250ms] ease-out ${
-        isClosing ? "opacity-0 scale-95" : "opacity-100 scale-100"
+      className={`fixed inset-0 z-50 bg-black/50 backdrop-blur-sm p-2 transition-[opacity,transform] duration-[250ms] ease-out ${
+        isClosing ? "opacity-0 translate-y-full" : "opacity-100 translate-y-0"
       }`}
       onMouseDown={handleBackgroundEvent}
       onClick={handleBackgroundEvent}
@@ -143,11 +143,11 @@ const SupersamplingOverlayComponent = ({ onClose }: SupersamplingOverlayProps) =
       {/* キャンバスコンテナ */}
       <div
         ref={containerRef}
-        className={
+        className={`rounded-xl border border-white/20 shadow-2xl bg-black/40 ${
           fitMode
             ? "w-full h-full flex items-center justify-center"
             : "w-full h-full overflow-auto cursor-grab active:cursor-grabbing"
-        }
+        }`}
         onMouseDown={handleMouseDown}
         onMouseMove={handleMouseMove}
         onMouseUp={handleMouseUp}

--- a/src/view/supersampling-overlay/index.tsx
+++ b/src/view/supersampling-overlay/index.tsx
@@ -18,6 +18,7 @@ const SupersamplingOverlayComponent = ({ onClose }: SupersamplingOverlayProps) =
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [fitMode, setFitMode] = useState(true);
+  const [isClosing, setIsClosing] = useState(false);
   const [dragState, setDragState] = useState({
     isDragging: false,
     startX: 0,
@@ -77,23 +78,31 @@ const SupersamplingOverlayComponent = ({ onClose }: SupersamplingOverlayProps) =
     e.stopPropagation();
   }, []);
 
+  /** 閉じるアニメーションの時間 (ms) */
+  const CLOSE_ANIMATION_MS = 200;
+
   const handleClose = useCallback(() => {
-    // 閉じるときにcanvasのメモリ解放しておく
-    const canvas = document.getElementById("supersampling-canvas") as HTMLCanvasElement;
-    if (canvas) {
-      canvas.width = 0;
-      canvas.height = 0;
-    }
+    if (isClosing) return;
+    setIsClosing(true);
+    // fadeアニメ完了後に実DOM cleanupを行う
+    setTimeout(() => {
+      const canvas = document.getElementById("supersampling-canvas") as HTMLCanvasElement;
+      if (canvas) {
+        canvas.width = 0;
+        canvas.height = 0;
+      }
 
-    const overlay = document.getElementById("supersampling-overlay");
-    if (overlay) {
-      overlay.style.display = "";
-    }
-    // 処理中だったらバッチを止める
-    cancelBatch(getPrevBatchId());
+      const overlay = document.getElementById("supersampling-overlay");
+      if (overlay) {
+        overlay.style.display = "";
+      }
+      // 処理中だったらバッチを止める
+      cancelBatch(getPrevBatchId());
 
-    onClose?.();
-  }, [onClose]);
+      setIsClosing(false);
+      onClose?.();
+    }, CLOSE_ANIMATION_MS);
+  }, [isClosing, onClose]);
 
   /** supersampling結果canvasをPNGとしてダウンロード */
   const handleSave = useCallback(() => {
@@ -125,7 +134,9 @@ const SupersamplingOverlayComponent = ({ onClose }: SupersamplingOverlayProps) =
 
   return (
     <div
-      className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm"
+      className={`fixed inset-0 z-50 bg-black/50 backdrop-blur-sm transition-[opacity,transform] duration-200 ease-out ${
+        isClosing ? "opacity-0 scale-95" : "opacity-100 scale-100"
+      }`}
       onMouseDown={handleBackgroundEvent}
       onClick={handleBackgroundEvent}
     >
@@ -175,8 +186,8 @@ const SupersamplingOverlayComponent = ({ onClose }: SupersamplingOverlayProps) =
         />
       </div>
 
-      {/* 左上の閉じるボタン (丸型) */}
-      <div className="absolute top-4 left-4 z-20">
+      {/* 左上の閉じるボタン (丸型、メインUIと同じtop-3 left-3) */}
+      <div className="absolute top-3 left-3 z-20">
         <button
           type="button"
           onClick={handleClose}
@@ -188,7 +199,7 @@ const SupersamplingOverlayComponent = ({ onClose }: SupersamplingOverlayProps) =
       </div>
 
       {/* 右上のコントロール (縦並び: Fit切替 + 保存、保存は描画完了時のみ) */}
-      <div className="absolute top-4 right-4 z-20 flex flex-col gap-3">
+      <div className="absolute top-3 right-3 z-20 flex flex-col gap-5">
         <button
           type="button"
           onClick={handleToggleFitMode}
@@ -201,7 +212,7 @@ const SupersamplingOverlayComponent = ({ onClose }: SupersamplingOverlayProps) =
           <button
             type="button"
             onClick={handleSave}
-            className={`${CIRCLE_BUTTON_BASE_CLASS} hover:bg-white/20 hover:text-white`}
+            className="size-16 rounded-full bg-primary text-primary-foreground shadow-[0_4px_12px_rgba(0,0,0,0.4)] flex items-center justify-center transition-colors hover:bg-primary/90"
             aria-label="Save image"
           >
             <Download className="size-8" />

--- a/src/view/supersampling-overlay/index.tsx
+++ b/src/view/supersampling-overlay/index.tsx
@@ -224,7 +224,9 @@ const SupersamplingOverlayComponent = ({ onClose }: SupersamplingOverlayProps) =
             disabled={!isRenderComplete}
           >
             {fitMode ? <Expand className="mr-1 size-4" /> : <Shrink className="mr-1 size-4" />}
-            {fitMode ? "Actual Size" : "Fit to Screen"}
+            {fitMode
+              ? t("Actual Size", "supersampling.actualSize")
+              : t("Fit to Screen", "supersampling.fitToScreen")}
           </Button>
           <Button variant="default" size="sm" onClick={handleSave} disabled={!isRenderComplete}>
             <Download className="mr-1 size-4" />

--- a/src/view/supersampling-popover/dialog.tsx
+++ b/src/view/supersampling-popover/dialog.tsx
@@ -30,7 +30,7 @@ export const SupersamplingDialog = ({
             </DialogDescription>
           </VisuallyHidden.Root>
         </DialogHeader>
-        <SupersamplingForm />
+        <SupersamplingForm onAfterGenerate={() => onOpenChange(false)} />
       </DialogContent>
     </Dialog>
   );

--- a/src/view/supersampling-popover/dialog.tsx
+++ b/src/view/supersampling-popover/dialog.tsx
@@ -1,5 +1,12 @@
 import { useT } from "@/i18n/context";
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/shadcn/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/shadcn/components/ui/dialog";
+import { VisuallyHidden } from "radix-ui";
 import { SupersamplingForm } from "./form";
 
 /** スーパーサンプリング設定ダイアログ (モバイル用) */
@@ -17,6 +24,11 @@ export const SupersamplingDialog = ({
       <DialogContent className="max-w-sm">
         <DialogHeader>
           <DialogTitle>{t("Supersampling x2", "header.supersamplingX2")}</DialogTitle>
+          <VisuallyHidden.Root>
+            <DialogDescription>
+              {t("Supersampling settings", "dialog.description.supersampling")}
+            </DialogDescription>
+          </VisuallyHidden.Root>
         </DialogHeader>
         <SupersamplingForm />
       </DialogContent>

--- a/src/view/supersampling-popover/dialog.tsx
+++ b/src/view/supersampling-popover/dialog.tsx
@@ -1,0 +1,25 @@
+import { useT } from "@/i18n/context";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/shadcn/components/ui/dialog";
+import { SupersamplingForm } from "./form";
+
+/** スーパーサンプリング設定ダイアログ (モバイル用) */
+export const SupersamplingDialog = ({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) => {
+  const t = useT();
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>{t("Supersampling x2", "header.supersamplingX2")}</DialogTitle>
+        </DialogHeader>
+        <SupersamplingForm />
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/view/supersampling-popover/form.tsx
+++ b/src/view/supersampling-popover/form.tsx
@@ -1,0 +1,163 @@
+import { useT } from "@/i18n/context";
+import { setCurrentParams } from "@/mandelbrot-state/mandelbrot-state";
+import { Button } from "@/shadcn/components/ui/button";
+import { Input } from "@/shadcn/components/ui/input";
+import { Label } from "@/shadcn/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/shadcn/components/ui/select";
+import { updateStore, useStoreValue } from "@/store/store";
+import { Expand } from "lucide-react";
+import { useState } from "react";
+
+const MIN_SIZE = 100;
+const MAX_WIDTH = 7680;
+const MAX_HEIGHT = 4320;
+
+/** サイズをmin/max範囲にclampする */
+const clampSize = (value: number, min: number, max: number): number =>
+  Math.max(min, Math.min(max, value));
+
+type Preset = {
+  label: string;
+  width: number;
+  height: number;
+};
+
+const PRESETS: Preset[] = [
+  { label: "HD (1280x720)", width: 1280, height: 720 },
+  { label: "Full HD (1920x1080)", width: 1920, height: 1080 },
+  { label: "QHD (2560x1440)", width: 2560, height: 1440 },
+  { label: "4K (3840x2160)", width: 3840, height: 2160 },
+  { label: "5K (5120x2880)", width: 5120, height: 2880 },
+  { label: "8K (7680x4320)", width: 7680, height: 4320 },
+];
+
+/** 現在の幅・高さに一致するプリセットキーを返す。なければ "custom" */
+const findPresetKey = (width: number, height: number): string => {
+  const match = PRESETS.find((p) => p.width === width && p.height === height);
+  if (match) return match.label;
+
+  if (width === window.screen.width && height === window.screen.height) {
+    return "display";
+  }
+
+  return "custom";
+};
+
+/**
+ * スーパーサンプリング設定フォーム
+ *
+ * PopoverContent や DialogContent の中に直接配置して使う。
+ */
+export const SupersamplingForm = () => {
+  const t = useT();
+  const storedWidth = useStoreValue("supersamplingWidth");
+  const storedHeight = useStoreValue("supersamplingHeight");
+
+  const [width, setWidth] = useState(storedWidth);
+  const [height, setHeight] = useState(storedHeight);
+  const [presetKey, setPresetKey] = useState(() => findPresetKey(storedWidth, storedHeight));
+
+  /** プリセット選択時のハンドラ */
+  const handlePresetChange = (key: string) => {
+    setPresetKey(key);
+
+    if (key === "display") {
+      const w = clampSize(window.screen.width, MIN_SIZE, MAX_WIDTH);
+      const h = clampSize(window.screen.height, MIN_SIZE, MAX_HEIGHT);
+      setWidth(w);
+      setHeight(h);
+      updateStore("supersamplingWidth", w);
+      updateStore("supersamplingHeight", h);
+      return;
+    }
+
+    if (key === "custom") return;
+
+    const preset = PRESETS.find((p) => p.label === key);
+    if (preset) {
+      setWidth(preset.width);
+      setHeight(preset.height);
+      updateStore("supersamplingWidth", preset.width);
+      updateStore("supersamplingHeight", preset.height);
+    }
+  };
+
+  /** 幅の入力確定 */
+  const commitWidth = (raw: string) => {
+    const parsed = Number.parseInt(raw, 10);
+    if (Number.isNaN(parsed)) return;
+    const clamped = clampSize(parsed, MIN_SIZE, MAX_WIDTH);
+    setWidth(clamped);
+    updateStore("supersamplingWidth", clamped);
+    setPresetKey(findPresetKey(clamped, height));
+  };
+
+  /** 高さの入力確定 */
+  const commitHeight = (raw: string) => {
+    const parsed = Number.parseInt(raw, 10);
+    if (Number.isNaN(parsed)) return;
+    const clamped = clampSize(parsed, MIN_SIZE, MAX_HEIGHT);
+    setHeight(clamped);
+    updateStore("supersamplingHeight", clamped);
+    setPresetKey(findPresetKey(width, clamped));
+  };
+
+  /** スーパーサンプリング実行 */
+  const handleGenerate = () => {
+    setCurrentParams({ isSuperSampling: true });
+  };
+
+  const displaySizeLabel = `${t("Display Size", "settings.displaySize")} (${window.screen.width}x${window.screen.height})`;
+
+  return (
+    <div className="flex flex-col gap-3">
+      <Label className="text-xs text-muted-foreground">
+        {t("Output Size", "settings.outputSize")}
+      </Label>
+
+      <Select value={presetKey} onValueChange={handlePresetChange}>
+        <SelectTrigger className="h-8 text-xs">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="display">{displaySizeLabel}</SelectItem>
+          {PRESETS.map((p) => (
+            <SelectItem key={p.label} value={p.label}>
+              {p.label}
+            </SelectItem>
+          ))}
+          <SelectItem value="custom">{t("Custom", "settings.custom")}</SelectItem>
+        </SelectContent>
+      </Select>
+
+      <div className="flex items-center gap-2">
+        <Input
+          inputMode="numeric"
+          value={width}
+          onChange={(e) => setWidth(Number.parseInt(e.target.value, 10) || MIN_SIZE)}
+          onBlur={(e) => commitWidth(e.target.value)}
+          className="h-8 font-mono text-xs"
+        />
+        <span className="text-xs text-muted-foreground">x</span>
+        <Input
+          inputMode="numeric"
+          value={height}
+          onChange={(e) => setHeight(Number.parseInt(e.target.value, 10) || MIN_SIZE)}
+          onBlur={(e) => commitHeight(e.target.value)}
+          className="h-8 font-mono text-xs"
+        />
+      </div>
+
+      <Button size="sm" onClick={handleGenerate}>
+        <Expand className="mr-1 size-4" />
+        {t("Generate", "settings.generate")}
+      </Button>
+    </div>
+  );
+};

--- a/src/view/supersampling-popover/form.tsx
+++ b/src/view/supersampling-popover/form.tsx
@@ -37,12 +37,25 @@ const PRESETS: Preset[] = [
   { label: "8K (7680x4320)", width: 7680, height: 4320 },
 ];
 
+/**
+ * Display Size プリセット用の物理px解像度を返す
+ *
+ * 論理px (window.screen.width/height) にdevicePixelRatioを掛けて物理解像度化する。
+ * モバイル (例: Pixel 6a 論理412×915, dpr=2.625) で真の実機解像度 (~1081×2403) を
+ * supersamplingに指定するために使う。
+ */
+const getPhysicalDisplaySize = (): { width: number; height: number } => ({
+  width: Math.round(window.screen.width * window.devicePixelRatio),
+  height: Math.round(window.screen.height * window.devicePixelRatio),
+});
+
 /** 現在の幅・高さに一致するプリセットキーを返す。なければ "custom" */
 const findPresetKey = (width: number, height: number): string => {
   const match = PRESETS.find((p) => p.width === width && p.height === height);
   if (match) return match.label;
 
-  if (width === window.screen.width && height === window.screen.height) {
+  const physical = getPhysicalDisplaySize();
+  if (width === physical.width && height === physical.height) {
     return "display";
   }
 
@@ -68,8 +81,9 @@ export const SupersamplingForm = () => {
     setPresetKey(key);
 
     if (key === "display") {
-      const w = clampSize(window.screen.width, MIN_SIZE, MAX_WIDTH);
-      const h = clampSize(window.screen.height, MIN_SIZE, MAX_HEIGHT);
+      const physical = getPhysicalDisplaySize();
+      const w = clampSize(physical.width, MIN_SIZE, MAX_WIDTH);
+      const h = clampSize(physical.height, MIN_SIZE, MAX_HEIGHT);
       setWidth(w);
       setHeight(h);
       updateStore("supersamplingWidth", w);
@@ -113,7 +127,8 @@ export const SupersamplingForm = () => {
     setCurrentParams({ isSuperSampling: true });
   };
 
-  const displaySizeLabel = `${t("Display Size", "settings.displaySize")} (${window.screen.width}x${window.screen.height})`;
+  const physicalDisplay = getPhysicalDisplaySize();
+  const displaySizeLabel = `${t("Display Size", "settings.displaySize")} (${physicalDisplay.width}x${physicalDisplay.height})`;
 
   return (
     <div className="flex flex-col gap-3">

--- a/src/view/supersampling-popover/form.tsx
+++ b/src/view/supersampling-popover/form.tsx
@@ -66,8 +66,9 @@ const findPresetKey = (width: number, height: number): string => {
  * スーパーサンプリング設定フォーム
  *
  * PopoverContent や DialogContent の中に直接配置して使う。
+ * Generate押下後に任意の後処理を行いたい場合は onAfterGenerate を渡す (e.g. Dialog自動close)。
  */
-export const SupersamplingForm = () => {
+export const SupersamplingForm = ({ onAfterGenerate }: { onAfterGenerate?: () => void } = {}) => {
   const t = useT();
   const storedWidth = useStoreValue("supersamplingWidth");
   const storedHeight = useStoreValue("supersamplingHeight");
@@ -125,6 +126,7 @@ export const SupersamplingForm = () => {
   /** スーパーサンプリング実行 */
   const handleGenerate = () => {
     setCurrentParams({ isSuperSampling: true });
+    onAfterGenerate?.();
   };
 
   const physicalDisplay = getPhysicalDisplaySize();

--- a/src/view/supersampling-popover/index.tsx
+++ b/src/view/supersampling-popover/index.tsx
@@ -1,116 +1,12 @@
 import { useT } from "@/i18n/context";
-import { setCurrentParams } from "@/mandelbrot-state/mandelbrot-state";
 import { Button } from "@/shadcn/components/ui/button";
-import { Input } from "@/shadcn/components/ui/input";
-import { Label } from "@/shadcn/components/ui/label";
 import { Popover, PopoverContent, PopoverTrigger } from "@/shadcn/components/ui/popover";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/shadcn/components/ui/select";
-import { updateStore, useStoreValue } from "@/store/store";
 import { Expand } from "lucide-react";
-import { useState } from "react";
+import { SupersamplingForm } from "./form";
 
-const MIN_SIZE = 100;
-const MAX_WIDTH = 7680;
-const MAX_HEIGHT = 4320;
-
-/** サイズをmin/max範囲にclampする */
-const clampSize = (value: number, min: number, max: number): number =>
-  Math.max(min, Math.min(max, value));
-
-type Preset = {
-  label: string;
-  width: number;
-  height: number;
-};
-
-const PRESETS: Preset[] = [
-  { label: "HD (1280x720)", width: 1280, height: 720 },
-  { label: "Full HD (1920x1080)", width: 1920, height: 1080 },
-  { label: "QHD (2560x1440)", width: 2560, height: 1440 },
-  { label: "4K (3840x2160)", width: 3840, height: 2160 },
-  { label: "5K (5120x2880)", width: 5120, height: 2880 },
-  { label: "8K (7680x4320)", width: 7680, height: 4320 },
-];
-
-/** 現在の幅・高さに一致するプリセットキーを返す。なければ "custom" */
-const findPresetKey = (width: number, height: number): string => {
-  const match = PRESETS.find((p) => p.width === width && p.height === height);
-  if (match) return match.label;
-
-  if (width === window.screen.width && height === window.screen.height) {
-    return "display";
-  }
-
-  return "custom";
-};
-
-/** スーパーサンプリング設定ポップオーバー */
+/** スーパーサンプリング設定ポップオーバー (デスクトップ用) */
 export const SupersamplingPopover = () => {
   const t = useT();
-  const storedWidth = useStoreValue("supersamplingWidth");
-  const storedHeight = useStoreValue("supersamplingHeight");
-
-  const [width, setWidth] = useState(storedWidth);
-  const [height, setHeight] = useState(storedHeight);
-  const [presetKey, setPresetKey] = useState(() => findPresetKey(storedWidth, storedHeight));
-
-  /** プリセット選択時のハンドラ */
-  const handlePresetChange = (key: string) => {
-    setPresetKey(key);
-
-    if (key === "display") {
-      const w = clampSize(window.screen.width, MIN_SIZE, MAX_WIDTH);
-      const h = clampSize(window.screen.height, MIN_SIZE, MAX_HEIGHT);
-      setWidth(w);
-      setHeight(h);
-      updateStore("supersamplingWidth", w);
-      updateStore("supersamplingHeight", h);
-      return;
-    }
-
-    if (key === "custom") return;
-
-    const preset = PRESETS.find((p) => p.label === key);
-    if (preset) {
-      setWidth(preset.width);
-      setHeight(preset.height);
-      updateStore("supersamplingWidth", preset.width);
-      updateStore("supersamplingHeight", preset.height);
-    }
-  };
-
-  /** 幅の入力確定 */
-  const commitWidth = (raw: string) => {
-    const parsed = Number.parseInt(raw, 10);
-    if (Number.isNaN(parsed)) return;
-    const clamped = clampSize(parsed, MIN_SIZE, MAX_WIDTH);
-    setWidth(clamped);
-    updateStore("supersamplingWidth", clamped);
-    setPresetKey(findPresetKey(clamped, height));
-  };
-
-  /** 高さの入力確定 */
-  const commitHeight = (raw: string) => {
-    const parsed = Number.parseInt(raw, 10);
-    if (Number.isNaN(parsed)) return;
-    const clamped = clampSize(parsed, MIN_SIZE, MAX_HEIGHT);
-    setHeight(clamped);
-    updateStore("supersamplingHeight", clamped);
-    setPresetKey(findPresetKey(width, clamped));
-  };
-
-  /** スーパーサンプリング実行 */
-  const handleGenerate = () => {
-    setCurrentParams({ isSuperSampling: true });
-  };
-
-  const displaySizeLabel = `${t("Display Size", "settings.displaySize")} (${window.screen.width}x${window.screen.height})`;
 
   return (
     <Popover>
@@ -125,49 +21,7 @@ export const SupersamplingPopover = () => {
         align="start"
         sideOffset={8}
       >
-        <div className="flex flex-col gap-3">
-          <Label className="text-xs text-muted-foreground">
-            {t("Output Size", "settings.outputSize")}
-          </Label>
-
-          <Select value={presetKey} onValueChange={handlePresetChange}>
-            <SelectTrigger className="h-8 text-xs">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="display">{displaySizeLabel}</SelectItem>
-              {PRESETS.map((p) => (
-                <SelectItem key={p.label} value={p.label}>
-                  {p.label}
-                </SelectItem>
-              ))}
-              <SelectItem value="custom">{t("Custom", "settings.custom")}</SelectItem>
-            </SelectContent>
-          </Select>
-
-          <div className="flex items-center gap-2">
-            <Input
-              inputMode="numeric"
-              value={width}
-              onChange={(e) => setWidth(Number.parseInt(e.target.value, 10) || MIN_SIZE)}
-              onBlur={(e) => commitWidth(e.target.value)}
-              className="h-8 font-mono text-xs"
-            />
-            <span className="text-xs text-muted-foreground">x</span>
-            <Input
-              inputMode="numeric"
-              value={height}
-              onChange={(e) => setHeight(Number.parseInt(e.target.value, 10) || MIN_SIZE)}
-              onBlur={(e) => commitHeight(e.target.value)}
-              className="h-8 font-mono text-xs"
-            />
-          </div>
-
-          <Button size="sm" onClick={handleGenerate}>
-            <Expand className="mr-1 size-4" />
-            {t("Generate", "settings.generate")}
-          </Button>
-        </div>
+        <SupersamplingForm />
       </PopoverContent>
     </Popover>
   );

--- a/src/view/supersampling-popover/index.tsx
+++ b/src/view/supersampling-popover/index.tsx
@@ -2,14 +2,16 @@ import { useT } from "@/i18n/context";
 import { Button } from "@/shadcn/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/shadcn/components/ui/popover";
 import { Expand } from "lucide-react";
+import { useState } from "react";
 import { SupersamplingForm } from "./form";
 
 /** スーパーサンプリング設定ポップオーバー (デスクトップ用) */
 export const SupersamplingPopover = () => {
   const t = useT();
+  const [open, setOpen] = useState(false);
 
   return (
-    <Popover>
+    <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <Button variant="outline" size="sm">
           <Expand className="mr-1 size-5" />
@@ -21,7 +23,7 @@ export const SupersamplingPopover = () => {
         align="start"
         sideOffset={8}
       >
-        <SupersamplingForm />
+        <SupersamplingForm onAfterGenerate={() => setOpen(false)} />
       </PopoverContent>
     </Popover>
   );

--- a/src/view/toolbar/index.tsx
+++ b/src/view/toolbar/index.tsx
@@ -1,9 +1,27 @@
 import { SimpleTooltip } from "@/components/simple-tooltip";
 import { useT } from "@/i18n/context";
 import { Button } from "@/shadcn/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/shadcn/components/ui/dropdown";
 import { updateStoreWith, useStoreValue } from "@/store/store";
-import { IconBug, IconLayoutSidebar, IconNavigation, IconSettings } from "@tabler/icons-react";
-import { Actions } from "../header/actions";
+import { SupersamplingDialog } from "@/view/supersampling-popover/dialog";
+import { useIsMobile } from "@/view/use-is-mobile";
+import {
+  IconBug,
+  IconDownload,
+  IconLayoutSidebar,
+  IconMaximize,
+  IconMenu2,
+  IconNavigation,
+  IconSettings,
+  IconShare,
+} from "@tabler/icons-react";
+import { Actions, performSaveImage, RandomJumpButton, ShareDialogHost } from "../header/actions";
 import { useModalState } from "../modal/use-modal-state";
 import { PalettePopover } from "../palette-popover";
 import { SettingsDialog } from "../settings-dialog";
@@ -46,14 +64,108 @@ const POIPanelToggle = () => {
   );
 };
 
-/** フローティングツールバー（左上固定） */
-export const Toolbar = () => {
+type OpenHandlers = {
+  openShare: () => void;
+  openSS: () => void;
+  openJump: () => void;
+  openSettings: () => void;
+};
+
+/** デスクトップ幅のツールバー内容 (従来レイアウト) */
+const DesktopToolbarBody = ({ openShare, openJump, openSettings }: OpenHandlers) => {
   const t = useT();
-  const [settingsOpened, { open: openSettings, close: closeSettings }] = useModalState();
-  const [jumpOpened, { open: openJump, close: closeJump }] = useModalState();
+  return (
+    <>
+      <Actions onOpenShare={openShare} />
+      <div className="bg-border mx-1 h-6 w-px" />
+      <PalettePopover />
+      <Button variant="outline" size="sm" onClick={openJump}>
+        <IconNavigation className="mr-1 size-5" />
+        {t("Jump", "toolbar.jump")}
+      </Button>
+      <Button variant="outline" size="sm" onClick={openSettings}>
+        <IconSettings className="mr-1 size-5" />
+        {t("Settings", "operations.settings")}
+      </Button>
+      <div className="bg-border mx-1 h-6 w-px" />
+      <DebugPanelToggle />
+      <POIPanelToggle />
+    </>
+  );
+};
+
+/** モバイル幅のツールバー内容 (Lucky/Palette/POI独立 + ハンバーガー) */
+const MobileToolbarBody = ({ openShare, openSS, openJump, openSettings }: OpenHandlers) => {
+  const t = useT();
 
   return (
     <>
+      <RandomJumpButton />
+      <PalettePopover />
+      <POIPanelToggle />
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline" size="sm" aria-label="Menu">
+            <IconMenu2 className="size-5" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" sideOffset={8} className="min-w-48">
+          <DropdownMenuItem onSelect={openShare}>
+            <IconShare className="size-4" />
+            {t("Share", "header.share")}
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => performSaveImage(t)}>
+            <IconDownload className="size-4" />
+            {t("Save Image")}
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={openSS}>
+            <IconMaximize className="size-4" />
+            {t("Supersampling x2", "header.supersamplingX2")}
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onSelect={openJump}>
+            <IconNavigation className="size-4" />
+            {t("Jump", "toolbar.jump")}
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={openSettings}>
+            <IconSettings className="size-4" />
+            {t("Settings", "operations.settings")}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </>
+  );
+};
+
+/** フローティングツールバー (左上固定) */
+export const Toolbar = () => {
+  const isMobile = useIsMobile();
+  const [shareOpened, { open: openShare, close: closeShare }] = useModalState();
+  const [ssOpened, { open: openSS, close: closeSS }] = useModalState();
+  const [jumpOpened, { open: openJump, close: closeJump }] = useModalState();
+  const [settingsOpened, { open: openSettings, close: closeSettings }] = useModalState();
+
+  const openHandlers: OpenHandlers = {
+    openShare,
+    openSS,
+    openJump,
+    openSettings,
+  };
+
+  return (
+    <>
+      <ShareDialogHost
+        open={shareOpened}
+        onOpenChange={(isOpen) => {
+          if (!isOpen) closeShare();
+        }}
+      />
+      <SupersamplingDialog
+        open={ssOpened}
+        onOpenChange={(isOpen) => {
+          if (!isOpen) closeSS();
+        }}
+      />
       <SettingsDialog
         open={settingsOpened}
         onOpenChange={(isOpen) => {
@@ -67,20 +179,11 @@ export const Toolbar = () => {
         }}
       />
       <div className="fixed top-3 left-3 z-100 flex items-center gap-2 rounded-xl border border-[#2a2a3a] bg-[#1c1c24]/95 px-3 py-2 backdrop-blur-sm">
-        <Actions />
-        <div className="bg-border mx-1 h-6 w-px" />
-        <PalettePopover />
-        <Button variant="outline" size="sm" onClick={openJump}>
-          <IconNavigation className="mr-1 size-5" />
-          {t("Jump", "toolbar.jump")}
-        </Button>
-        <Button variant="outline" size="sm" onClick={openSettings}>
-          <IconSettings className="mr-1 size-5" />
-          {t("Settings", "operations.settings")}
-        </Button>
-        <div className="bg-border mx-1 h-6 w-px" />
-        <DebugPanelToggle />
-        <POIPanelToggle />
+        {isMobile ? (
+          <MobileToolbarBody {...openHandlers} />
+        ) : (
+          <DesktopToolbarBody {...openHandlers} />
+        )}
       </div>
     </>
   );

--- a/src/view/toolbar/index.tsx
+++ b/src/view/toolbar/index.tsx
@@ -1,31 +1,16 @@
 import { SimpleTooltip } from "@/components/simple-tooltip";
 import { useT } from "@/i18n/context";
 import { Button } from "@/shadcn/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/shadcn/components/ui/dropdown";
 import { updateStoreWith, useStoreValue } from "@/store/store";
 import { SupersamplingDialog } from "@/view/supersampling-popover/dialog";
 import { useIsMobile } from "@/view/use-is-mobile";
-import {
-  IconBug,
-  IconDownload,
-  IconLayoutSidebar,
-  IconMaximize,
-  IconMenu2,
-  IconNavigation,
-  IconSettings,
-  IconShare,
-} from "@tabler/icons-react";
-import { Actions, performSaveImage, RandomJumpButton, ShareDialogHost } from "../header/actions";
+import { IconBug, IconLayoutSidebar, IconNavigation, IconSettings } from "@tabler/icons-react";
+import { Actions, ShareDialogHost } from "../header/actions";
 import { useModalState } from "../modal/use-modal-state";
 import { PalettePopover } from "../palette-popover";
 import { SettingsDialog } from "../settings-dialog";
 import { JumpDialog } from "./jump-dialog";
+import { MobileToolbar } from "./mobile";
 
 /** デバッグパネルの開閉トグルボタン */
 const DebugPanelToggle = () => {
@@ -75,7 +60,7 @@ type OpenHandlers = {
 const DesktopToolbarBody = ({ openShare, openJump, openSettings }: OpenHandlers) => {
   const t = useT();
   return (
-    <>
+    <div className="fixed top-3 left-3 z-100 flex items-center gap-2 rounded-xl border border-[#2a2a3a] bg-[#1c1c24]/95 px-3 py-2 backdrop-blur-sm">
       <Actions onOpenShare={openShare} />
       <div className="bg-border mx-1 h-6 w-px" />
       <PalettePopover />
@@ -90,54 +75,11 @@ const DesktopToolbarBody = ({ openShare, openJump, openSettings }: OpenHandlers)
       <div className="bg-border mx-1 h-6 w-px" />
       <DebugPanelToggle />
       <POIPanelToggle />
-    </>
+    </div>
   );
 };
 
-/** モバイル幅のツールバー内容 (Lucky/Palette/POI独立 + ハンバーガー) */
-const MobileToolbarBody = ({ openShare, openSS, openJump, openSettings }: OpenHandlers) => {
-  const t = useT();
-
-  return (
-    <>
-      <RandomJumpButton />
-      <PalettePopover />
-      <POIPanelToggle />
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button variant="outline" size="sm" aria-label="Menu">
-            <IconMenu2 className="size-5" />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="start" sideOffset={8} className="min-w-48">
-          <DropdownMenuItem onSelect={openShare}>
-            <IconShare className="size-4" />
-            {t("Share", "header.share")}
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => performSaveImage(t)}>
-            <IconDownload className="size-4" />
-            {t("Save Image")}
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={openSS}>
-            <IconMaximize className="size-4" />
-            {t("Supersampling x2", "header.supersamplingX2")}
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem onSelect={openJump}>
-            <IconNavigation className="size-4" />
-            {t("Jump", "toolbar.jump")}
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={openSettings}>
-            <IconSettings className="size-4" />
-            {t("Settings", "operations.settings")}
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
-    </>
-  );
-};
-
-/** フローティングツールバー (左上固定) */
+/** フローティングツールバー (デスクトップ/モバイルで切替) */
 export const Toolbar = () => {
   const isMobile = useIsMobile();
   const [shareOpened, { open: openShare, close: closeShare }] = useModalState();
@@ -178,13 +120,7 @@ export const Toolbar = () => {
           if (!isOpen) closeJump();
         }}
       />
-      <div className="fixed top-3 left-3 z-100 flex items-center gap-2 rounded-xl border border-[#2a2a3a] bg-[#1c1c24]/95 px-3 py-2 backdrop-blur-sm">
-        {isMobile ? (
-          <MobileToolbarBody {...openHandlers} />
-        ) : (
-          <DesktopToolbarBody {...openHandlers} />
-        )}
-      </div>
+      {isMobile ? <MobileToolbar {...openHandlers} /> : <DesktopToolbarBody {...openHandlers} />}
     </>
   );
 };

--- a/src/view/toolbar/jump-dialog.tsx
+++ b/src/view/toolbar/jump-dialog.tsx
@@ -16,7 +16,6 @@ import {
 import { Input } from "@/shadcn/components/ui/input";
 import { Label } from "@/shadcn/components/ui/label";
 import { Textarea } from "@/shadcn/components/ui/textarea";
-import { PERTURBATION_THRESHOLD } from "@/utils/palette-encoding";
 import BigNumber from "bignumber.js";
 import { useState } from "react";
 
@@ -158,10 +157,9 @@ export const JumpDialog = ({ open, onOpenChange }: JumpDialogProps) => {
         return;
       }
 
-      const mode = r.isLessThan(PERTURBATION_THRESHOLD) ? "perturbation" : "normal";
-
       setManualN(N);
-      setCurrentParams({ x, y, r, N, mode });
+      // modeはsetCurrentParams側でrから自動決定される
+      setCurrentParams({ x, y, r, N });
       clearIterationCache();
 
       // ダイアログを閉じてリセット

--- a/src/view/toolbar/jump-dialog.tsx
+++ b/src/view/toolbar/jump-dialog.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/shadcn/components/ui/button";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
@@ -17,6 +18,7 @@ import { Input } from "@/shadcn/components/ui/input";
 import { Label } from "@/shadcn/components/ui/label";
 import { Textarea } from "@/shadcn/components/ui/textarea";
 import BigNumber from "bignumber.js";
+import { VisuallyHidden } from "radix-ui";
 import { useState } from "react";
 
 /** パラメータ名のエイリアスマッピング */
@@ -177,6 +179,11 @@ export const JumpDialog = ({ open, onOpenChange }: JumpDialogProps) => {
       <DialogContent className="max-w-md overflow-hidden">
         <DialogHeader>
           <DialogTitle>{t("Jump to Coordinates", "toolbar.jumpToCoordinates")}</DialogTitle>
+          <VisuallyHidden.Root>
+            <DialogDescription>
+              {t("Jump to specified coordinates", "dialog.description.jump")}
+            </DialogDescription>
+          </VisuallyHidden.Root>
         </DialogHeader>
 
         <div className="flex flex-col gap-4">

--- a/src/view/toolbar/mobile.tsx
+++ b/src/view/toolbar/mobile.tsx
@@ -25,7 +25,7 @@ import { PaletteEditor } from "../right-sidebar/palette-editor";
 
 /** モバイル用の丸型フローティングアイコンボタンの共通クラス */
 const FLOATING_BUTTON_CLASS =
-  "size-11 rounded-full border-[#2a2a3a] bg-[#1c1c24]/95 shadow-[0_4px_12px_rgba(0,0,0,0.4)] backdrop-blur-sm";
+  "size-16 rounded-full border-[#2a2a3a] bg-[#1c1c24]/95 shadow-[0_4px_12px_rgba(0,0,0,0.4)] backdrop-blur-sm";
 
 type MobileToolbarProps = {
   openShare: () => void;
@@ -43,7 +43,7 @@ const HamburgerMenu = ({ openShare, openSS, openJump, openSettings }: MobileTool
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button variant="outline" size="icon" aria-label="Menu" className={FLOATING_BUTTON_CLASS}>
-            <IconMenu2 className="size-5" />
+            <IconMenu2 className="size-8" />
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start" sideOffset={8} className="min-w-48">
@@ -74,17 +74,17 @@ const HamburgerMenu = ({ openShare, openSS, openJump, openSettings }: MobileTool
   );
 };
 
-/** 右上: I'm Feeling Lucky + Palette */
+/** 右上: I'm Feeling Lucky + Palette (縦並び、上からLucky→Palette) */
 const TopRightActions = () => (
-  <div className="fixed top-3 right-3 z-100 flex gap-2">
+  <div className="fixed top-3 right-3 z-100 flex flex-col gap-2">
     <Button
       variant="default"
       size="icon"
       aria-label="I'm Feeling Lucky"
-      className="size-11 rounded-full shadow-[0_4px_12px_rgba(0,0,0,0.4)]"
+      className="size-16 rounded-full shadow-[0_4px_12px_rgba(0,0,0,0.4)]"
       onClick={performRandomJump}
     >
-      <IconDice className="size-5" />
+      <IconDice className="size-8" />
     </Button>
     <Popover>
       <PopoverTrigger asChild>
@@ -94,7 +94,7 @@ const TopRightActions = () => (
           aria-label="Palette"
           className={FLOATING_BUTTON_CLASS}
         >
-          <IconPalette className="size-5" />
+          <IconPalette className="size-8" />
         </Button>
       </PopoverTrigger>
       <PopoverContent
@@ -129,7 +129,7 @@ const POIToggleFab = () => {
         className={FLOATING_BUTTON_CLASS}
         onClick={() => updateStoreWith("poiPanelOpen", (v) => !v)}
       >
-        <IconLayoutSidebar className="size-5" />
+        <IconLayoutSidebar className="size-8" />
       </Button>
     </div>
   );

--- a/src/view/toolbar/mobile.tsx
+++ b/src/view/toolbar/mobile.tsx
@@ -27,6 +27,9 @@ import { PaletteEditor } from "../right-sidebar/palette-editor";
 const FLOATING_BUTTON_CLASS =
   "size-16 rounded-full border-[#2a2a3a] bg-[#1c1c24]/95 shadow-[0_4px_12px_rgba(0,0,0,0.4)] backdrop-blur-sm";
 
+/** モバイル用DropdownMenuItemの共通クラス (タップ領域拡大) */
+const MOBILE_MENU_ITEM_CLASS = "gap-2 py-3 text-base";
+
 type MobileToolbarProps = {
   openShare: () => void;
   openSS: () => void;
@@ -58,26 +61,26 @@ const HamburgerMenu = ({ openShare, openSS, openJump, openSettings }: MobileTool
             <IconMenu2 className="size-8" />
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="start" sideOffset={8} className="min-w-48">
-          <DropdownMenuItem onSelect={openShare}>
-            <IconShare className="size-4" />
+        <DropdownMenuContent align="start" sideOffset={8} className="min-w-60">
+          <DropdownMenuItem onSelect={openShare} className={MOBILE_MENU_ITEM_CLASS}>
+            <IconShare className="size-5" />
             {t("Share", "header.share")}
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => performSaveImage(t)}>
-            <IconDownload className="size-4" />
+          <DropdownMenuItem onSelect={() => performSaveImage(t)} className={MOBILE_MENU_ITEM_CLASS}>
+            <IconDownload className="size-5" />
             {t("Save Image")}
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={openSS}>
-            <IconMaximize className="size-4" />
+          <DropdownMenuItem onSelect={openSS} className={MOBILE_MENU_ITEM_CLASS}>
+            <IconMaximize className="size-5" />
             {t("Supersampling x2", "header.supersamplingX2")}
           </DropdownMenuItem>
           <DropdownMenuSeparator />
-          <DropdownMenuItem onSelect={openJump}>
-            <IconNavigation className="size-4" />
+          <DropdownMenuItem onSelect={openJump} className={MOBILE_MENU_ITEM_CLASS}>
+            <IconNavigation className="size-5" />
             {t("Jump", "toolbar.jump")}
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={openSettings}>
-            <IconSettings className="size-4" />
+          <DropdownMenuItem onSelect={openSettings} className={MOBILE_MENU_ITEM_CLASS}>
+            <IconSettings className="size-5" />
             {t("Settings", "operations.settings")}
           </DropdownMenuItem>
         </DropdownMenuContent>

--- a/src/view/toolbar/mobile.tsx
+++ b/src/view/toolbar/mobile.tsx
@@ -30,6 +30,17 @@ const FLOATING_BUTTON_CLASS =
 /** モバイル用DropdownMenuItemの共通クラス (タップ領域拡大) */
 const MOBILE_MENU_ITEM_CLASS = "gap-2 py-3 text-base";
 
+/**
+ * トリガー押下直後にfocusを外す。
+ *
+ * Radix Dialog/Popover/Dropdown open時に外側(toolbar)へaria-hiddenが付与され、
+ * focusを保持したままのtriggerがaria-hidden祖先内に残ると警告が出る。
+ * pointer操作のときだけ解除すればよく、キーボード操作には影響させない。
+ */
+const blurOnPointerDown = (e: React.PointerEvent<HTMLButtonElement>) => {
+  e.currentTarget.blur();
+};
+
 type MobileToolbarProps = {
   openShare: () => void;
   openSS: () => void;
@@ -57,7 +68,13 @@ const HamburgerMenu = ({ openShare, openSS, openJump, openSettings }: MobileTool
     >
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <Button variant="outline" size="icon" aria-label="Menu" className={FLOATING_BUTTON_CLASS}>
+          <Button
+            variant="outline"
+            size="icon"
+            aria-label="Menu"
+            className={FLOATING_BUTTON_CLASS}
+            onPointerDown={blurOnPointerDown}
+          >
             <IconMenu2 className="size-8" />
           </Button>
         </DropdownMenuTrigger>
@@ -104,6 +121,7 @@ const TopRightActions = () => {
         aria-label="I'm Feeling Lucky"
         className="size-16 rounded-full shadow-[0_4px_12px_rgba(0,0,0,0.4)]"
         onClick={performRandomJump}
+        onPointerDown={blurOnPointerDown}
       >
         <IconDice className="size-8" />
       </Button>
@@ -114,6 +132,7 @@ const TopRightActions = () => {
             size="icon"
             aria-label="Palette"
             className={FLOATING_BUTTON_CLASS}
+            onPointerDown={blurOnPointerDown}
           >
             <IconPalette className="size-8" />
           </Button>
@@ -149,6 +168,7 @@ const POIToggleFab = () => {
         aria-label="Open POI drawer"
         className={FLOATING_BUTTON_CLASS}
         onClick={() => updateStore("poiDrawerSnap", "small")}
+        onPointerDown={blurOnPointerDown}
       >
         <IconLayoutSidebar className="size-8" />
       </Button>

--- a/src/view/toolbar/mobile.tsx
+++ b/src/view/toolbar/mobile.tsx
@@ -118,7 +118,7 @@ const POIToggleFab = () => {
 
   return (
     <div
-      className={`fixed right-3 bottom-6 z-100 transition-opacity duration-200 ${
+      className={`fixed right-3 bottom-7 z-100 transition-opacity duration-200 ${
         poiPanelOpen ? "pointer-events-none opacity-0" : "opacity-100"
       }`}
     >

--- a/src/view/toolbar/mobile.tsx
+++ b/src/view/toolbar/mobile.tsx
@@ -1,0 +1,151 @@
+import { useT } from "@/i18n/context";
+import { Button } from "@/shadcn/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/shadcn/components/ui/dropdown";
+import { Popover, PopoverContent, PopoverTrigger } from "@/shadcn/components/ui/popover";
+import { updateStoreWith, useStoreValue } from "@/store/store";
+import {
+  IconDice,
+  IconDownload,
+  IconLayoutSidebar,
+  IconMaximize,
+  IconMenu2,
+  IconNavigation,
+  IconPalette,
+  IconSettings,
+  IconShare,
+} from "@tabler/icons-react";
+import { performRandomJump, performSaveImage } from "../header/actions";
+import { PaletteEditor } from "../right-sidebar/palette-editor";
+
+/** モバイル用の丸型フローティングアイコンボタンの共通クラス */
+const FLOATING_BUTTON_CLASS =
+  "size-11 rounded-full border-[#2a2a3a] bg-[#1c1c24]/95 shadow-[0_4px_12px_rgba(0,0,0,0.4)] backdrop-blur-sm";
+
+type MobileToolbarProps = {
+  openShare: () => void;
+  openSS: () => void;
+  openJump: () => void;
+  openSettings: () => void;
+};
+
+/** 左上: ハンバーガーメニュー (Share/Save/SS/Jump/Settings) */
+const HamburgerMenu = ({ openShare, openSS, openJump, openSettings }: MobileToolbarProps) => {
+  const t = useT();
+
+  return (
+    <div className="fixed top-3 left-3 z-100">
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline" size="icon" aria-label="Menu" className={FLOATING_BUTTON_CLASS}>
+            <IconMenu2 className="size-5" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" sideOffset={8} className="min-w-48">
+          <DropdownMenuItem onSelect={openShare}>
+            <IconShare className="size-4" />
+            {t("Share", "header.share")}
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => performSaveImage(t)}>
+            <IconDownload className="size-4" />
+            {t("Save Image")}
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={openSS}>
+            <IconMaximize className="size-4" />
+            {t("Supersampling x2", "header.supersamplingX2")}
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onSelect={openJump}>
+            <IconNavigation className="size-4" />
+            {t("Jump", "toolbar.jump")}
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={openSettings}>
+            <IconSettings className="size-4" />
+            {t("Settings", "operations.settings")}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+};
+
+/** 右上: I'm Feeling Lucky + Palette */
+const TopRightActions = () => (
+  <div className="fixed top-3 right-3 z-100 flex gap-2">
+    <Button
+      variant="default"
+      size="icon"
+      aria-label="I'm Feeling Lucky"
+      className="size-11 rounded-full shadow-[0_4px_12px_rgba(0,0,0,0.4)]"
+      onClick={performRandomJump}
+    >
+      <IconDice className="size-5" />
+    </Button>
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          size="icon"
+          aria-label="Palette"
+          className={FLOATING_BUTTON_CLASS}
+        >
+          <IconPalette className="size-5" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-84 border border-[#2a2a3a] p-4 shadow-[0_8px_32px_rgba(0,0,0,0.6)]"
+        align="end"
+        sideOffset={8}
+      >
+        <PaletteEditor />
+      </PopoverContent>
+    </Popover>
+  </div>
+);
+
+/**
+ * 右下: POIドロワーのトグルボタン
+ *
+ * poiPanelOpen=true (ドロワー全開) のときはフェードアウトして操作不可にする。
+ */
+const POIToggleFab = () => {
+  const poiPanelOpen = useStoreValue("poiPanelOpen");
+
+  return (
+    <div
+      className={`fixed right-3 bottom-6 z-100 transition-opacity duration-200 ${
+        poiPanelOpen ? "pointer-events-none opacity-0" : "opacity-100"
+      }`}
+    >
+      <Button
+        variant="outline"
+        size="icon"
+        aria-label="Toggle POI panel"
+        className={FLOATING_BUTTON_CLASS}
+        onClick={() => updateStoreWith("poiPanelOpen", (v) => !v)}
+      >
+        <IconLayoutSidebar className="size-5" />
+      </Button>
+    </div>
+  );
+};
+
+/**
+ * モバイル向けツールバー (丸型アイコンボタンを画面各所に配置)
+ *
+ * 左上: ハンバーガー / 右上: Lucky + Palette / 右下: POIトグル
+ */
+export const MobileToolbar = (props: MobileToolbarProps) => {
+  return (
+    <>
+      <HamburgerMenu {...props} />
+      <TopRightActions />
+      <POIToggleFab />
+    </>
+  );
+};

--- a/src/view/toolbar/mobile.tsx
+++ b/src/view/toolbar/mobile.tsx
@@ -8,7 +8,7 @@ import {
   DropdownMenuTrigger,
 } from "@/shadcn/components/ui/dropdown";
 import { Popover, PopoverContent, PopoverTrigger } from "@/shadcn/components/ui/popover";
-import { updateStoreWith, useStoreValue } from "@/store/store";
+import { updateStore, useStoreValue } from "@/store/store";
 import {
   IconDice,
   IconDownload,
@@ -34,12 +34,24 @@ type MobileToolbarProps = {
   openSettings: () => void;
 };
 
+/**
+ * fade用の透明度クラスを返す
+ *
+ * @param hidden - trueならフェードアウト + 操作不可に
+ */
+const fadeClass = (hidden: boolean): string =>
+  hidden ? "pointer-events-none opacity-0" : "opacity-100";
+
 /** 左上: ハンバーガーメニュー (Share/Save/SS/Jump/Settings) */
 const HamburgerMenu = ({ openShare, openSS, openJump, openSettings }: MobileToolbarProps) => {
   const t = useT();
+  const snap = useStoreValue("poiDrawerSnap");
+  const hidden = snap === "full";
 
   return (
-    <div className="fixed top-3 left-3 z-100">
+    <div
+      className={`fixed top-3 left-3 z-100 transition-opacity duration-200 ${fadeClass(hidden)}`}
+    >
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button variant="outline" size="icon" aria-label="Menu" className={FLOATING_BUTTON_CLASS}>
@@ -75,59 +87,65 @@ const HamburgerMenu = ({ openShare, openSS, openJump, openSettings }: MobileTool
 };
 
 /** 右上: I'm Feeling Lucky + Palette (縦並び、上からLucky→Palette) */
-const TopRightActions = () => (
-  <div className="fixed top-3 right-3 z-100 flex flex-col gap-5">
-    <Button
-      variant="default"
-      size="icon"
-      aria-label="I'm Feeling Lucky"
-      className="size-16 rounded-full shadow-[0_4px_12px_rgba(0,0,0,0.4)]"
-      onClick={performRandomJump}
-    >
-      <IconDice className="size-8" />
-    </Button>
-    <Popover>
-      <PopoverTrigger asChild>
-        <Button
-          variant="outline"
-          size="icon"
-          aria-label="Palette"
-          className={FLOATING_BUTTON_CLASS}
-        >
-          <IconPalette className="size-8" />
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent
-        className="w-84 border border-[#2a2a3a] p-4 shadow-[0_8px_32px_rgba(0,0,0,0.6)]"
-        align="end"
-        sideOffset={8}
-      >
-        <PaletteEditor />
-      </PopoverContent>
-    </Popover>
-  </div>
-);
-
-/**
- * 右下: POIドロワーのトグルボタン
- *
- * poiPanelOpen=true (ドロワー全開) のときはフェードアウトして操作不可にする。
- */
-const POIToggleFab = () => {
-  const poiPanelOpen = useStoreValue("poiPanelOpen");
+const TopRightActions = () => {
+  const snap = useStoreValue("poiDrawerSnap");
+  const hidden = snap === "full";
 
   return (
     <div
-      className={`fixed right-3 bottom-7 z-100 transition-opacity duration-200 ${
-        poiPanelOpen ? "pointer-events-none opacity-0" : "opacity-100"
-      }`}
+      className={`fixed top-3 right-3 z-100 flex flex-col gap-5 transition-opacity duration-200 ${fadeClass(hidden)}`}
+    >
+      <Button
+        variant="default"
+        size="icon"
+        aria-label="I'm Feeling Lucky"
+        className="size-16 rounded-full shadow-[0_4px_12px_rgba(0,0,0,0.4)]"
+        onClick={performRandomJump}
+      >
+        <IconDice className="size-8" />
+      </Button>
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button
+            variant="outline"
+            size="icon"
+            aria-label="Palette"
+            className={FLOATING_BUTTON_CLASS}
+          >
+            <IconPalette className="size-8" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent
+          className="w-84 border border-[#2a2a3a] p-4 shadow-[0_8px_32px_rgba(0,0,0,0.6)]"
+          align="end"
+          sideOffset={8}
+        >
+          <PaletteEditor />
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+};
+
+/**
+ * 右下: POIドロワーを開くボタン
+ *
+ * closed状態のときだけ表示。タップするとsmall状態に遷移する。
+ */
+const POIToggleFab = () => {
+  const snap = useStoreValue("poiDrawerSnap");
+  const hidden = snap !== "closed";
+
+  return (
+    <div
+      className={`fixed right-3 bottom-7 z-100 transition-opacity duration-200 ${fadeClass(hidden)}`}
     >
       <Button
         variant="outline"
         size="icon"
-        aria-label="Toggle POI panel"
+        aria-label="Open POI drawer"
         className={FLOATING_BUTTON_CLASS}
-        onClick={() => updateStoreWith("poiPanelOpen", (v) => !v)}
+        onClick={() => updateStore("poiDrawerSnap", "small")}
       >
         <IconLayoutSidebar className="size-8" />
       </Button>
@@ -138,7 +156,7 @@ const POIToggleFab = () => {
 /**
  * モバイル向けツールバー (丸型アイコンボタンを画面各所に配置)
  *
- * 左上: ハンバーガー / 右上: Lucky + Palette / 右下: POIトグル
+ * 左上: ハンバーガー / 右上: Lucky + Palette / 右下: POIドロワー展開
  */
 export const MobileToolbar = (props: MobileToolbarProps) => {
   return (

--- a/src/view/toolbar/mobile.tsx
+++ b/src/view/toolbar/mobile.tsx
@@ -76,7 +76,7 @@ const HamburgerMenu = ({ openShare, openSS, openJump, openSettings }: MobileTool
 
 /** 右上: I'm Feeling Lucky + Palette (縦並び、上からLucky→Palette) */
 const TopRightActions = () => (
-  <div className="fixed top-3 right-3 z-100 flex flex-col gap-3">
+  <div className="fixed top-3 right-3 z-100 flex flex-col gap-5">
     <Button
       variant="default"
       size="icon"

--- a/src/view/toolbar/mobile.tsx
+++ b/src/view/toolbar/mobile.tsx
@@ -76,7 +76,7 @@ const HamburgerMenu = ({ openShare, openSS, openJump, openSettings }: MobileTool
 
 /** 右上: I'm Feeling Lucky + Palette (縦並び、上からLucky→Palette) */
 const TopRightActions = () => (
-  <div className="fixed top-3 right-3 z-100 flex flex-col gap-2">
+  <div className="fixed top-3 right-3 z-100 flex flex-col gap-3">
     <Button
       variant="default"
       size="icon"

--- a/src/view/use-is-mobile.tsx
+++ b/src/view/use-is-mobile.tsx
@@ -1,0 +1,24 @@
+import { useEffect, useState } from "react";
+
+/** モバイル扱いとするビューポートの最大幅 (px) */
+export const MOBILE_MAX_WIDTH = 768;
+
+/**
+ * ビューポート幅がモバイル扱い (<= {@link MOBILE_MAX_WIDTH}px) かどうかを返すフック
+ *
+ * @returns モバイル扱いなら true
+ */
+export const useIsMobile = (): boolean => {
+  const [isMobile, setIsMobile] = useState(() => window.innerWidth <= MOBILE_MAX_WIDTH);
+
+  useEffect(() => {
+    const mql = window.matchMedia(`(max-width: ${MOBILE_MAX_WIDTH}px)`);
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+
+    setIsMobile(mql.matches);
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, []);
+
+  return isMobile;
+};

--- a/src/view/use-is-mobile.tsx
+++ b/src/view/use-is-mobile.tsx
@@ -4,6 +4,15 @@ import { useEffect, useState } from "react";
 export const MOBILE_MAX_WIDTH = 768;
 
 /**
+ * 現在のビューポートがモバイル幅かどうかを同期的に返す
+ *
+ * Reactコンテキスト外 (p5 draw ループ等) から使うための関数版。
+ * UI から使う場合は {@link useIsMobile} を使うこと。
+ */
+export const isMobileViewport = (): boolean =>
+  window.matchMedia(`(max-width: ${MOBILE_MAX_WIDTH}px)`).matches;
+
+/**
  * ビューポート幅がモバイル扱い (<= {@link MOBILE_MAX_WIDTH}px) かどうかを返すフック
  *
  * @returns モバイル扱いなら true

--- a/src/worker-pool/callbacks/iteration-worker.ts
+++ b/src/worker-pool/callbacks/iteration-worker.ts
@@ -39,6 +39,14 @@ export const onIterationWorkerResult: IterationResultCallback = (result, job) =>
   const iterationsResult = new Uint32Array(iterations);
   const iterBuffer = upsertIterationCache(rect, iterationsResult, resolution, isSuperSampled);
 
+  const maxIter = batchContext.mandelbrotParams.N;
+  let hitCount = 0;
+  for (let i = 0; i < iterationsResult.length; i++) {
+    if (iterationsResult[i] === maxIter) hitCount++;
+  }
+  batchContext.nHitCount += hitCount;
+  batchContext.totalPixelCount += iterationsResult.length;
+
   // jobを完了させる
   batchContext.progressMap.set(job.id, 1.0);
   addTraceEvent("worker", { type: "completed", workerId: getWorkerId(job) });

--- a/src/worker-pool/worker-pool.ts
+++ b/src/worker-pool/worker-pool.ts
@@ -65,6 +65,18 @@ export const clearBatchContext = () => {
 };
 
 /**
+ * 最新バッチの iteration=N 到達率 (0..1) を返す
+ *
+ * 描画完了済みの場合のみ値を返し、未完了/集計不能時は null
+ */
+export const getNHitRatio = (): number | null => {
+  const batchContext = getLatestBatchContext();
+  if (!batchContext || !batchContext.finishedAt) return null;
+  if (batchContext.totalPixelCount === 0) return null;
+  return batchContext.nHitCount / batchContext.totalPixelCount;
+};
+
+/**
  * Footerで表示するための進捗情報をbatchContextから取得する
  */
 export const getProgressData = (): string | ResultSpans => {
@@ -156,6 +168,8 @@ export function registerBatch(
     startedAt: performance.now(),
     refProgress: -1,
     spans: [],
+    nHitCount: 0,
+    totalPixelCount: 0,
   });
 
   tickWorkerPool();

--- a/src/worker-pool/worker-pool.ts
+++ b/src/worker-pool/worker-pool.ts
@@ -1,5 +1,4 @@
 import { addTraceEvent, removeBatchTrace, startBatchTrace } from "@/event-viewer/event";
-import { getStore } from "@/store/store";
 import type {
   BatchContext,
   CalcIterationJob,
@@ -7,10 +6,8 @@ import type {
   InitialOmittedBatchContextKeys,
   MandelbrotJob,
   MandelbrotRenderingUnit,
-  MandelbrotWorkerType,
   ResultSpans,
 } from "@/types";
-import { mandelbrotWorkerTypes } from "@/types";
 import { throttle } from "es-toolkit";
 import {
   calcNormalizedWorkerIndex,
@@ -94,16 +91,6 @@ export const getProgressData = (): string | ResultSpans => {
   const progress = progressList.reduce((a, b) => a + b, 0) / progressList.length;
 
   return `Generating... ${Math.floor(progress * 100)}%`;
-};
-
-export const cycleWorkerType = (): MandelbrotWorkerType => {
-  const currentMode = getStore("mode");
-
-  const currentIndex = mandelbrotWorkerTypes.findIndex((v) => v === currentMode);
-
-  const nextMode = mandelbrotWorkerTypes[(currentIndex + 1) % mandelbrotWorkerTypes.length];
-
-  return nextMode;
 };
 
 export function registerBatch(


### PR DESCRIPTION
## Summary

モバイル表示に一通り対応
PC向けのUIには影響を与えず、モバイル表示時のみレイアウトと操作系を差し替え

## なぜやったのか

度重なる高速化により、
Pixel 6aでもほぼすべての地点が1-4秒程度で描画できることに気付いてもうやるしかねえと思った

## モバイル向けUI

従来の横並びtoolbarは非表示にして、floating iconベースの配置に差し替え
初見ではとりあえずなんか目立ってるボタンを押したらなんかすごい模様が出てきたウワーとなってほしいので、I'm feeling luckyだけ目立たせといた

以下スクリーンショット

|||
|----|----|
|[![Image from Gyazo](https://i.gyazo.com/88f0c90fb144f664e9ad538fcb1f9c58.png)](https://gyazo.com/88f0c90fb144f664e9ad538fcb1f9c58)|[![Image from Gyazo](https://i.gyazo.com/70c385395673c79e560627b0f4fc6642.png)](https://gyazo.com/70c385395673c79e560627b0f4fc6642)|
|[![Image from Gyazo](https://i.gyazo.com/23c82e7af83eca2d651e1d224448d95b.png)](https://gyazo.com/23c82e7af83eca2d651e1d224448d95b)|[![Image from Gyazo](https://i.gyazo.com/ee3a2a7a42fda6c692bc4008af32b961.png)](https://gyazo.com/ee3a2a7a42fda6c692bc4008af32b961)|

<!-- ここにモバイル表示のスクリーンショットを貼る -->

## モバイル向けの操作

- スワイプ: 中心移動
- タップ: 画面中央で拡大
- ピンチ: 画面中央で拡大/縮小

PCの右クリックドラッグ相当の「場所を選んで拡大」はモバイルでは省略した。
手で狙った場所ピンチするのは無理ゲーだから
スワイプで中心を定めてタップかピンチでズームしていく、という操作になる

## normal/perturbaion mode自動切替

今までは「もう精度足りてないからmキー押してperturbation modeに切り替えてね」という警告を出していた
が、モバイルでは操作に困るのでもう勝手に切り替えるようにした
手動切替も廃止

正直ほとんどnormalとperturbationと速度差がなくなっている（開始地点でnormal: 30ms, perturbation: 70msくらい）
ので常にperturbation modeでもよい気もする
が、数十msだろうが早いに越したことはないので自動切り換えを選択

## Max iterationの簡易な調整方法を追加

正直←→で調整できることなんかぱっと分からんし、Instructionをまず真面目に見る人などいない
それにモバイルだとキー入力できないので調整の方法がない
なのでN=maxである地点の比率を見てNを増やすボタンを出すようにした

黒い部分が多かったら出てくる＝押すと直る、ということだけ1回分かればよいはず。
minibrotがあるといつまで経ってもN=max地点の比率は変わらないので、数回で出なくなるようにはしてある

|mobile|PC|
|----|----|
|[![Image from Gyazo](https://i.gyazo.com/a38ad567ddde8196fdb21abbb0fe24aa.png)](https://gyazo.com/a38ad567ddde8196fdb21abbb0fe24aa)|[![Image from Gyazo](https://i.gyazo.com/6f864b32930d68fb7aef3147018b5698.png)](https://gyazo.com/6f864b32930d68fb7aef3147018b5698)|

## Supersamplingの結果表示も変更

通常ビューに重ねる形だとモバイル側で通常画面と区別つきにくかったのでDialogに乗せた
ついでに保存ボタンもつけるようにした。モバイルだとcanvas長押しで画像保存できなかったので・・・
