### PR TITLE
プリセット名をつけてリスト上で表示できるようにした

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Figtree:wght@500;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Figtree:wght@500;600;700&family=Spectral:wght@700&display=swap"
       rel="stylesheet"
     />
   </head>

--- a/src/preset-poi/preset-poi.ts
+++ b/src/preset-poi/preset-poi.ts
@@ -14,6 +14,11 @@ const CANVAS_WIDTH_FOR_COMPARISON = 8192;
  */
 export interface PresetPOIRaw {
   id: string;
+  /**
+   * 表示用の名前（Title Case想定、例: "The Ember Eye"）
+   * 未定義時はUI側で `#${id}` にフォールバックする
+   */
+  name?: string;
   x: string;
   y: string;
   r: string;
@@ -21,6 +26,16 @@ export interface PresetPOIRaw {
   mode: MandelbrotWorkerType;
   palette?: string;
 }
+
+/**
+ * プリセットの表示用ラベルを返す
+ * nameがあればname、なければ `#${id}`（ゼロ埋めは外す）を返す
+ */
+export const getPresetDisplayLabel = (poi: PresetPOIRaw): string => {
+  if (poi.name) return poi.name;
+  const n = parseInt(poi.id, 10);
+  return Number.isNaN(n) ? `#${poi.id}` : `#${n}`;
+};
 
 /** 読み込み済みのプリセットPOIリスト */
 let presetPOIList: readonly PresetPOIRaw[] = [];

--- a/src/view/minimap/minimap-dialog.tsx
+++ b/src/view/minimap/minimap-dialog.tsx
@@ -4,6 +4,7 @@ import { clearIterationCache } from "@/iteration-buffer/iteration-buffer";
 import { setCurrentParams, setManualN } from "@/mandelbrot-state/mandelbrot-state";
 import {
   type PresetPOIRaw,
+  getPresetDisplayLabel,
   getPresetThumbnailUrl,
   isSamePOI,
   usePresetPOIList,
@@ -332,7 +333,7 @@ export const MinimapDialog = ({ open, onOpenChange }: MinimapDialogProps) => {
         y,
         source: "preset",
         id: poi.id,
-        label: `#${poi.id} N:${poi.N}`,
+        label: `${getPresetDisplayLabel(poi)} N:${poi.N}`,
         thumbnailUrl: getPresetThumbnailUrl(poi.id),
         jumpAction: () => jumpToPreset(poi),
       });

--- a/src/view/preset-list/preset-list-dialog.tsx
+++ b/src/view/preset-list/preset-list-dialog.tsx
@@ -4,6 +4,7 @@ import { clearIterationCache } from "@/iteration-buffer/iteration-buffer";
 import { setCurrentParams, setManualN } from "@/mandelbrot-state/mandelbrot-state";
 import {
   type PresetPOIRaw,
+  getPresetDisplayLabel,
   getPresetThumbnailUrl,
   initializePresetPOIList,
   isGCSMode,
@@ -196,7 +197,7 @@ export const PresetListDialog = ({ open, onOpenChange }: PresetListDialogProps) 
         <div
           className="grid auto-rows-min gap-2 overflow-y-auto pr-1"
           style={{
-            gridTemplateColumns: "repeat(auto-fill, minmax(160px, 1fr))",
+            gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))",
             maxHeight: "calc(80dvh - 160px)",
           }}
         >
@@ -247,6 +248,8 @@ const PresetCard = ({
   onDelete: () => void;
 }) => {
   const thumbnailUrl = getPresetThumbnailUrl(poi.id, revision);
+  const label = getPresetDisplayLabel(poi);
+  const r = new BigNumber(poi.r);
 
   return (
     <div className="group overflow-hidden rounded border border-[#2a2a3a] bg-[#1e1e2e] transition-colors hover:border-primary/50">
@@ -257,7 +260,7 @@ const PresetCard = ({
         <img
           crossOrigin="anonymous"
           src={thumbnailUrl}
-          alt={`Preset ${poi.id}`}
+          alt={`Preset ${label}`}
           className="h-full w-full object-cover"
           onError={(e) => {
             e.currentTarget.style.display = "none";
@@ -267,19 +270,22 @@ const PresetCard = ({
           Jump
         </div>
       </button>
-      <div className="flex items-center justify-between px-2 py-1 text-xs">
-        <span>
-          <span className="text-muted-foreground">#{poi.id}</span>{" "}
-          <span className="text-muted-foreground">N:</span>
-          {poi.N}
-        </span>
+      <div className="flex items-center justify-between gap-1 px-2 pt-0.5 pb-1">
+        <div className="min-w-0 flex-1">
+          <div className="truncate font-display text-base font-bold leading-tight" title={label}>
+            {label}
+          </div>
+          <div className="mt-1 text-xs text-muted-foreground">
+            N:{poi.N} r:{r.toPrecision(3)}
+          </div>
+        </div>
         {isDevMode() && (
           <button
             onClick={(e) => {
               e.stopPropagation();
               onDelete();
             }}
-            className="text-muted-foreground hover:text-destructive rounded p-0.5 transition-colors"
+            className="shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:text-destructive"
           >
             <IconTrash className="size-3.5" />
           </button>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -17,6 +17,9 @@ export default {
       },
     },
     extend: {
+      fontFamily: {
+        display: ['"Spectral"', "serif"],
+      },
       colors: {
         border: "var(--border)",
         input: "var(--input)",


### PR DESCRIPTION
## Summary
[![Image from Gyazo](https://i.gyazo.com/79e8db8856c686ee4d78bec14f3505a4.png)](https://gyazo.com/79e8db8856c686ee4d78bec14f3505a4)

えっ・・・かっこいい・・・
ということでプリセット名をつけられるようにした

プリセットリストではこんな感じになる
[![Image from Gyazo](https://i.gyazo.com/1252a41a17db5e246ccd3514b52ad23b.png)](https://gyazo.com/1252a41a17db5e246ccd3514b52ad23b)

フォントはClaudeに候補を挙げてもらいよさそうなのを選んだ。
主張が強いかもしれない
他言語のフォントの感覚さっぱり分からない

## 命名フロー
現状は手作業でChatGPTに放り込んでいるのでAPI叩いてサッとやれるフローを組んでも良いかもしれない
とはいえこれに名前は別につけなくていいかな・・・ってのもあるしなぁ

