### PR TITLE
compute shaderが全然並列処理できていなかったのを修正し、統合バッファ再利用するケースで200ms程度高速化

### DIFF
--- a/src/rendering/shader/compute.wgsl
+++ b/src/rendering/shader/compute.wgsl
@@ -9,18 +9,8 @@ struct Uniforms {
   width: f32,
   height: f32,
   iterationBufferCount: f32,
+  totalPixelCount: f32,
 }
-
-struct IterationInputMeta {
-  x: f32,
-  y: f32,
-  width: f32,
-  height: f32,
-  resolutionWidth: f32,
-  resolutionHeight: f32,
-  length: f32, // element length (not byte)
-  isSuperSampled: f32, // 0 or 1
-};
 
 @group(0) @binding(0) var<uniform> uniforms: Uniforms;
 @group(0) @binding(1) var<storage, read_write> iterations: array<u32>;
@@ -28,60 +18,106 @@ struct IterationInputMeta {
 @group(0) @binding(3) var<storage> iterInput: array<u32>;
 @group(0) @binding(4) var<storage> iterInputMeta: array<f32>;
 
+// metadata 1エントリあたりのf32数。webgpu-renderer.ts の META_STRIDE と一致させること
+const META_STRIDE: u32 = 14u;
+
+const FIELD_RECT_X: u32 = 0u;
+const FIELD_RECT_Y: u32 = 1u;
+const FIELD_RECT_WIDTH: u32 = 2u;
+const FIELD_RECT_HEIGHT: u32 = 3u;
+const FIELD_RESOLUTION_WIDTH: u32 = 4u;
+const FIELD_RESOLUTION_HEIGHT: u32 = 5u;
+const FIELD_BUFFER_LENGTH: u32 = 6u;
+// const FIELD_IS_SUPER_SAMPLED: u32 = 7u;
+const FIELD_DATA_START: u32 = 8u;
+const FIELD_PIXEL_START: u32 = 9u;
+const FIELD_CLIP_X: u32 = 10u;
+const FIELD_CLIP_Y: u32 = 11u;
+const FIELD_CLIP_WIDTH: u32 = 12u;
+
+const WORKGROUP_SIZE: u32 = 64u;
+
 fn isValidIdx(idx: i32, length: i32) -> bool {
   return idx >= 0 && idx < length;
 }
 
+fn readMeta(entry: u32, field: u32) -> f32 {
+  return iterInputMeta[entry * META_STRIDE + field];
+}
+
+/**
+ * 宛先ピクセルの通し番号 p が属するmetadataエントリを二分探索する
+ *
+ * pixelStart は各エントリのクリップ後ピクセル数の前置和なので、
+ * pixelStart[entry] <= p を満たす最大のentryが答えになる。
+ * クリップ後の面積が0のエントリは pixelStart が次のエントリと同値になるため、
+ * 「最大のentry」を選ぶことで自然にスキップされる (= clipWidthが0のエントリは選ばれない)。
+ */
+fn findEntry(p: u32, entryCount: u32) -> u32 {
+  var lo = 0u;
+  var hi = entryCount - 1u;
+
+  while (lo < hi) {
+    let mid = (lo + hi + 1u) / 2u;
+    if (u32(readMeta(mid, FIELD_PIXEL_START)) <= p) {
+      lo = mid;
+    } else {
+      hi = mid - 1u;
+    }
+  }
+
+  return lo;
+}
+
 @compute @workgroup_size(64)
-fn computeMain(@builtin(global_invocation_id) global_id: vec3u) {
-  let thread_id = global_id.x;
-  
-  let thread_count = u32(uniforms.iterationBufferCount);
-  if (thread_id >= thread_count) {
+fn computeMain(
+  @builtin(global_invocation_id) global_id: vec3u,
+  @builtin(num_workgroups) num_workgroups: vec3u,
+) {
+  let entryCount = u32(uniforms.iterationBufferCount);
+  if (entryCount == 0u) {
     return;
   }
-  
-  let meta_offset = thread_id * 8;
-  let rect_x = i32(iterInputMeta[meta_offset]);
-  let rect_y = i32(iterInputMeta[meta_offset + 1]);
-  let rect_width = i32(iterInputMeta[meta_offset + 2]);
-  let rect_height = i32(iterInputMeta[meta_offset + 3]);
-  let resolution_width = i32(iterInputMeta[meta_offset + 4]);
-  let resolution_height = i32(iterInputMeta[meta_offset + 5]);
-  let buffer_length = i32(iterInputMeta[meta_offset + 6]);
-  let is_super_sampled = i32(iterInputMeta[meta_offset + 7]);
-  
-  var data_start = 0;
-  for (var i = 0; i < i32(thread_id); i++) {
-    let prev_length = i32(iterInputMeta[i * 8 + 6]);
-    data_start += prev_length;
-  }
-  
+
+  let total = u32(uniforms.totalPixelCount);
+  // dispatch数はworkgroup数の上限で頭打ちにしているので、足りない分はgrid-strideで回す
+  let threadStride = num_workgroups.x * WORKGROUP_SIZE;
+
   let canvas_width = i32(uniforms.canvasWidth);
   let canvas_height = i32(uniforms.canvasHeight);
 
-  let start_x = clamp(rect_x, 0, canvas_width);
-  let start_y = clamp(rect_y, 0, canvas_height);
-  let end_x = clamp(rect_x + rect_width, 0, canvas_width);
-  let end_y = clamp(rect_y + rect_height, 0, canvas_height);
-  
-  for (var world_y = start_y; world_y < end_y; world_y++) {
-    for (var world_x = start_x; world_x < end_x; world_x++) {
-      let local_x = world_x - rect_x;
-      let local_y = world_y - rect_y;
-      
-      let ratio_x = f32(resolution_width) / f32(rect_width);
-      let ratio_y = f32(resolution_height) / f32(rect_height);
-      
-      let scaled_x = i32(f32(local_x) * ratio_x);
-      let scaled_y = i32(f32(local_y) * ratio_y);
-      
-      let idx = scaled_x + scaled_y * resolution_width;
-      let world_idx = world_y * canvas_width + world_x;
-      
-      if (idx < buffer_length && isValidIdx(world_idx, i32(uniforms.canvasWidth * uniforms.canvasHeight))) {
-        iterations[world_idx] = iterInput[data_start + idx];
-      }
+  for (var p = global_id.x; p < total; p += threadStride) {
+    let entry = findEntry(p, entryCount);
+
+    let clip_x = i32(readMeta(entry, FIELD_CLIP_X));
+    let clip_y = i32(readMeta(entry, FIELD_CLIP_Y));
+    let clip_width = i32(readMeta(entry, FIELD_CLIP_WIDTH));
+
+    // エントリ内のローカル通し番号から宛先ピクセル座標を復元する
+    let localIndex = i32(p - u32(readMeta(entry, FIELD_PIXEL_START)));
+    let world_x = clip_x + localIndex % clip_width;
+    let world_y = clip_y + localIndex / clip_width;
+
+    let rect_x = i32(readMeta(entry, FIELD_RECT_X));
+    let rect_y = i32(readMeta(entry, FIELD_RECT_Y));
+    let rect_width = i32(readMeta(entry, FIELD_RECT_WIDTH));
+    let rect_height = i32(readMeta(entry, FIELD_RECT_HEIGHT));
+    let resolution_width = i32(readMeta(entry, FIELD_RESOLUTION_WIDTH));
+    let resolution_height = i32(readMeta(entry, FIELD_RESOLUTION_HEIGHT));
+    let buffer_length = i32(readMeta(entry, FIELD_BUFFER_LENGTH));
+    let data_start = i32(readMeta(entry, FIELD_DATA_START));
+
+    let ratio_x = f32(resolution_width) / f32(rect_width);
+    let ratio_y = f32(resolution_height) / f32(rect_height);
+
+    let scaled_x = i32(f32(world_x - rect_x) * ratio_x);
+    let scaled_y = i32(f32(world_y - rect_y) * ratio_y);
+
+    let idx = scaled_x + scaled_y * resolution_width;
+    let world_idx = world_y * canvas_width + world_x;
+
+    if (idx < buffer_length && isValidIdx(world_idx, canvas_width * canvas_height)) {
+      iterations[world_idx] = iterInput[data_start + idx];
     }
   }
 }

--- a/src/rendering/shader/shader.wgsl
+++ b/src/rendering/shader/shader.wgsl
@@ -9,6 +9,7 @@ struct Uniforms {
   width: f32,
   height: f32,
   iterationBufferCount: f32,
+  totalPixelCount: f32,
 }
 
 @group(0) @binding(0) var<uniform> uniforms: Uniforms;

--- a/src/rendering/webgpu-renderer.ts
+++ b/src/rendering/webgpu-renderer.ts
@@ -58,9 +58,27 @@ const UniformSchema = d.struct({
   width: d.f32,
   height: d.f32,
   iterationBufferCount: d.f32,
+  totalPixelCount: d.f32,
 });
 
 const PaletteSchema = d.arrayOf(d.vec4f, 8192); // FIXME: paletteの最大サイズ分固定で確保している（手抜き）
+
+/** metadataに格納できるiteration bufferの最大数 */
+const META_ENTRY_MAX = 1024;
+
+/**
+ * metadata 1エントリあたりのf32数
+ *
+ * compute.wgsl の META_STRIDE およびFIELD_*の並びと一致させること。
+ * shader側はこのbufferを array<f32> として読むため、structはtightly packedである必要がある。
+ */
+const META_STRIDE = 14;
+
+/** compute shaderのworkgroupサイズ。compute.wgsl の @workgroup_size と一致させること */
+const COMPUTE_WORKGROUP_SIZE = 64;
+
+/** dispatchWorkgroupsの1次元あたりの上限。超える分はshader側のgrid-strideループで処理する */
+const MAX_COMPUTE_WORKGROUPS = 65535;
 
 const IterationInputMetadataSchema = d.arrayOf(
   d.struct({
@@ -72,9 +90,18 @@ const IterationInputMetadataSchema = d.arrayOf(
     resolutionHeight: d.f32,
     bufferLength: d.f32,
     isSuperSampled: d.f32,
+    dataStart: d.f32,
+    pixelStart: d.f32,
+    clipX: d.f32,
+    clipY: d.f32,
+    clipWidth: d.f32,
+    clipHeight: d.f32,
   }),
-  1024,
+  META_ENTRY_MAX,
 );
+
+/** metadata書き込み用の使い回しバッファ。毎フレームのallocを避けるために持つ */
+const metadataScratch = new Float32Array(META_ENTRY_MAX * META_STRIDE);
 
 export const getCanvasSize: Renderer["getCanvasSize"] = () => ({
   width,
@@ -116,6 +143,100 @@ export const initRenderer: Renderer["initRenderer"] = async (w, h) => {
   }
 };
 
+const clampInt = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+/**
+ * iteration bufferの内容をGPUのinput bufferとmetadata bufferに書き込む
+ *
+ * 各itemについてcanvasでクリップした宛先ピクセル数を求め、その前置和(pixelStart)をmetadataに載せる。
+ * compute shaderはこの前置和を二分探索することで、1スレッド1宛先ピクセルで処理できる。
+ *
+ * 戻り値は全itemの宛先ピクセル数の合計 (= compute shaderに必要なthread数)
+ */
+const writeIterationInputs = (
+  items: IterationBuffer[],
+  canvasWidth: number,
+  canvasHeight: number,
+): number => {
+  let bufferByteOffset = 0;
+  let dataStart = 0;
+  let pixelStart = 0;
+
+  for (let idx = 0; idx < items.length; idx++) {
+    const { rect, buffer, resolution, isSuperSampled } = items[idx];
+
+    // scaleRectAroundPointがwidth/heightを丸めずに返すためrectは小数になりうる。
+    // 従来shader側の i32() で切り捨てていたので、同じ値をCPU側で作る
+    const rectX = Math.trunc(rect.x);
+    const rectY = Math.trunc(rect.y);
+    const rectWidth = Math.trunc(rect.width);
+    const rectHeight = Math.trunc(rect.height);
+
+    const clipX = clampInt(rectX, 0, canvasWidth);
+    const clipY = clampInt(rectY, 0, canvasHeight);
+    const clipWidth = clampInt(rectX + rectWidth, 0, canvasWidth) - clipX;
+    const clipHeight = clampInt(rectY + rectHeight, 0, canvasHeight) - clipY;
+
+    const offset = idx * META_STRIDE;
+    metadataScratch[offset] = rectX;
+    metadataScratch[offset + 1] = rectY;
+    metadataScratch[offset + 2] = rectWidth;
+    metadataScratch[offset + 3] = rectHeight;
+    metadataScratch[offset + 4] = resolution.width;
+    metadataScratch[offset + 5] = resolution.height;
+    metadataScratch[offset + 6] = buffer.length;
+    metadataScratch[offset + 7] = isSuperSampled ? 1 : 0;
+    metadataScratch[offset + 8] = dataStart;
+    metadataScratch[offset + 9] = pixelStart;
+    metadataScratch[offset + 10] = clipX;
+    metadataScratch[offset + 11] = clipY;
+    metadataScratch[offset + 12] = clipWidth;
+    metadataScratch[offset + 13] = clipHeight;
+
+    device.queue.writeBuffer(
+      root.unwrap(iterationInputBuffer),
+      bufferByteOffset,
+      buffer,
+      0,
+      buffer.length,
+    );
+
+    bufferByteOffset += buffer.byteLength;
+    dataStart += buffer.length;
+    pixelStart += clipWidth * clipHeight;
+  }
+
+  device.queue.writeBuffer(
+    root.unwrap(iterationInputMetadataBuffer),
+    0,
+    metadataScratch,
+    0,
+    items.length * META_STRIDE,
+  );
+
+  return pixelStart;
+};
+
+/**
+ * iterationInputBufferからiterations[]へコピーするcompute passを積む
+ *
+ * 1スレッドが1宛先ピクセルを担当するので、dispatch数は宛先ピクセル数から決まる
+ */
+const encodeCopyComputePass = (encoder: GPUCommandEncoder, totalPixelCount: number) => {
+  if (totalPixelCount === 0) return;
+
+  const workgroupCount = Math.min(
+    Math.ceil(totalPixelCount / COMPUTE_WORKGROUP_SIZE),
+    MAX_COMPUTE_WORKGROUPS,
+  );
+
+  const computePass = encoder.beginComputePass();
+  computePass.setPipeline(computePipeline);
+  computePass.setBindGroup(0, root.unwrap(bindGroup));
+  computePass.dispatchWorkgroups(workgroupCount);
+  computePass.end();
+};
+
 export const renderToCanvas: Renderer["renderToCanvas"] = (x, y, width, height) => {
   if (isFlushing) return;
   if (!gpuInitialized) {
@@ -128,7 +249,6 @@ export const renderToCanvas: Renderer["renderToCanvas"] = (x, y, width, height) 
   const palette = getCurrentPalette();
 
   // queueに積まれたiteration bufferをGPUBufferに書き込む
-  let bufferByteOffset = 0;
   const maxBufferSize = iterationInputBuffer.buffer.size;
 
   // 解像度（rect.width/resolution.width）が荒い順にソートする
@@ -152,6 +272,9 @@ export const renderToCanvas: Renderer["renderToCanvas"] = (x, y, width, height) 
     const nextSize = iterBuffer.buffer.byteLength;
     const resolution = iterBuffer.rect.width / iterBuffer.resolution.width;
 
+    // metadataに載る数を超えないようにする
+    if (processableCount >= META_ENTRY_MAX) break;
+
     // バッファサイズオーバーチェック
     if (tempBufferByteOffset + nextSize > maxBufferSize) {
       const remaining = iterationBufferQueue.length - processableCount;
@@ -171,6 +294,25 @@ export const renderToCanvas: Renderer["renderToCanvas"] = (x, y, width, height) 
     processableCount++;
   }
 
+  let totalPixelCount = 0;
+
+  if (0 < processableCount) {
+    const remaining = iterationBufferQueue.length - processableCount;
+    const resolution =
+      iterationBufferQueue[0].rect.width / iterationBufferQueue[0].resolution.width;
+
+    const items = iterationBufferQueue.splice(0, processableCount);
+    totalPixelCount = writeIterationInputs(items, canvasWidth, canvasHeight);
+
+    addTraceEvent("renderer", {
+      type: "iterationBufferProcessing",
+      resolution,
+      count: processableCount,
+      remaining,
+      rects: items.map((item) => item.rect),
+    });
+  }
+
   // write uniform buffer
   uniformBuffer.write({
     maxIterations: params.N,
@@ -183,67 +325,15 @@ export const renderToCanvas: Renderer["renderToCanvas"] = (x, y, width, height) 
     width: width ?? canvasWidth,
     height: height ?? canvasHeight,
     iterationBufferCount: processableCount,
+    totalPixelCount,
   });
-
-  if (0 < processableCount) {
-    const remaining = iterationBufferQueue.length - processableCount;
-
-    const resolution =
-      iterationBufferQueue[0].rect.width / iterationBufferQueue[0].resolution.width;
-    const rects: Rect[] = [];
-
-    // 処理可能な数だけ処理
-    for (let idx = 0; idx < processableCount; idx++) {
-      const iteration = iterationBufferQueue.shift()!;
-      const { rect, buffer, resolution, isSuperSampled } = iteration;
-      rects.push(rect);
-
-      iterationInputMetadataBuffer.writePartial([
-        {
-          idx,
-          value: {
-            rectX: rect.x,
-            rectY: rect.y,
-            rectWidth: rect.width,
-            rectHeight: rect.height,
-            resolutionWidth: resolution.width,
-            resolutionHeight: resolution.height,
-            bufferLength: buffer.length,
-            isSuperSampled: isSuperSampled ? 1 : 0,
-          },
-        },
-      ]);
-
-      device.queue.writeBuffer(
-        root.unwrap(iterationInputBuffer),
-        bufferByteOffset,
-        buffer,
-        0,
-        buffer.length,
-      );
-
-      bufferByteOffset += buffer.byteLength;
-    }
-
-    addTraceEvent("renderer", {
-      type: "iterationBufferProcessing",
-      resolution,
-      count: processableCount,
-      remaining,
-      rects,
-    });
-  }
 
   // 毎フレームのunifiedIterationBufferの転送は不要
   // GPUのcompute shaderによってiterationInputBufferからiterationBufferに直接書き込まれる
 
   const encoder = device.createCommandEncoder();
 
-  const computePass = encoder.beginComputePass();
-  computePass.setPipeline(computePipeline);
-  computePass.setBindGroup(0, root.unwrap(bindGroup));
-  computePass.dispatchWorkgroups(64);
-  computePass.end();
+  encodeCopyComputePass(encoder, totalPixelCount);
 
   const renderPass = encoder.beginRenderPass({
     colorAttachments: [
@@ -274,6 +364,7 @@ export const flushIterationBufferQueue = async (): Promise<void> => {
   if (!gpuInitialized || iterationBufferQueue.length === 0) return;
 
   isFlushing = true;
+
   try {
     // iterationBufferを0クリアして古い位置のデータを除去
     {
@@ -292,6 +383,8 @@ export const flushIterationBufferQueue = async (): Promise<void> => {
       let processableCount = 0;
 
       for (let i = 0; i < iterationBufferQueue.length; i++) {
+        if (processableCount >= META_ENTRY_MAX) break;
+
         const nextSize = iterationBufferQueue[i].buffer.byteLength;
         if (tempByteOffset + nextSize > maxBufferSize) break;
         tempByteOffset += nextSize;
@@ -299,6 +392,9 @@ export const flushIterationBufferQueue = async (): Promise<void> => {
       }
 
       if (processableCount === 0) break;
+
+      const items = iterationBufferQueue.splice(0, processableCount);
+      const totalPixelCount = writeIterationInputs(items, canvasWidth, canvasHeight);
 
       uniformBuffer.write({
         maxIterations: params.N,
@@ -311,46 +407,11 @@ export const flushIterationBufferQueue = async (): Promise<void> => {
         width: canvasWidth,
         height: canvasHeight,
         iterationBufferCount: processableCount,
+        totalPixelCount,
       });
 
-      let bufferByteOffset = 0;
-      for (let idx = 0; idx < processableCount; idx++) {
-        const iteration = iterationBufferQueue.shift()!;
-        const { rect, buffer, resolution, isSuperSampled } = iteration;
-
-        iterationInputMetadataBuffer.writePartial([
-          {
-            idx,
-            value: {
-              rectX: rect.x,
-              rectY: rect.y,
-              rectWidth: rect.width,
-              rectHeight: rect.height,
-              resolutionWidth: resolution.width,
-              resolutionHeight: resolution.height,
-              bufferLength: buffer.length,
-              isSuperSampled: isSuperSampled ? 1 : 0,
-            },
-          },
-        ]);
-
-        device.queue.writeBuffer(
-          root.unwrap(iterationInputBuffer),
-          bufferByteOffset,
-          buffer,
-          0,
-          buffer.length,
-        );
-
-        bufferByteOffset += buffer.byteLength;
-      }
-
       const encoder = device.createCommandEncoder();
-      const computePass = encoder.beginComputePass();
-      computePass.setPipeline(computePipeline);
-      computePass.setBindGroup(0, root.unwrap(bindGroup));
-      computePass.dispatchWorkgroups(64);
-      computePass.end();
+      encodeCopyComputePass(encoder, totalPixelCount);
       device.queue.submit([encoder.finish()]);
 
       await device.queue.onSubmittedWorkDone();


### PR DESCRIPTION
# Summary

WebGPUのcompute shaderが実質1スレッドで動いていたので並列化した
1スレッドが1rect担当してたので、バッファ統合後は1スレッドしか働いてなかった...

## Benchmark

| POI | total before | total after | Δ |
|---|---:|---:|---:|
| Heavy N + heavy iter (N=408k) | 915.6ms | 869.8ms | −45.8ms |
| Heavy N, light iter (N=444k) | 479.0ms | 476.9ms | −2.1ms |
| Near-limit r, light N (N=39k) | 98.3ms | 96.9ms | −1.4ms |
| Average (N=94k) | 203.8ms | 200.3ms | −3.5ms |
| Famous spot (N=35k) | 169.5ms | 168.2ms | −1.3ms |
| Spiral, iter-heavy (N=30k) | 1213.2ms | 1210.7ms | −2.5ms |
| Spiral, iter-heavy (N=20k) | 235.6ms | 239.2ms | +3.6ms |

ベンチの数字が伸びないのは、ベンチが本命のケース（consolidate後の1枚をflushする経路）をほとんど踏まないから
