### PR TITLE
描画にかかった時間の計測を強化

### DIFF
--- a/src/benchmark/benchmark-runner.ts
+++ b/src/benchmark/benchmark-runner.ts
@@ -46,9 +46,6 @@ export type BenchmarkProgress = {
   phase: "warmup" | "sample" | "done";
 };
 
-/** presented待ちの上限。これを超えたらpresentedは計測不能(0)として扱う */
-const PRESENTED_TIMEOUT_MS = 2000;
-
 export type BenchmarkAllProgress = {
   poiIndex: number;
   poiCount: number;
@@ -62,18 +59,18 @@ export type BenchmarkAllProgress = {
  * refOrbit: spans[name="reference_orbit"].elapsed
  * iter: spans[name="iteration_*"].elapsedのmax (bottleneck worker)
  * iterMean: 同じspansのmean
- * presented: 計算開始から描画が画面に反映されるまで。取得できなかった場合は0
+ * presented: 計算開始から描画が画面に反映されるまで
  */
 const extractSample = (
   iteration: number,
   t0: number,
   t1: number,
-  presentedAt: number | null,
+  presentedAt: number,
   batchId: string,
 ): BenchmarkSample => {
   const batchCtx = getBatchContext(batchId);
   const total = t1 - t0;
-  const presented = presentedAt != null ? presentedAt - t0 : 0;
+  const presented = presentedAt - t0;
 
   if (batchCtx == null) {
     return { iteration, total, presented, refOrbit: 0, iter: 0, iterMean: 0 };
@@ -137,20 +134,13 @@ export const runBenchmark = async (
       const t0 = performance.now();
 
       let t1 = 0;
-      const presentedAt = await new Promise<number | null>((resolve) => {
-        let timeoutId: ReturnType<typeof setTimeout> | undefined;
-
+      const presentedAt = await new Promise<number>((resolve) => {
         void startCalculation(
           () => {
             t1 = performance.now();
-            // 画面が更新されない状況 (タブが非アクティブでrAFが止まる等) でも止まらないようにする
-            timeoutId = setTimeout(() => resolve(null), PRESENTED_TIMEOUT_MS);
           },
           () => {},
-          () => {
-            clearTimeout(timeoutId);
-            resolve(performance.now());
-          },
+          () => resolve(performance.now()),
         );
       });
 

--- a/src/benchmark/benchmark-runner.ts
+++ b/src/benchmark/benchmark-runner.ts
@@ -16,6 +16,7 @@ import { computeStats, type Stats } from "./benchmark-stats";
 export type BenchmarkSample = {
   iteration: number;
   total: number;
+  presented: number;
   refOrbit: number;
   iter: number;
   iterMean: number;
@@ -23,6 +24,7 @@ export type BenchmarkSample = {
 
 const METRIC_KEYS = [
   "total",
+  "presented",
   "refOrbit",
   "iter",
   "iterMean",
@@ -44,6 +46,9 @@ export type BenchmarkProgress = {
   phase: "warmup" | "sample" | "done";
 };
 
+/** presented待ちの上限。これを超えたらpresentedは計測不能(0)として扱う */
+const PRESENTED_TIMEOUT_MS = 2000;
+
 export type BenchmarkAllProgress = {
   poiIndex: number;
   poiCount: number;
@@ -57,18 +62,21 @@ export type BenchmarkAllProgress = {
  * refOrbit: spans[name="reference_orbit"].elapsed
  * iter: spans[name="iteration_*"].elapsedのmax (bottleneck worker)
  * iterMean: 同じspansのmean
+ * presented: 計算開始から描画が画面に反映されるまで。取得できなかった場合は0
  */
 const extractSample = (
   iteration: number,
   t0: number,
   t1: number,
+  presentedAt: number | null,
   batchId: string,
 ): BenchmarkSample => {
   const batchCtx = getBatchContext(batchId);
   const total = t1 - t0;
+  const presented = presentedAt != null ? presentedAt - t0 : 0;
 
   if (batchCtx == null) {
-    return { iteration, total, refOrbit: 0, iter: 0, iterMean: 0 };
+    return { iteration, total, presented, refOrbit: 0, iter: 0, iterMean: 0 };
   }
 
   const refOrbit = batchCtx.spans.find((s) => s.name === "reference_orbit")?.elapsed ?? 0;
@@ -80,7 +88,7 @@ const extractSample = (
   const iterMean =
     iterElapsed.length > 0 ? iterElapsed.reduce((a, b) => a + b, 0) / iterElapsed.length : 0;
 
-  return { iteration, total, refOrbit, iter, iterMean };
+  return { iteration, total, presented, refOrbit, iter, iterMean };
 };
 
 /**
@@ -128,18 +136,28 @@ export const runBenchmark = async (
 
       const t0 = performance.now();
 
-      await new Promise<void>((resolve) => {
+      let t1 = 0;
+      const presentedAt = await new Promise<number | null>((resolve) => {
+        let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
         void startCalculation(
-          () => resolve(),
+          () => {
+            t1 = performance.now();
+            // 画面が更新されない状況 (タブが非アクティブでrAFが止まる等) でも止まらないようにする
+            timeoutId = setTimeout(() => resolve(null), PRESENTED_TIMEOUT_MS);
+          },
           () => {},
+          () => {
+            clearTimeout(timeoutId);
+            resolve(performance.now());
+          },
         );
       });
 
-      const t1 = performance.now();
       const batchId = getPrevBatchId();
 
       if (!isWarmup) {
-        samples.push(extractSample(i - opts.warmup, t0, t1, batchId));
+        samples.push(extractSample(i - opts.warmup, t0, t1, presentedAt, batchId));
       }
     }
   } finally {
@@ -203,11 +221,11 @@ export const formatResultAsMarkdown = (result: BenchmarkResult): string => {
   lines.push("");
 
   lines.push("### Samples (ms)");
-  lines.push("| # | total | refOrbit | iter | iterMean |");
-  lines.push("|---|------:|---------:|-----:|---------:|");
+  lines.push("| # | total | presented | refOrbit | iter | iterMean |");
+  lines.push("|---|------:|----------:|---------:|-----:|---------:|");
   for (const s of samples) {
     lines.push(
-      `| ${s.iteration + 1} | ${fmt(s.total)} | ${fmt(s.refOrbit)} | ${fmt(s.iter)} | ${fmt(s.iterMean)} |`,
+      `| ${s.iteration + 1} | ${fmt(s.total)} | ${fmt(s.presented)} | ${fmt(s.refOrbit)} | ${fmt(s.iter)} | ${fmt(s.iterMean)} |`,
     );
   }
   lines.push("");
@@ -234,6 +252,7 @@ export const formatSummaryAsMarkdown = (results: BenchmarkResult[]): string => {
   for (const r of results) {
     lines.push(`${r.poi.label}:`);
     lines.push(`- total: ${formatMetric(r.stats.total)}`);
+    lines.push(`- presented: ${formatMetric(r.stats.presented)}`);
     lines.push(`- ref: ${formatMetric(r.stats.refOrbit)}`);
     lines.push(`- iter: ${formatMetric(r.stats.iter)}`);
   }

--- a/src/event-viewer/event.ts
+++ b/src/event-viewer/event.ts
@@ -32,6 +32,13 @@ export type RendererEvent = EventBase & {/* common type */} & (
         type: "bufferSizeExceeded";
         remaining: number;
       }
+    | {
+        type: "flushed";
+        elapsed: number;
+      }
+    | {
+        type: "presented";
+      }
   );
 
 // Job Event ==================================================

--- a/src/mandelbrot.ts
+++ b/src/mandelbrot.ts
@@ -1,4 +1,5 @@
 import { markNeedsRerender } from "./camera/palette";
+import { addTraceEvent } from "./event-viewer/event";
 import {
   removeUnusedIterationCache,
   scaleIterationCacheAroundPoint,
@@ -34,6 +35,7 @@ import { cancelBatch, registerBatch, startBatch } from "./worker-pool/worker-poo
 export const startCalculation = async (
   onComplete: (elapsed: number) => void,
   onTranslated: () => void,
+  onPresented?: () => void,
 ) => {
   const { isSuperSampling } = getCurrentParams();
   // supersamplingは一回きりなのでここで変更はなかったことにする
@@ -65,6 +67,8 @@ export const startCalculation = async (
     ? { width: supersamplingWidth, height: supersamplingHeight }
     : getCanvasSize();
 
+  const flushStartedAt = performance.now();
+
   if (!isSuperSampling) {
     const rect = translateIterationCache(canvasWidth, canvasHeight, getOffsetParams());
 
@@ -79,6 +83,9 @@ export const startCalculation = async (
     // ドラッグ中に描画をずらしていたのを戻す
     onTranslated();
   }
+
+  const flushElapsed = performance.now() - flushStartedAt;
+  addTraceEvent("renderer", { type: "flushed", elapsed: Math.floor(flushElapsed) });
 
   // workerに分配するために描画範囲を分割
   const divideRectCount = getWorkerCount("calc-iteration") * (isSuperSampling ? 4 : 1);
@@ -102,10 +109,12 @@ export const startCalculation = async (
   registerBatch(currentBatchId, units, {
     onComplete,
     onChangeProgress: () => {},
+    onPresented,
     mandelbrotParams: currentParams,
     pixelWidth: canvasWidth,
     pixelHeight: canvasHeight,
     terminator,
+    flushElapsed,
   });
 };
 

--- a/src/p5-adapter/p5-adapter.ts
+++ b/src/p5-adapter/p5-adapter.ts
@@ -46,11 +46,17 @@ import {
   drawUIIterationAtCursor,
   drawUIScaleRate,
 } from "../rendering/p5-renderer";
-import { getCanvasSize, initRenderer, renderToCanvas, resizeCanvas } from "../rendering/renderer";
+import {
+  getCanvasSize,
+  initRenderer,
+  renderToCanvas,
+  resizeCanvas,
+  setOnIterationBufferDrained,
+} from "../rendering/renderer";
 import { getStore, updateStore } from "../store/store";
 import type { MandelbrotParams } from "../types";
 import { extractMandelbrotParams } from "../utils/mandelbrot-url-params";
-import { getNHitRatio, getProgressData } from "../worker-pool/worker-pool";
+import { getNHitRatio, getProgressData, markPresented } from "../worker-pool/worker-pool";
 import BigNumber from "bignumber.js";
 import type p5 from "p5";
 import { isMobileViewport } from "../view/use-is-mobile";
@@ -484,6 +490,11 @@ export const p5Setup = async (p: p5) => {
   UNSAFE_p5Instance = p;
 
   const { width, height } = initializeCanvasSize();
+
+  // 描画結果が画面に出た時刻を記録する。rendererが描き切ったフレームの次のフレーム開始時点を「見えた時刻」とする
+  setOnIterationBufferDrained(() => {
+    requestAnimationFrame(() => markPresented(performance.now()));
+  });
 
   // p5 renderer
   await initRenderer(width, height, p);

--- a/src/rendering/p5-renderer.ts
+++ b/src/rendering/p5-renderer.ts
@@ -33,6 +33,16 @@ let bufferRect: Rect;
 
 let unifiedIterationBuffer: Uint32Array<ArrayBuffer>;
 
+/**
+ * unifiedIterationBufferに書き込んだ内容がまだmainBufferに反映されていないかどうか
+ *
+ * needsRerenderはpalette変更でも立つため、iteration bufferの反映待ち判定には使えない
+ */
+let pendingIterationDraw = false;
+
+/** mainBufferへの反映が済んだときに呼ぶcallback */
+let onIterationBufferDrained: (() => void) | null = null;
+
 export const getCanvasSize: Renderer["getCanvasSize"] = () => ({
   width,
   height,
@@ -63,11 +73,20 @@ export const renderToCanvas: Renderer["renderToCanvas"] = (x, y, width, height) 
   if (needsRerender()) {
     markAsRendered();
     renderToMainBuffer();
+
+    if (pendingIterationDraw) {
+      pendingIterationDraw = false;
+      onIterationBufferDrained?.();
+    }
   }
 
   const buffer = mainBuffer;
   p5Instance.clear();
   p5Instance.image(buffer, x, y, width, height);
+};
+
+export const setOnIterationBufferDrained: Renderer["setOnIterationBufferDrained"] = (callback) => {
+  onIterationBufferDrained = callback;
 };
 
 export const addIterationBuffer: Renderer["addIterationBuffer"] = (
@@ -83,6 +102,7 @@ export const addIterationBuffer: Renderer["addIterationBuffer"] = (
       unifiedIterationBuffer,
       iterBuffer ?? getIterationCache(),
     );
+    pendingIterationDraw = true;
     markNeedsRerender();
   }
 };

--- a/src/rendering/p5-renderer.ts
+++ b/src/rendering/p5-renderer.ts
@@ -1,3 +1,4 @@
+import type p5 from "p5";
 import {
   getCurrentPalette,
   markAsRendered,
@@ -5,16 +6,15 @@ import {
   needsRerender,
 } from "../camera/palette";
 import type { Palette } from "../color";
-import { getIterationCache } from "../iteration-buffer/iteration-buffer";
-import { applyMaxCanvasSize, rescaleIterationCacheForResize } from "./common";
-import { getCurrentParams } from "../mandelbrot-state/mandelbrot-state";
-import { clamp } from "../math/util";
-import { isMobileViewport } from "../view/use-is-mobile";
-import type p5 from "p5";
 import type { InterestingPoint } from "../interesting-points/find-interesting-points";
+import { getIterationCache } from "../iteration-buffer/iteration-buffer";
+import { getCurrentParams } from "../mandelbrot-state/mandelbrot-state";
 import type { Rect } from "../math/rect";
+import { clamp } from "../math/util";
 import type { IterationBuffer } from "../types";
 import { type MandelbrotParams } from "../types";
+import { isMobileViewport } from "../view/use-is-mobile";
+import { applyMaxCanvasSize, rescaleIterationCacheForResize } from "./common";
 import type { Renderer } from "./renderer";
 
 export interface Resolution {
@@ -35,8 +35,6 @@ let unifiedIterationBuffer: Uint32Array<ArrayBuffer>;
 
 /**
  * unifiedIterationBufferに書き込んだ内容がまだmainBufferに反映されていないかどうか
- *
- * needsRerenderはpalette変更でも立つため、iteration bufferの反映待ち判定には使えない
  */
 let pendingIterationDraw = false;
 

--- a/src/rendering/renderer.ts
+++ b/src/rendering/renderer.ts
@@ -58,6 +58,10 @@ export type Renderer = {
    * iterationBufferQueueを全て処理してGPU iterations[]を更新し、完了を待つ
    */
   flushIterationBufferQueue: () => Promise<void>;
+  /**
+   * 未描画のiteration bufferを全て画面に反映し終えたときに呼ばれるcallbackを登録する
+   */
+  setOnIterationBufferDrained: (callback: () => void) => void;
 };
 
 export const initRenderer: Renderer["initRenderer"] = async (w, h, p5Instance?) => {
@@ -163,4 +167,12 @@ export const flushIterationBufferQueue: Renderer["flushIterationBufferQueue"] = 
     case "webgpu":
       return webGPURenderer.flushIterationBufferQueue();
   }
+};
+
+/**
+ * 描画途中でrendererを切り替えても取りこぼさないよう、両方のrendererに登録する
+ */
+export const setOnIterationBufferDrained: Renderer["setOnIterationBufferDrained"] = (callback) => {
+  p5Renderer.setOnIterationBufferDrained(callback);
+  webGPURenderer.setOnIterationBufferDrained(callback);
 };

--- a/src/rendering/webgpu-renderer.ts
+++ b/src/rendering/webgpu-renderer.ts
@@ -47,6 +47,9 @@ const iterationBufferQueue: IterationBuffer[] = [];
 let gpuInitialized = false;
 let isFlushing = false;
 
+/** queueを空にし切ったフレームで呼ぶcallback */
+let onIterationBufferDrained: (() => void) | null = null;
+
 const UniformSchema = d.struct({
   maxIterations: d.f32,
   canvasWidth: d.f32,
@@ -353,6 +356,11 @@ export const renderToCanvas: Renderer["renderToCanvas"] = (x, y, width, height) 
   renderPass.end();
 
   device.queue.submit([encoder.finish()]);
+
+  // このフレームで積まれていた分を処理し切った
+  if (0 < processableCount && iterationBufferQueue.length === 0) {
+    onIterationBufferDrained?.();
+  }
 };
 
 /**
@@ -419,6 +427,10 @@ export const flushIterationBufferQueue = async (): Promise<void> => {
   } finally {
     isFlushing = false;
   }
+};
+
+export const setOnIterationBufferDrained: Renderer["setOnIterationBufferDrained"] = (callback) => {
+  onIterationBufferDrained = callback;
 };
 
 export const addIterationBuffer: Renderer["addIterationBuffer"] = (

--- a/src/types.ts
+++ b/src/types.ts
@@ -140,6 +140,8 @@ export interface ResultSpans {
 export interface BatchContext {
   onComplete: BatchCompleteCallback;
   onChangeProgress: BatchProgressChangedCallback;
+  /** 最後の描画結果が画面に反映されたときに呼ばれる */
+  onPresented?: () => void;
 
   mandelbrotParams: MandelbrotParams;
   refX: string;
@@ -150,10 +152,17 @@ export interface BatchContext {
   blaTable?: BLATableBuffer;
   terminator: SharedArrayBuffer;
 
+  /** iteration cacheのtranslateとGPUへのflushにかかった時間 */
+  flushElapsed: number;
+
   progressMap: Map<string, number>;
   refProgress: number;
   startedAt: number;
+  /** 最初のworkerが起動した時刻。queue-waitの算出に使う */
+  firstJobStartedAt?: number;
   finishedAt?: number;
+  /** 最後の描画結果が画面に反映された時刻 */
+  presentedAt?: number;
   spans: Span[];
 
   /** iteration値が N に到達した画素の累積数 (描画済みtile全体) */

--- a/src/view/footer/index.tsx
+++ b/src/view/footer/index.tsx
@@ -56,12 +56,53 @@ const BarGraph = (props: ResultSpans) => {
   return (
     <Tooltip.Provider>
       <div className="flex w-full items-center">
-        <div className="mr-4 flex-none">Done! ({total}ms)</div>
-        <div className="flex grow">
+        <Tooltip.Root delayDuration={0}>
+          <Tooltip.Trigger className="mr-4 flex-none">Done! ({total}ms)</Tooltip.Trigger>
+          <Tooltip.Content side="top" align="start">
+            <div className="bg-gray-3 border-teal-2 text-gray-12 w-64 rounded-md border-2 p-2">
+              <AllSpansDetail spans={spans} />
+            </div>
+          </Tooltip.Content>
+        </Tooltip.Root>
+        {/* min-w-0がないとflex itemが縮まずバーが枠からはみ出す */}
+        <div className="flex min-w-0 grow">
           <Bar spans={spans} total={total} />
         </div>
       </div>
     </Tooltip.Provider>
+  );
+};
+
+/**
+ * 全spanの内訳をリスト表示する
+ *
+ * バーが細くてホバーできないspan (flush, queue-wait, drain など) もここで確認できる。
+ * iteration_* はworker数だけあるので最大値1行にまとめる。
+ */
+const AllSpansDetail = (props: { spans: Span[] }) => {
+  const { spans } = props;
+
+  const iterationSpans = spans.filter((s) => s.name.includes("iteration"));
+  const otherSpans = spans.filter((s) => !s.name.includes("iteration"));
+
+  return (
+    <div>
+      {otherSpans.map((span, idx) => (
+        <React.Fragment key={span.name}>
+          {idx > 0 && <Separator />}
+          <ListItem label={span.name} value={`${span.elapsed} ms`} />
+        </React.Fragment>
+      ))}
+      {iterationSpans.length > 0 && (
+        <>
+          <Separator />
+          <ListItem
+            label={`iteration (max of ${iterationSpans.length})`}
+            value={`${Math.max(...iterationSpans.map((s) => s.elapsed))} ms`}
+          />
+        </>
+      )}
+    </div>
   );
 };
 

--- a/src/view/footer/index.tsx
+++ b/src/view/footer/index.tsx
@@ -1,10 +1,10 @@
-import { useT } from "../../i18n/context";
-import { Separator } from "../../shadcn/components/ui/separator";
-import type { ResultSpans, Span } from "../../types";
 import clsx from "clsx";
 import { Tooltip } from "radix-ui";
 import React from "react";
+import { useT } from "../../i18n/context";
+import { Separator } from "../../shadcn/components/ui/separator";
 import { useStoreValue } from "../../store/store";
+import type { ResultSpans, Span } from "../../types";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const convertSpans = (value: any): ResultSpans | undefined => {
@@ -68,7 +68,6 @@ const BarGraph = (props: ResultSpans) => {
             <AllSpansDetail spans={spans} />
           </TooltipPanel>
         </Tooltip.Root>
-        {/* min-w-0がないとflex itemが縮まずバーが枠からはみ出す */}
         <div className="flex min-w-0 grow">
           <Bar spans={spans} total={total} />
         </div>
@@ -165,7 +164,7 @@ const BarContent = (props: { name: string; elapsed: number; total: number; spans
 /**
  * ホバー内容を載せるパネル
  *
- * canvasより手前に出す必要があるのでz-indexを明示する
+ * z-indexはcanvasより手前に出すため
  */
 const TooltipPanel = (props: { children: React.ReactNode }) => (
   <Tooltip.Content side="top" sideOffset={4} className="z-200">

--- a/src/view/footer/index.tsx
+++ b/src/view/footer/index.tsx
@@ -47,7 +47,13 @@ const colorMap = (label: string) => {
   if (label.includes("iteration")) {
     return "bg-iris-7";
   }
-  return "bg-ruby-7";
+  if (label === "flush") {
+    return "bg-tomato-7";
+  }
+  if (label === "drain") {
+    return "bg-lime-7";
+  }
+  return "bg-sage-7";
 };
 
 const BarGraph = (props: ResultSpans) => {
@@ -58,11 +64,9 @@ const BarGraph = (props: ResultSpans) => {
       <div className="flex w-full items-center">
         <Tooltip.Root delayDuration={0}>
           <Tooltip.Trigger className="mr-4 flex-none">Done! ({total}ms)</Tooltip.Trigger>
-          <Tooltip.Content side="top" align="start">
-            <div className="bg-gray-3 border-teal-2 text-gray-12 w-64 rounded-md border-2 p-2">
-              <AllSpansDetail spans={spans} />
-            </div>
-          </Tooltip.Content>
+          <TooltipPanel>
+            <AllSpansDetail spans={spans} />
+          </TooltipPanel>
         </Tooltip.Root>
         {/* min-w-0がないとflex itemが縮まずバーが枠からはみ出す */}
         <div className="flex min-w-0 grow">
@@ -116,10 +120,10 @@ const Bar = (props: ResultSpans) => {
   const iterationSpans = spans.filter((s) => s.name.includes("iteration"));
 
   return (
-    <div className="bg-gray-7 flex h-8 w-full">
-      {iterationExceptedSpans.map((span, idx) => (
+    <div className="bg-gray-7 flex h-8 w-full overflow-hidden rounded-sm">
+      {iterationExceptedSpans.map((span) => (
         <BarContent
-          key={idx}
+          key={span.name}
           name={span.name}
           elapsed={span.elapsed}
           total={total}
@@ -136,47 +140,40 @@ const Bar = (props: ResultSpans) => {
   );
 };
 
+/**
+ * 1フェーズ分の色帯
+ *
+ * 幅が狭いフェーズではラベルが読めないので、バーは色分けのみとし詳細はホバーで出す
+ */
 const BarContent = (props: { name: string; elapsed: number; total: number; spans: Span[] }) => {
   const { name, elapsed, total, spans } = props;
 
-  const [displayText, setDisplayText] = React.useState(`${name}: ${elapsed}ms`);
-  const ref = React.useRef<HTMLDivElement>(null);
-
-  React.useEffect(() => {
-    if (ref.current && ref.current.offsetWidth < ref.current.scrollWidth) {
-      // 実際の幅がコンテナの幅より大きい場合は、`elapsed` のみを表示
-      setDisplayText(`${elapsed}ms`);
-    }
-  }, [name, elapsed]);
-
   const width = (elapsed / total) * 100;
-  const bgColorClassName = colorMap(name);
 
   return (
     <Tooltip.Root delayDuration={0}>
-      <div
-        ref={ref}
-        className={clsx(
-          "text-white-a-12 flex w-52 items-center justify-center truncate",
-          bgColorClassName,
-        )}
-        style={{ width: `${width}%` }}
-      >
-        <Tooltip.Trigger>{displayText}</Tooltip.Trigger>
-      </div>
-      <Tooltip.Content>
-        <div
-          className={clsx(
-            "border-teal-2 text-white-a-12 w-52 rounded-md border-2 p-2",
-            bgColorClassName,
-          )}
-        >
-          <SpansDetail name={name} spans={spans} />
-        </div>
-      </Tooltip.Content>
+      <Tooltip.Trigger asChild>
+        <div className={clsx("h-full", colorMap(name))} style={{ width: `${width}%` }} />
+      </Tooltip.Trigger>
+      <TooltipPanel>
+        <SpansDetail name={name} spans={spans} />
+      </TooltipPanel>
     </Tooltip.Root>
   );
 };
+
+/**
+ * ホバー内容を載せるパネル
+ *
+ * canvasより手前に出す必要があるのでz-indexを明示する
+ */
+const TooltipPanel = (props: { children: React.ReactNode }) => (
+  <Tooltip.Content side="top" sideOffset={4} className="z-200">
+    <div className="bg-popover text-popover-foreground border-border w-64 rounded-md border p-2 shadow-lg">
+      {props.children}
+    </div>
+  </Tooltip.Content>
+);
 
 const SpansDetail = (props: { name: string; spans: Span[] }) => {
   const t = useT();

--- a/src/view/right-sidebar/debug-mode/event-viewer.tsx
+++ b/src/view/right-sidebar/debug-mode/event-viewer.tsx
@@ -177,6 +177,14 @@ export const EventViewer = () => {
             return (
               <div className="text-xs text-gray-600">Remaining: {rendererEvent.remaining}</div>
             );
+          case "flushed":
+            return (
+              <div className="text-xs text-gray-600">
+                Flush: {formatTime(rendererEvent.elapsed)}
+              </div>
+            );
+          case "presented":
+            return <div className="text-xs text-gray-600">Presented</div>;
         }
 
       case "job":

--- a/src/worker-pool/callbacks/iteration-worker.ts
+++ b/src/worker-pool/callbacks/iteration-worker.ts
@@ -79,6 +79,13 @@ export const onIterationWorkerResult: IterationResultCallback = (result, job) =>
     batchContext.finishedAt = finishedAt;
     const elapsed = finishedAt - batchContext.startedAt;
 
+    if (batchContext.firstJobStartedAt != null) {
+      batchContext.spans.push({
+        name: "queue-wait",
+        elapsed: Math.floor(batchContext.firstJobStartedAt - batchContext.startedAt),
+      });
+    }
+
     finalizeBatch(job.batchId, elapsed);
 
     batchContext.onComplete(elapsed);

--- a/src/worker-pool/worker-pool.ts
+++ b/src/worker-pool/worker-pool.ts
@@ -78,6 +78,10 @@ export const getNHitRatio = (): number | null => {
 
 /**
  * Footerで表示するための進捗情報をbatchContextから取得する
+ *
+ * totalはflush開始 (= startedAtのflushElapsed分手前) から画面反映までを含めた全体時間。
+ * spansのflush/drainがこの範囲の外に出ないようにするため、startedAt起点にはしていない。
+ * presentedAtが未確定の間はfinishedAtまでで暫定表示する。
  */
 export const getProgressData = (): string | ResultSpans => {
   const batchContext = getLatestBatchContext();
@@ -87,8 +91,11 @@ export const getProgressData = (): string | ResultSpans => {
   }
 
   if (batchContext.finishedAt) {
+    const startedAt = batchContext.startedAt - batchContext.flushElapsed;
+    const endedAt = batchContext.presentedAt ?? batchContext.finishedAt;
+
     return {
-      total: Math.floor(batchContext.finishedAt - batchContext.startedAt),
+      total: Math.floor(endedAt - startedAt),
       spans: batchContext.spans,
     };
   }
@@ -167,13 +174,34 @@ export function registerBatch(
     progressMap,
     startedAt: performance.now(),
     refProgress: -1,
-    spans: [],
+    spans: [{ name: "flush", elapsed: Math.floor(batchContext.flushElapsed) }],
     nHitCount: 0,
     totalPixelCount: 0,
   });
 
   tickWorkerPool();
 }
+
+/**
+ * 画面反映待ちのバッチにpresentedAtを記録し、drain spanを積む
+ *
+ * rendererのバッファが空になった次のフレームで呼ばれる
+ */
+export const markPresented = (presentedAt: number): void => {
+  for (const batchContext of batchContextMap.values()) {
+    if (batchContext.finishedAt == null || batchContext.presentedAt != null) continue;
+
+    batchContext.presentedAt = presentedAt;
+    batchContext.spans.push({
+      name: "drain",
+      elapsed: Math.floor(presentedAt - batchContext.finishedAt),
+    });
+
+    addTraceEvent("renderer", { type: "presented" });
+
+    batchContext.onPresented?.();
+  }
+};
 
 export function tickWorkerPool() {
   let jobStarted = false;
@@ -260,6 +288,8 @@ function start(workerIdx: number, job: MandelbrotJob) {
 
   const assignedJob = { ...job, workerIdx: workerIdxForTerminate };
   const workerFacade = getWorkerPool(assignedJob.type)[workerIdx];
+
+  batchContext.firstJobStartedAt ??= performance.now();
 
   workerFacade.startCalculate(assignedJob, batchContext, workerIdxForTerminate);
 

--- a/src/worker-pool/worker-pool.ts
+++ b/src/worker-pool/worker-pool.ts
@@ -1,3 +1,4 @@
+import { throttle } from "es-toolkit";
 import { addTraceEvent, removeBatchTrace, startBatchTrace } from "../event-viewer/event";
 import type {
   BatchContext,
@@ -8,7 +9,6 @@ import type {
   MandelbrotRenderingUnit,
   ResultSpans,
 } from "../types";
-import { throttle } from "es-toolkit";
 import {
   calcNormalizedWorkerIndex,
   findFreeWorkerIndex,
@@ -78,10 +78,6 @@ export const getNHitRatio = (): number | null => {
 
 /**
  * Footerで表示するための進捗情報をbatchContextから取得する
- *
- * totalはflush開始 (= startedAtのflushElapsed分手前) から画面反映までを含めた全体時間。
- * spansのflush/drainがこの範囲の外に出ないようにするため、startedAt起点にはしていない。
- * presentedAtが未確定の間はfinishedAtまでで暫定表示する。
  */
 export const getProgressData = (): string | ResultSpans => {
   const batchContext = getLatestBatchContext();
@@ -91,7 +87,10 @@ export const getProgressData = (): string | ResultSpans => {
   }
 
   if (batchContext.finishedAt) {
+    // startedAtはバッチの計算開始なので、計算開始前のflushにかかった時間を引いておく
+    // これでtotalがだいたいユーザ操作終了後から描画完了までになる
     const startedAt = batchContext.startedAt - batchContext.flushElapsed;
+    // presentedAtがない間は暫定表示
     const endedAt = batchContext.presentedAt ?? batchContext.finishedAt;
 
     return {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -63,6 +63,15 @@ export default {
         jade: {
           7: "var(--jade-7)",
         },
+        tomato: {
+          7: "var(--tomato-7)",
+        },
+        lime: {
+          7: "var(--lime-7)",
+        },
+        sage: {
+          7: "var(--sage-7)",
+        },
         white: {
           "a-12": "var(--white-a12)",
         },


### PR DESCRIPTION
# Summary

ボトルネックになり得るが計測できていなかった部分を計測追加した。

これまでは `registerBatch` から最後のworker結果を受け取るまでしか測っておらず、その前後にあるflushと画面反映待ちが計測から漏れていた

## 追加したフェーズ

| span | 区間 |
|---|---|
| `flush` | iteration cacheのtranslate + GPUへのflush（`startedAt` より前） |
| `queue-wait` | `registerBatch` → 最初のworker起動 |
| `drain` | 計算完了 → 画面反映（`finishedAt` より後） |

footerの `Done! (Nms)` もこの全体をカバーする値に変更した
これによりかかった秒数自体はこのPRで増えているが、描画反映まではこのくらいはかかっていたということ

## かかった時間表示の変化
[![Image from Gyazo](https://i.gyazo.com/aa01a6aa6d205b7d14e19254f6660efa.png)](https://gyazo.com/aa01a6aa6d205b7d14e19254f6660efa)

フェーズが細かくなったのでラベルは廃止して色分けのみにした。
ホバーすれば特に問題なく表示は可能

Event Viewerにもflush, presentedを追加
presentedは描画全部完了したタイミング

## 分かったこと

移動時の `drain` が 200〜300ms あった（拡縮時は 20〜30ms）
`renderToCanvas` が1フレームに1解像度グループしか処理しないのが原因。別途対応する
