### PR TITLE
同一rectの荒い画像が同一queueに入っていた場合はスキップしてGPU描画を高速化

### DIFF
--- a/src/event-viewer/event.ts
+++ b/src/event-viewer/event.ts
@@ -29,6 +29,11 @@ export type RendererEvent = EventBase & {/* common type */} & (
         rects: Rect[];
       }
     | {
+        type: "iterationBufferDeduped";
+        dropped: number;
+        kept: number;
+      }
+    | {
         type: "bufferSizeExceeded";
         remaining: number;
       }

--- a/src/rendering/webgpu-renderer.ts
+++ b/src/rendering/webgpu-renderer.ts
@@ -221,6 +221,50 @@ const writeIterationInputs = (
 };
 
 /**
+ * 1ピクセルあたりの粗さを返す。値が大きいほど解像度が荒い
+ */
+const getCoarseness = (item: IterationBuffer) => item.rect.width / item.resolution.width;
+
+/**
+ * queueを描画可能な形に整える
+ *
+ * 同一rectのエントリは最も細かい1件だけを残す。同じ領域を覆うので粗い方はGPUに送るだけ無駄になる。
+ * 残った分は粗い順に並べる。異なるrect同士は重なりうる (rect.tsのminSideによる拡張) ため、
+ * 細かい方が後に書き込まれるよう順序は保証する必要がある。
+ *
+ * @returns 重複排除で捨てたエントリ数
+ */
+const prepareIterationBufferQueue = (): number => {
+  if (iterationBufferQueue.length <= 1) return 0;
+
+  const finestByRect = new Map<string, IterationBuffer>();
+
+  for (const item of iterationBufferQueue) {
+    const { x, y, width: w, height: h } = item.rect;
+    const key = `${x},${y},${w},${h}`;
+    const current = finestByRect.get(key);
+
+    if (current == null) {
+      finestByRect.set(key, item);
+    } else if (getCoarseness(item) <= getCoarseness(current)) {
+      // 同解像度なら後から積まれた方が新しいので、Map上の位置ごと入れ替える
+      finestByRect.delete(key);
+      finestByRect.set(key, item);
+    }
+  }
+
+  const dropped = iterationBufferQueue.length - finestByRect.size;
+
+  const kept = Array.from(finestByRect.values());
+  kept.sort((a, b) => getCoarseness(b) - getCoarseness(a));
+
+  iterationBufferQueue.length = 0;
+  for (const item of kept) iterationBufferQueue.push(item);
+
+  return dropped;
+};
+
+/**
  * iterationInputBufferからiterations[]へコピーするcompute passを積む
  *
  * 1スレッドが1宛先ピクセルを担当するので、dispatch数は宛先ピクセル数から決まる
@@ -251,73 +295,7 @@ export const renderToCanvas: Renderer["renderToCanvas"] = (x, y, width, height) 
   const { width: canvasWidth, height: canvasHeight } = getCanvasSize();
   const palette = getCurrentPalette();
 
-  // queueに積まれたiteration bufferをGPUBufferに書き込む
-  const maxBufferSize = iterationInputBuffer.buffer.size;
-
-  // 解像度（rect.width/resolution.width）が荒い順にソートする
-  // 値が大きいほど1ピクセルあたりの解像度が荒い
-  if (iterationBufferQueue.length > 1) {
-    iterationBufferQueue.sort((a, b) => {
-      const resolutionA = a.rect.width / a.resolution.width;
-      const resolutionB = b.rect.width / b.resolution.width;
-      return resolutionB - resolutionA; // 降順（荒い順）
-    });
-  }
-
-  // 一度に処理できる最大数を計算
-  let processableCount = 0;
-  let tempBufferByteOffset = 0;
-  let currentResolution = -1; // 現在処理中の解像度
-
-  // ソートされたキューから同じ解像度のバッファのみを処理
-  for (let i = 0; i < iterationBufferQueue.length; i++) {
-    const iterBuffer = iterationBufferQueue[i];
-    const nextSize = iterBuffer.buffer.byteLength;
-    const resolution = iterBuffer.rect.width / iterBuffer.resolution.width;
-
-    // metadataに載る数を超えないようにする
-    if (processableCount >= META_ENTRY_MAX) break;
-
-    // バッファサイズオーバーチェック
-    if (tempBufferByteOffset + nextSize > maxBufferSize) {
-      const remaining = iterationBufferQueue.length - processableCount;
-      addTraceEvent("renderer", { type: "bufferSizeExceeded", remaining });
-      break;
-    }
-
-    // 初回または同じ解像度のみ処理
-    if (currentResolution === -1) {
-      currentResolution = resolution;
-    } else if (Math.abs(resolution - currentResolution) > 0.001) {
-      // 解像度が変わったら処理を中断
-      break;
-    }
-
-    tempBufferByteOffset += nextSize;
-    processableCount++;
-  }
-
-  let totalPixelCount = 0;
-
-  if (0 < processableCount) {
-    const remaining = iterationBufferQueue.length - processableCount;
-    const resolution =
-      iterationBufferQueue[0].rect.width / iterationBufferQueue[0].resolution.width;
-
-    const items = iterationBufferQueue.splice(0, processableCount);
-    totalPixelCount = writeIterationInputs(items, canvasWidth, canvasHeight);
-
-    addTraceEvent("renderer", {
-      type: "iterationBufferProcessing",
-      resolution,
-      count: processableCount,
-      remaining,
-      rects: items.map((item) => item.rect),
-    });
-  }
-
-  // write uniform buffer
-  uniformBuffer.write({
+  const renderUniforms = {
     maxIterations: params.N,
     canvasWidth: canvasWidth,
     canvasHeight: canvasHeight,
@@ -327,16 +305,88 @@ export const renderToCanvas: Renderer["renderToCanvas"] = (x, y, width, height) 
     offsetY: y,
     width: width ?? canvasWidth,
     height: height ?? canvasHeight,
-    iterationBufferCount: processableCount,
-    totalPixelCount,
-  });
+    iterationBufferCount: 0,
+    totalPixelCount: 0,
+  };
+
+  const dropped = prepareIterationBufferQueue();
+  if (0 < dropped) {
+    addTraceEvent("renderer", {
+      type: "iterationBufferDeduped",
+      dropped,
+      kept: iterationBufferQueue.length,
+    });
+  }
+
+  // queueに積まれたiteration bufferをGPUBufferに書き込む
+  const maxBufferSize = iterationInputBuffer.buffer.size;
+
+  let processedCount = 0;
+
+  // 解像度グループごとにcompute passを積んでsubmitする。
+  // queueへの投入順に実行されるので、iterationInputBufferを使い回しても粗い順に上書きされる
+  while (0 < iterationBufferQueue.length) {
+    const groupCoarseness = getCoarseness(iterationBufferQueue[0]);
+
+    let processableCount = 0;
+    let tempBufferByteOffset = 0;
+
+    for (let i = 0; i < iterationBufferQueue.length; i++) {
+      const iterBuffer = iterationBufferQueue[i];
+
+      // metadataに載る数を超えないようにする
+      if (processableCount >= META_ENTRY_MAX) break;
+
+      // バッファサイズオーバーチェック
+      const nextSize = iterBuffer.buffer.byteLength;
+      if (tempBufferByteOffset + nextSize > maxBufferSize) break;
+
+      // 同じ解像度のバッファのみ処理する
+      if (Math.abs(getCoarseness(iterBuffer) - groupCoarseness) > 0.001) break;
+
+      tempBufferByteOffset += nextSize;
+      processableCount++;
+    }
+
+    if (processableCount === 0) {
+      // 単体でiterationInputBufferに収まらないので、このフレームでは処理できない
+      addTraceEvent("renderer", {
+        type: "bufferSizeExceeded",
+        remaining: iterationBufferQueue.length,
+      });
+      break;
+    }
+
+    const items = iterationBufferQueue.splice(0, processableCount);
+    const totalPixelCount = writeIterationInputs(items, canvasWidth, canvasHeight);
+
+    uniformBuffer.write({
+      ...renderUniforms,
+      iterationBufferCount: processableCount,
+      totalPixelCount,
+    });
+
+    const computeEncoder = device.createCommandEncoder();
+    encodeCopyComputePass(computeEncoder, totalPixelCount);
+    device.queue.submit([computeEncoder.finish()]);
+
+    processedCount += processableCount;
+
+    addTraceEvent("renderer", {
+      type: "iterationBufferProcessing",
+      resolution: groupCoarseness,
+      count: processableCount,
+      remaining: iterationBufferQueue.length,
+      rects: items.map((item) => item.rect),
+    });
+  }
 
   // 毎フレームのunifiedIterationBufferの転送は不要
   // GPUのcompute shaderによってiterationInputBufferからiterationBufferに直接書き込まれる
 
-  const encoder = device.createCommandEncoder();
+  uniformBuffer.write(renderUniforms);
 
-  encodeCopyComputePass(encoder, totalPixelCount);
+  const encoder = device.createCommandEncoder();
 
   const renderPass = encoder.beginRenderPass({
     colorAttachments: [
@@ -358,7 +408,7 @@ export const renderToCanvas: Renderer["renderToCanvas"] = (x, y, width, height) 
   device.queue.submit([encoder.finish()]);
 
   // このフレームで積まれていた分を処理し切った
-  if (0 < processableCount && iterationBufferQueue.length === 0) {
+  if (0 < processedCount && iterationBufferQueue.length === 0) {
     onIterationBufferDrained?.();
   }
 };

--- a/src/rendering/webgpu-renderer.ts
+++ b/src/rendering/webgpu-renderer.ts
@@ -414,9 +414,11 @@ export const renderToCanvas: Renderer["renderToCanvas"] = (x, y, width, height) 
 };
 
 /**
- * iterationBufferQueueを全て処理してGPU iterations[]を更新し、完了を待つ
+ * iterationBufferQueueを全て処理してGPU iterations[]を更新する
  *
- * translate後にGPUバッファを即座に最新化し、次フレームで古いデータが描画されるのを防ぐ
+ * translate後にGPUバッファを最新化し、次フレームで古いデータが描画されるのを防ぐ。
+ * queueへの投入順に実行されるので、後から積まれるrender passは必ず更新後のiterations[]を読む。
+ * このためGPU側の完了をCPUで待つ必要はない。
  */
 export const flushIterationBufferQueue = async (): Promise<void> => {
   if (!gpuInitialized || iterationBufferQueue.length === 0) return;
@@ -424,12 +426,8 @@ export const flushIterationBufferQueue = async (): Promise<void> => {
   isFlushing = true;
 
   try {
-    // iterationBufferを0クリアして古い位置のデータを除去
-    {
-      const encoder = device.createCommandEncoder();
-      encoder.clearBuffer(root.unwrap(iterationBuffer));
-      device.queue.submit([encoder.finish()]);
-    }
+    /** iterationBufferの0クリア (古い位置のデータの除去) がまだ積まれていない */
+    let needsClear = true;
 
     const params = getCurrentParams();
     const { width: canvasWidth, height: canvasHeight } = getCanvasSize();
@@ -469,10 +467,19 @@ export const flushIterationBufferQueue = async (): Promise<void> => {
       });
 
       const encoder = device.createCommandEncoder();
+      if (needsClear) {
+        encoder.clearBuffer(root.unwrap(iterationBuffer));
+        needsClear = false;
+      }
       encodeCopyComputePass(encoder, totalPixelCount);
       device.queue.submit([encoder.finish()]);
+    }
 
-      await device.queue.onSubmittedWorkDone();
+    if (needsClear) {
+      // 1グループも処理できなかった場合もクリアだけは流しておく
+      const encoder = device.createCommandEncoder();
+      encoder.clearBuffer(root.unwrap(iterationBuffer));
+      device.queue.submit([encoder.finish()]);
     }
   } finally {
     isFlushing = false;

--- a/src/view/right-sidebar/debug-mode/event-viewer.tsx
+++ b/src/view/right-sidebar/debug-mode/event-viewer.tsx
@@ -173,6 +173,12 @@ export const EventViewer = () => {
                 Remaining: {rendererEvent.remaining}
               </div>
             );
+          case "iterationBufferDeduped":
+            return (
+              <div className="text-xs text-gray-600">
+                Dropped: {rendererEvent.dropped}, Kept: {rendererEvent.kept}
+              </div>
+            );
           case "bufferSizeExceeded":
             return (
               <div className="text-xs text-gray-600">Remaining: {rendererEvent.remaining}</div>


### PR DESCRIPTION
# Summary

WebGPUの `renderToCanvas` に無駄が多かったのを直した

WebGPUの `renderToCanvas` が1フレームに1解像度グループしか処理していなかったので、
荒い解像度から徐々に描画していくだけで数フレーム使ってしまっていた。
ワーカー数が多いほど、後から荒いものが到着するとそれ描画だけで1フレーム使ってしまっていたりと無駄が多かった

既により細かいものがあるなら荒い方は描画する必要すらないので落とすようにした

## 計測

| 指標 | before | after |
|---|---:|---:|
| `drain`（移動時） | 200〜300ms | 0〜20ms |
| bench `presented - total` | 60ms | 10ms |

描画完了までの時間が減ったという感じ

## 1フレームで全解像度グループを処理する

同一rectのエントリは最も細かい1件だけ残して残りは描画せず、無駄な描画を省いた。
残った分は粗い順に処理する。異なるrect同士はで重なりうるので、順序は維持する必要がある。

捨てた数をEvent Viewerで見るためにtrace event `iterationBufferDeduped` を追加した。

## flush の GPU 完了待ちをやめた

`flushIterationBufferQueue` の `await device.queue.onSubmittedWorkDone()` を削除。

これは
- #102

で `flushIterationBufferQueue` ごと入ったものだが、
チラつき防止を実際に担っているのは `isFlushing` とp5-adapter側のオフセット保持のほうで、このawaitは不要だった

- 次フレームのrender passはcompute passより後に積まれるので、必ず更新後の `iterations[]` を読む
- CPU側がGPUの結果を使ってない

のでawaitを削除。特にちらつきも発生しなくなった

## 副作用

十分に描画が速い環境では、徐々に粗い解像度から表示される感じではなくパッと表示されるようになった
