### PR TITLE
無駄な処理の修正（速度には影響なし）

### DIFF
--- a/src/rendering/shader/shader.wgsl
+++ b/src/rendering/shader/shader.wgsl
@@ -37,7 +37,13 @@ fn fragmentMain(@builtin(position) fragCoord: vec4f) -> @location(0) vec4f {
 
   let index = i32(y) * i32(uniforms.canvasWidth) + i32(x);
   let iteration = iterations[index];
-  
+
+  // iteration == 0 は「まだ計算されていない」ことを表す番兵 (worker側は必ず1以上を返す)。
+  // ドラッグ中の未描画領域と同じ黒のままにする。maxIterations到達時の黒とは意味が違う
+  if (iteration == 0u) {
+    return vec4f(0.0, 0.0, 0.0, 1.0);
+  }
+
   if (iteration >= u32(uniforms.maxIterations)) {
     return vec4f(0.0, 0.0, 0.0, 1.0);
   }

--- a/src/rendering/webgpu-renderer.ts
+++ b/src/rendering/webgpu-renderer.ts
@@ -64,7 +64,10 @@ const UniformSchema = d.struct({
   totalPixelCount: d.f32,
 });
 
-const PaletteSchema = d.arrayOf(d.vec4f, 8192); // FIXME: paletteの最大サイズ分固定で確保している（手抜き）
+/** paletteに確保しているエントリ数 */
+const PALETTE_ENTRY_MAX = 8192;
+
+const PaletteSchema = d.arrayOf(d.vec4f, PALETTE_ENTRY_MAX); // FIXME: paletteの最大サイズ分固定で確保している（手抜き）
 
 /** metadataに格納できるiteration bufferの最大数 */
 const META_ENTRY_MAX = 1024;
@@ -105,6 +108,9 @@ const IterationInputMetadataSchema = d.arrayOf(
 
 /** metadata書き込み用の使い回しバッファ。毎フレームのallocを避けるために持つ */
 const metadataScratch = new Float32Array(META_ENTRY_MAX * META_STRIDE);
+
+/** palette書き込み用の使い回しバッファ。1エントリ = vec4f */
+const paletteScratch = new Float32Array(PALETTE_ENTRY_MAX * 4);
 
 export const getCanvasSize: Renderer["getCanvasSize"] = () => ({
   width,
@@ -535,12 +541,20 @@ export const resizeCanvas: Renderer["resizeCanvas"] = (requestWidth, requestHeig
 export const updatePaletteData: Renderer["updatePaletteData"] = (palette: Palette) => {
   if (!gpuInitialized) return;
 
+  const count = Math.min(palette.length, PALETTE_ENTRY_MAX);
+
   // FIXME: Palette側に定義しとくといいよ
-  for (let i = 0; i < palette.length; i++) {
+  for (let i = 0; i < count; i++) {
     // offsetに影響しないpalette dataを取得したいのでignoreOffset: true
     const [r, g, b] = palette.rgb(i, true);
-    paletteBuffer.writePartial([{ idx: i, value: d.vec4f(r / 255, g / 255, b / 255, 1.0) }]);
+    const offset = i * 4;
+    paletteScratch[offset] = r / 255;
+    paletteScratch[offset + 1] = g / 255;
+    paletteScratch[offset + 2] = b / 255;
+    paletteScratch[offset + 3] = 1.0;
   }
+
+  device.queue.writeBuffer(root.unwrap(paletteBuffer), 0, paletteScratch, 0, count * 4);
 };
 
 const initializeGPU = async (): Promise<boolean> => {

--- a/src/worker-pool/callbacks/iteration-worker.ts
+++ b/src/worker-pool/callbacks/iteration-worker.ts
@@ -26,7 +26,7 @@ export const onIterationWorkerProgress: IterationProgressCallback = (result, job
 };
 
 export const onIterationWorkerResult: IterationResultCallback = (result, job) => {
-  const { iterations, resolution, elapsed } = result;
+  const { iterations, resolution, elapsed, hitCount } = result;
   const { rect } = job;
   const batchContext = getBatchContext(job.batchId);
 
@@ -39,11 +39,6 @@ export const onIterationWorkerResult: IterationResultCallback = (result, job) =>
   const iterationsResult = new Uint32Array(iterations);
   const iterBuffer = upsertIterationCache(rect, iterationsResult, resolution, isSuperSampled);
 
-  const maxIter = batchContext.mandelbrotParams.N;
-  let hitCount = 0;
-  for (let i = 0; i < iterationsResult.length; i++) {
-    if (iterationsResult[i] === maxIter) hitCount++;
-  }
   batchContext.nHitCount += hitCount;
   batchContext.totalPixelCount += iterationsResult.length;
 

--- a/src/worker-pool/worker-facade.ts
+++ b/src/worker-pool/worker-facade.ts
@@ -20,6 +20,8 @@ export interface IterationResult {
   iterations: ArrayBuffer;
   resolution: { width: number; height: number };
   elapsed: number;
+  /** iterationがmaxIterationに到達したピクセル数。worker側のループ内で数えている */
+  hitCount: number;
 }
 
 export type RefOrbitResultCallback = (result: RefOrbitContext, job: CalcRefOrbitJob) => void;
@@ -83,9 +85,9 @@ export class CalcIterationWorker implements MandelbrotFacadeLike {
 
       switch (data.type) {
         case "result": {
-          const { iterations, resolution, elapsed } = data;
+          const { iterations, resolution, elapsed, hitCount } = data;
 
-          this.resultCallback?.({ type: "result", iterations, resolution, elapsed }, job);
+          this.resultCallback?.({ type: "result", iterations, resolution, elapsed, hitCount }, job);
 
           this.worker.removeEventListener("message", f);
           this.running = false;

--- a/src/workers/mandelbrot-perturbation-worker.ts
+++ b/src/workers/mandelbrot-perturbation-worker.ts
@@ -203,6 +203,10 @@ const calcHandler = (data: IterationWorkerParams) => {
     const xDiff = xDiffs[i];
     const yDiff = yDiffs[i];
 
+    // resultとして送るpassかどうか。hitCountはこのpassの書き込みだけを数える
+    const isResultPass = isSuperSampling || i === xDiffs.length - 1;
+    let hitCount = 0;
+
     const scaledAreaWidth = Math.floor(areaWidth / xDiff);
     const scaledAreaHeight = Math.floor(areaHeight / yDiff);
     const scaledIterations = new Uint32Array(scaledAreaWidth * scaledAreaHeight);
@@ -216,8 +220,10 @@ const calcHandler = (data: IterationWorkerParams) => {
         const scaledIndex = scaledX + scaledY * scaledAreaWidth;
 
         if (!isSuperSampling) {
-          if (iterations[index] !== 0) {
-            scaledIterations[scaledIndex] = iterations[index];
+          const cached = iterations[index];
+          if (cached !== 0) {
+            scaledIterations[scaledIndex] = cached;
+            if (isResultPass && cached === maxIteration) hitCount++;
             continue;
           }
         }
@@ -227,6 +233,7 @@ const calcHandler = (data: IterationWorkerParams) => {
         calculatedCount++;
         iterations[index] = n;
         scaledIterations[scaledIndex] = n;
+        if (isResultPass && n === maxIteration) hitCount++;
       }
 
       if (terminateChecker[workerIdx] !== 0) break;
@@ -243,8 +250,7 @@ const calcHandler = (data: IterationWorkerParams) => {
 
     if (terminateChecker[workerIdx] !== 0) break;
 
-    const isLastPass = i === xDiffs.length - 1;
-    if (isSuperSampling || isLastPass) {
+    if (isResultPass) {
       // 最終passの結果はintermediateResultではなくresultとして送り、
       // 別途末尾でiterationsを送り直す重複を避ける
       const elapsed = performance.now() - startedAt;
@@ -254,6 +260,7 @@ const calcHandler = (data: IterationWorkerParams) => {
           iterations: scaledIterations,
           resolution: { width: scaledAreaWidth, height: scaledAreaHeight },
           elapsed,
+          hitCount,
         },
         [scaledIterations.buffer],
       );

--- a/src/workers/mandelbrot-worker.ts
+++ b/src/workers/mandelbrot-worker.ts
@@ -39,6 +39,8 @@ self.addEventListener("message", (event) => {
   const diffX = isSuperSampling ? 0.5 : 1;
   const diffY = isSuperSampling ? 0.5 : 1;
 
+  let hitCount = 0;
+
   let scaledY = 0;
   for (let y = startY; y < endY; y = y + diffY, scaledY++) {
     let scaledX = 0;
@@ -67,6 +69,8 @@ self.addEventListener("message", (event) => {
         const index = Math.floor(x - startX + (y - startY) * areaPixelWidth);
         iterations[index] = n;
       }
+
+      if (n === N) hitCount++;
     }
     self.postMessage({
       type: "progress",
@@ -81,6 +85,7 @@ self.addEventListener("message", (event) => {
       iterations,
       resolution: { width: areaPixelWidth, height: areaPixelHeight },
       elapsed,
+      hitCount,
     },
     [iterations.buffer],
   );

--- a/src/workers/mandelbrot-worker.ts
+++ b/src/workers/mandelbrot-worker.ts
@@ -40,6 +40,9 @@ self.addEventListener("message", (event) => {
   const diffY = isSuperSampling ? 0.5 : 1;
 
   let hitCount = 0;
+  // progress postMessageのスロットリング用。前回送信時刻からPROGRESS_INTERVAL_MS経過時のみ送る
+  let lastProgressSentAt = 0;
+  const PROGRESS_INTERVAL_MS = 50;
 
   let scaledY = 0;
   for (let y = startY; y < endY; y = y + diffY, scaledY++) {
@@ -72,10 +75,14 @@ self.addEventListener("message", (event) => {
 
       if (n === N) hitCount++;
     }
-    self.postMessage({
-      type: "progress",
-      progress: (y - startY) / areaPixelHeight,
-    });
+    const nowMs = performance.now();
+    if (nowMs - lastProgressSentAt >= PROGRESS_INTERVAL_MS) {
+      lastProgressSentAt = nowMs;
+      self.postMessage({
+        type: "progress",
+        progress: (y - startY) / areaPixelHeight,
+      });
+    }
   }
 
   const elapsed = performance.now() - startedAt;


### PR DESCRIPTION
# Summary

無駄な処理の削除4件。速度には変化なし
1つ目だけ見た目の修正が入っている

## 1. 未計算領域を黒で描画するようにした

移動・ズームアウト時にマウス離した瞬間に黒からパレット0番の色に変わるのを修正した。
未描画は黒のままになるようになり、若干ちらつきっぽく感じるのが低減された

## 2. nHit カウントを worker 側へ

workerの結果ごとにメインスレッドで全ピクセル走査していたのを、worker側から返すようにした

## 3. updatePaletteData の writePartial ループ

最大8192エントリを1個ずつ `writePartial` していたのを、`Float32Array` に詰めて `writeBuffer` 1回にした
特に速度は変化なし

## 4. normal mode worker の progress postMessage

行ごとに `postMessage` していたのをperturbationと同じ50msでthrottle
