### PR TITLE
キャンバスのリサイズが壊れていたのを修正

### DIFF
--- a/src/iteration-buffer/iteration-buffer.test.ts
+++ b/src/iteration-buffer/iteration-buffer.test.ts
@@ -1,6 +1,12 @@
 import type { IterationBuffer } from "../types";
 import { describe, expect, it } from "vitest";
-import { scaleIterationCacheAroundPoint, scaleRectAroundPoint } from "./iteration-buffer";
+import {
+  consolidateIterationCache,
+  getIterationCache,
+  scaleIterationCacheAroundPoint,
+  scaleRectAroundPoint,
+  setIterationCache,
+} from "./iteration-buffer";
 
 describe("scaleRectAroundPoint", () => {
   it("原点で1.0倍しても変化しない", () => {
@@ -103,5 +109,47 @@ describe("scaleIterationCacheAroundPoint", () => {
       width: 100,
       height: 100,
     });
+  });
+});
+
+describe("consolidateIterationCache", () => {
+  it("縮小リサイズ後のキャッシュを新しいキャンバスサイズに焼き直す", () => {
+    // rectだけ800に縮められ、bufferは1024x1024のままという状態
+    const buffer = new Uint32Array(1024 * 1024);
+    buffer[512 * 1024 + 512] = 7;
+
+    setIterationCache([
+      {
+        rect: { x: 0, y: 0, width: 800, height: 800 },
+        buffer,
+        resolution: { width: 1024, height: 1024 },
+      },
+    ]);
+
+    consolidateIterationCache(800, 800);
+
+    const cache = getIterationCache();
+    expect(cache).toHaveLength(1);
+    expect(cache[0].rect).toEqual({ x: 0, y: 0, width: 800, height: 800 });
+    expect(cache[0].resolution).toEqual({ width: 800, height: 800 });
+    expect(cache[0].buffer.length).toBe(800 * 800);
+    // ratio 1.28なのでcanvas上の(400, 400)がsource(512, 512)を引く
+    expect(cache[0].buffer[400 * 800 + 400]).toBe(7);
+  });
+
+  it("既にキャンバス全面の等倍1枚なら焼き直さない", () => {
+    const buffer = new Uint32Array(100 * 100);
+
+    setIterationCache([
+      {
+        rect: { x: 0, y: 0, width: 100, height: 100 },
+        buffer,
+        resolution: { width: 100, height: 100 },
+      },
+    ]);
+
+    consolidateIterationCache(100, 100);
+
+    expect(getIterationCache()[0].buffer).toBe(buffer);
   });
 });

--- a/src/iteration-buffer/iteration-buffer.ts
+++ b/src/iteration-buffer/iteration-buffer.ts
@@ -140,17 +140,37 @@ export const removeUnusedIterationCache = (): void => {
 };
 
 /**
+ * 既にキャンバス全体をカバーする等倍1枚に統合済みかどうか
+ */
+const isConsolidated = (cw: number, ch: number): boolean => {
+  if (iterationCache.length !== 1) return false;
+
+  const { rect, resolution } = iterationCache[0];
+  return (
+    rect.x === 0 &&
+    rect.y === 0 &&
+    rect.width === cw &&
+    rect.height === ch &&
+    resolution.width === cw &&
+    resolution.height === ch
+  );
+};
+
+/**
  * 断片化したiterationCacheをキャンバス全体をカバーする1枚のIterationBufferに統合する
  *
- * 全workerのバッチ完了後に呼び出すことで、ズーム・移動の繰り返しによる断片化を解消する
+ * 全workerのバッチ完了後に呼び出すことで、ズーム・移動の繰り返しによる断片化を解消する。
+ * リサイズ後に呼ぶと、キャッシュのバッファが新しいキャンバスサイズに焼き直される。
  */
 export const consolidateIterationCache = (canvasWidth?: number, canvasHeight?: number): void => {
-  if (iterationCache.length <= 1) return;
+  if (iterationCache.length === 0) return;
 
   const { width: cw, height: ch } =
     canvasWidth != null && canvasHeight != null
       ? { width: canvasWidth, height: canvasHeight }
       : getCanvasSize();
+
+  if (isConsolidated(cw, ch)) return;
 
   // 解像度比率が1に最も近いキャッシュのみ対象
   const targetRes = iterationCache.reduce((prev, ic) => {
@@ -162,8 +182,6 @@ export const consolidateIterationCache = (canvasWidth?: number, canvasHeight?: n
     const res = ic.resolution.width / ic.rect.width;
     return Math.abs(res - targetRes) < Number.EPSILON;
   });
-
-  if (targets.length <= 1) return;
 
   const mergedBuffer = new Uint32Array(cw * ch);
 

--- a/src/p5-adapter/p5-adapter.ts
+++ b/src/p5-adapter/p5-adapter.ts
@@ -12,6 +12,7 @@ import {
 import { startCalculation } from "../mandelbrot";
 import { calcAutoN } from "../mandelbrot-state/auto-iteration";
 import {
+  forceReRender,
   getAutoIterationEnabled,
   getCurrentParams,
   getManualN,
@@ -479,6 +480,11 @@ export const resizeTo = (_p: p5 = UNSAFE_p5Instance) => {
 
   if (elm) {
     resizeCanvas(elm.clientWidth, elm.clientHeight);
+
+    // 拡縮の基準点が古いキャンバスの中心のままだと、次の計算でキャッシュがずれる
+    resetScaleParams();
+    // 解像度が変わったので、引き伸ばしたキャッシュを新しい解像度で計算し直す
+    forceReRender();
   }
 };
 

--- a/src/rendering/common.ts
+++ b/src/rendering/common.ts
@@ -1,5 +1,6 @@
 import { markNeedsRerender } from "../camera/palette";
 import {
+  consolidateIterationCache,
   scaleIterationCacheAroundPoint,
   setIterationCache,
   translateRectInIterationCache,
@@ -141,6 +142,11 @@ export const rescaleIterationCacheForResize = (
     to.height,
   );
   setIterationCache(translated);
+
+  // rectを縮めただけではbufferは元のキャンバスサイズのままで、
+  // 縮小時にrenderer側のバッファに収まらなくなる。新サイズに焼き直しておく
+  consolidateIterationCache(to.width, to.height);
+
   addIterationBuffer();
 
   markNeedsRerender();

--- a/src/rendering/p5-renderer.ts
+++ b/src/rendering/p5-renderer.ts
@@ -14,7 +14,7 @@ import { clamp } from "../math/util";
 import type { IterationBuffer } from "../types";
 import { type MandelbrotParams } from "../types";
 import { isMobileViewport } from "../view/use-is-mobile";
-import { applyMaxCanvasSize, rescaleIterationCacheForResize } from "./common";
+import { applyMaxCanvasSize } from "./common";
 import type { Renderer } from "./renderer";
 
 export interface Resolution {
@@ -131,8 +131,6 @@ export const resizeCanvas: Renderer["resizeCanvas"] = (requestWidth, requestHeig
 
   unifiedIterationBuffer = new Uint32Array(w * h);
   mainBuffer.resizeCanvas(width, height);
-
-  rescaleIterationCacheForResize(from, { width, height });
 };
 
 /**

--- a/src/rendering/renderer.ts
+++ b/src/rendering/renderer.ts
@@ -2,7 +2,7 @@ import type { Palette } from "../color";
 import type { Rect } from "../math/rect";
 import type { IterationBuffer } from "../types";
 import type p5 from "p5";
-import { getRenderer } from "./common";
+import { getRenderer, rescaleIterationCacheForResize } from "./common";
 
 import * as p5Renderer from "./p5-renderer";
 import * as webGPURenderer from "./webgpu-renderer";
@@ -94,17 +94,23 @@ export const renderToCanvas: Renderer["renderToCanvas"] = (...args) => {
 
 export const resizeCanvas: Renderer["resizeCanvas"] = (...args) => {
   const rendererType = getRenderer();
+  const from = getCanvasSize();
 
   switch (rendererType) {
     case "p5js":
-      return p5Renderer.resizeCanvas(...args);
+      p5Renderer.resizeCanvas(...args);
+      break;
     case "webgpu": {
       // 手抜きして従来のp5rendererをそのままUI描画用canvasに使っているので両方リサイズする必要がある
       // FIXME: UI描画用canvasを分離する
       webGPURenderer.resizeCanvas(...args);
-      return p5Renderer.resizeCanvas(...args);
+      p5Renderer.resizeCanvas(...args);
+      break;
     }
   }
+
+  // renderer実装ごとに呼ぶと同じ変換が二重にかかるのでここで1回だけ行う
+  rescaleIterationCacheForResize(from, getCanvasSize());
 };
 
 export const addIterationBuffer: Renderer["addIterationBuffer"] = (

--- a/src/rendering/webgpu-renderer.ts
+++ b/src/rendering/webgpu-renderer.ts
@@ -2,7 +2,7 @@ import { getCurrentPalette, setPalette } from "../camera/palette";
 import type { Palette } from "../color";
 import { addTraceEvent } from "../event-viewer/event";
 import { getIterationCache } from "../iteration-buffer/iteration-buffer";
-import { applyMaxCanvasSize, rescaleIterationCacheForResize } from "./common";
+import { applyMaxCanvasSize } from "./common";
 import { getCurrentParams } from "../mandelbrot-state/mandelbrot-state";
 import type { Rect } from "../math/rect";
 import type { IterationBuffer } from "../types";
@@ -508,8 +508,6 @@ export const addIterationBuffer: Renderer["addIterationBuffer"] = (
 export const resizeCanvas: Renderer["resizeCanvas"] = (requestWidth, requestHeight) => {
   if (!gpuInitialized) return;
 
-  const from = getCanvasSize();
-
   const gpuCanvas = document.getElementById("gpu-canvas")! as HTMLCanvasElement;
 
   const { width: w, height: h } = applyMaxCanvasSize(requestWidth, requestHeight);
@@ -538,8 +536,6 @@ export const resizeCanvas: Renderer["resizeCanvas"] = (requestWidth, requestHeig
   iterationInputBuffer = root.createBuffer(d.arrayOf(d.u32, width * height)).$usage("storage");
 
   bindGroup = createBindGroup(bindGroupLayout);
-
-  rescaleIterationCacheForResize(from, { width, height });
 };
 
 export const updatePaletteData: Renderer["updatePaletteData"] = (palette: Palette) => {

--- a/src/workers/calc-ref-orbit.ts
+++ b/src/workers/calc-ref-orbit.ts
@@ -175,7 +175,7 @@ async function initWasm() {
   try {
     const base = import.meta.env.BASE_URL ?? "/";
     const wasmUrl = new URL(`${base}wasm/apfp_bg.wasm`, self.location.origin);
-    await wasmInit(wasmUrl);
+    await wasmInit({ module_or_path: wasmUrl });
     wasmReady = true;
     console.log("Wasm module initialized");
   } catch (e) {

--- a/src/workers/mandelbrot-perturbation-worker.ts
+++ b/src/workers/mandelbrot-perturbation-worker.ts
@@ -30,7 +30,7 @@ let wasmMemory: WebAssembly.Memory | null = null;
 async function initWasm(): Promise<void> {
   const base = import.meta.env.BASE_URL ?? "/";
   const wasmUrl = new URL(`${base}wasm/mandelbrot_iter_bg.wasm`, self.location.origin);
-  const output = await wasmInit(wasmUrl);
+  const output = await wasmInit({ module_or_path: wasmUrl });
   wasmMemory = output.memory;
 }
 


### PR DESCRIPTION
# キャンバスのリサイズが壊れていたのを修正

Max Canvas Size を変更するとキャンバスが正しく描き直されなかったのを修正した。

## 直したもの

### 1. iteration cacheの再配置が二重に走っていた

再配置を `renderer.ts` の `resizeCanvas` に移し、1回だけ呼ぶようにした。

### 2. 縮小時にcacheがGPUバッファに収まらず真っ黒になっていた

拡縮時の処理があまりに適当すぎたので、リサイズ時にcacheを新しいcanvas sizeで作り直すようにした

### 3. リサイズ後に再計算が走るようにした

そのまま

### 4. (ついでに) wasm 初期化の非推奨な引数

前のPRで入った警告を抑制しただけ
